### PR TITLE
Log.lua: new feature & performance improve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.sdf
 *.opensdf
 *.idc
+*.dylib
+*.so
 
 .DS_Store
 
@@ -29,3 +31,5 @@ wrap/pyllbc/lib/
 wrap/pyllbc/linux/
 
 !.gitignore
+
+llbc.lua

--- a/wrap/lullbc/script/core/log/Log.lua
+++ b/wrap/lullbc/script/core/log/Log.lua
@@ -1,5 +1,11 @@
 local Log = llbc.newclass('llbc.Log')
 
+local type = type
+local getinfo = debug.getinfo
+local traceback = debug.traceback
+local Util_Table_Concat = _llbc.Util_Table_Concat
+local LogMsg = _llbc.LogMsg
+
 -- Log levels enumeration.
 Log.DEBUG = 0
 Log.INFO = 1
@@ -9,6 +15,8 @@ Log.FATAL = 4
 
 -- logFileInfo: to control output message included file&line information or not, default is false.
 Log.logFileInfo = false
+-- defaultFileInfo: use to fill <file> <line> param on output message, must be function, default is nil,
+Log.defaultFileInfo = nil
 -- defaultLogTag: use to fill <tag> param on output message, can set to string or function, default is nil.
 Log.defaultLogTag = nil
 
@@ -34,126 +42,6 @@ function Log.isinit()
     return _llbc.IsLogInit()
 end
 
--- Log DEBUG level message to root logger.
--- @param ... - log message.
--- @returns - no return.
-function Log.d(...)
-    Log.output(0, nil, nil, ...)
-end
-
--- Log DEBUG level message to specific logger.
--- @param[optional] logger - logger name, default is root logger.
--- @param ...              - log message.
--- @returns - no return.
-function Log.d2(logger, ...)
-    Log.output(0, logger, nil, ...)
-end
-
--- Log DEBUG level message to specific logger, and append tag.
--- @param[optional] logger - logger name, default is root logger.
--- @param[optional] tag    - log tag, default is nil.
--- @param ...              - log message.
--- @returns - no return.
-function Log.d3(logger, tag, ...)
-    Log.output(0, logger, tag, ...)
-end
-
--- Log INFO level message to root logger.
--- @param ... - log message.
--- @returns - no return.
-function Log.i(...)
-    Log.output(1, nil, nil, ...)
-end
-
--- Log INFO level message to specific logger.
--- @param[optional] logger - logger name, default is root logger.
--- @param ...              - log message.
--- @returns - no return.
-function Log.i2(logger, ...)
-    Log.output(1, logger, nil, ...)
-end
-
--- Log INFO level message to specific logger, and append tag.
--- @param[optional] logger - logger name, default is root logger.
--- @param[optional] tag    - log tag, default is nil.
--- @param ...              - log message.
--- @returns - no return.
-function Log.i3(logger, tag, ...)
-    Log.output(1, logger, tag, ...)
-end
-
--- Log WARN level message to root logger.
--- @param ... - log message.
--- @returns - no return.
-function Log.w(...)
-    Log.output(2, nil, nil, ...)
-end
-
--- Log WARN level message to specific logger.
--- @param[optional] logger - logger name, default is root logger.
--- @param ...              - log message.
--- @returns - no return.
-function Log.w2(logger, ...)
-    Log.output(2, logger, nil, ...)
-end
-
--- Log WARN level message to specific logger.
--- @param[optional] logger - logger name, default is root logger.
--- @param[optional] tag    - log tag, default is nil.
--- @param ... -              log message.
--- @returns - no return.
-function Log.w3(logger, tag, ...)
-    Log.output(2, logger, tag, ...)
-end
-
--- Log ERROR level message to root logger.
--- @param ... - log message.
--- @returns - no return.
-function Log.e(...)
-    Log.output(3, nil, nil, ...)
-end
-
--- Log ERROR level message to specific logger.
--- @param[optional] logger - logger name, default is root logger.
--- @param ...              - log message.
--- @returns - no return.
-function Log.e2(logger, ...)
-    Log.output(3, logger, nil, ...)
-end
-
--- Log ERROR level message to specific logger, and append tag.
--- @param[optional] logger - logger name, default is root logger.
--- @param[optional] tag    - log tag, default is nil.
--- @param ...              - log message.
--- @returns - no return.
-function Log.e3(logger, tag, ...)
-    Log.output(3, logger, tag, ...)
-end
-
--- Log FATAL level message to root logger.
--- @param ... - log message.
--- @returns - no return.
-function Log.f(...)
-    Log.output(4, nil, nil, ...)
-end
-
--- Log FATAL level message to specific logger.
--- @param[optional] logger - logger name, default is root logger.
--- @param ...              - log message.
--- @returns - no return.
-function Log.f2(logger, ...)
-    Log.output(4, logger, nil, ...)
-end
-
--- Log FATAL level message to specific logger, and append tag.
--- @param[optional] logger - logger name, default is root logger.
--- @param[optional] tag    - log tag, default is nil.
--- @param ...              - log message.
--- @returns - no return.
-function Log.f3(logger, tag, ...)
-    Log.output(4, logger, tag, ...)
-end
-
 -- Output message to logger.
 -- @param level  - logger level.
 -- @param logger - logger name, default is root logger.
@@ -163,13 +51,18 @@ end
 function Log.output(level, logger, tag, ...)
     local file, line
     if Log.logFileInfo then
-        local di = debug.getinfo(3, 'Sl')
-        file, line = string.sub(di.source, 2), di.currentline
+        local defaultFileInfo = Log.defaultFileInfo
+        if defaultFileInfo then
+            file, line = defaultFileInfo()
+        else
+            local di = getinfo(3, 'Sl')
+            file, line = di.source, di.currentline
+        end
     end
 
-    if tag == nil then
+    if not tag then
         local defaultLogTag = Log.defaultLogTag
-        if defaultLogTag ~= nil then
+        if defaultLogTag then
             if type(defaultLogTag) == 'function' then
                 tag = defaultLogTag()
             else
@@ -179,12 +72,132 @@ function Log.output(level, logger, tag, ...)
     end
 
     if level >= 3 then -- For improve Log performance, explicit use Log Level value to perform if condition judge.
-        local logMsg = _llbc.Util_Table_Concat({...}, ' ')
-        local logMsgAppendedTb = debug.traceback(logMsg, 3)
-        _llbc.LogMsg(level, logger, tag, file, line, logMsgAppendedTb)
+        LogMsg(level, logger, tag, file, line, ..., traceback(3))
     else
-        _llbc.LogMsg(level, logger, tag, file, line, ...)
+        LogMsg(level, logger, tag, file, line, ...)
     end
+end
+
+local output = Log.output
+
+-- Log DEBUG level message to root logger.
+-- @param ... - log message.
+-- @returns - no return.
+function Log.d(...)
+    output(0, nil, nil, ...)
+end
+
+-- Log DEBUG level message to specific logger.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.d2(logger, ...)
+    output(0, logger, nil, ...)
+end
+
+-- Log DEBUG level message to specific logger, and append tag.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param[optional] tag    - log tag, default is nil.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.d3(logger, tag, ...)
+    output(0, logger, tag, ...)
+end
+
+-- Log INFO level message to root logger.
+-- @param ... - log message.
+-- @returns - no return.
+function Log.i(...)
+    output(1, nil, nil, ...)
+end
+
+-- Log INFO level message to specific logger.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.i2(logger, ...)
+    output(1, logger, nil, ...)
+end
+
+-- Log INFO level message to specific logger, and append tag.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param[optional] tag    - log tag, default is nil.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.i3(logger, tag, ...)
+    output(1, logger, tag, ...)
+end
+
+-- Log WARN level message to root logger.
+-- @param ... - log message.
+-- @returns - no return.
+function Log.w(...)
+    output(2, nil, nil, ...)
+end
+
+-- Log WARN level message to specific logger.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.w2(logger, ...)
+    output(2, logger, nil, ...)
+end
+
+-- Log WARN level message to specific logger.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param[optional] tag    - log tag, default is nil.
+-- @param ... -              log message.
+-- @returns - no return.
+function Log.w3(logger, tag, ...)
+    output(2, logger, tag, ...)
+end
+
+-- Log ERROR level message to root logger.
+-- @param ... - log message.
+-- @returns - no return.
+function Log.e(...)
+    output(3, nil, nil, ...)
+end
+
+-- Log ERROR level message to specific logger.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.e2(logger, ...)
+    output(3, logger, nil, ...)
+end
+
+-- Log ERROR level message to specific logger, and append tag.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param[optional] tag    - log tag, default is nil.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.e3(logger, tag, ...)
+    output(3, logger, tag, ...)
+end
+
+-- Log FATAL level message to root logger.
+-- @param ... - log message.
+-- @returns - no return.
+function Log.f(...)
+    output(4, nil, nil, ...)
+end
+
+-- Log FATAL level message to specific logger.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.f2(logger, ...)
+    output(4, logger, nil, ...)
+end
+
+-- Log FATAL level message to specific logger, and append tag.
+-- @param[optional] logger - logger name, default is root logger.
+-- @param[optional] tag    - log tag, default is nil.
+-- @param ...              - log message.
+-- @returns - no return.
+function Log.f3(logger, tag, ...)
+    output(4, logger, tag, ...)
 end
 
 -- Set Log table to llbc

--- a/wrap/lullbc/script/core/log/Log.lua
+++ b/wrap/lullbc/script/core/log/Log.lua
@@ -3,7 +3,6 @@ local Log = llbc.newclass('llbc.Log')
 local type = type
 local getinfo = debug.getinfo
 local traceback = debug.traceback
-local Util_Table_Concat = _llbc.Util_Table_Concat
 local LogMsg = _llbc.LogMsg
 
 -- Log levels enumeration.


### PR DESCRIPTION
* Add `Log.defaultFileInfo` to fill `file` `line` param on output message, a function that returns two arguments: `file`,`line`.
* Use `local` to improve performance, see [Lua Performance Tips](http://www.lua.org/gems/sample.pdf).
* Delete `_llbc.Util_Table_Concat()` in `Log.output`, this is useless and has extra performance overhead since Lua allows parameters to be passed after variadic.