### PR TITLE
delete unused member variable from overlapped

### DIFF
--- a/llbc/include/llbc/common/SocketDataType.h
+++ b/llbc/include/llbc/common/SocketDataType.h
@@ -309,7 +309,6 @@ struct LLBC_Overlapped
 #endif // LLBC_TARGET_PLATFORM_WIN32 
 {
     int opcode;
-    int sessionId;
     LLBC_SocketHandle sock;
     LLBC_SocketHandle acceptSock;
     void *data;

--- a/llbc/include/llbc/core/objectpool/ObjectPoolImpl.h
+++ b/llbc/include/llbc/core/objectpool/ObjectPoolImpl.h
@@ -25,6 +25,7 @@
 #include "llbc/core/helper/Common.h"
 
 #include "llbc/core/objectpool/ObjectPoolStat.h"
+#include "llbc/core/objectpool/IObjectPoolInstFactory.h"
 
 __LLBC_NS_BEGIN
 

--- a/llbc/src/comm/Socket.cpp
+++ b/llbc/src/comm/Socket.cpp
@@ -558,7 +558,6 @@ void LLBC_Socket::OnSend()
 
     ol = LLBC_New(LLBC_Overlapped);
     ol->opcode = _Opcode::Send;
-    ol->sessionId = _session->GetId();
     ol->sock = _handle;
     ol->data = block;
 
@@ -795,7 +794,6 @@ int LLBC_Socket::PostZeroWSARecv()
 {
     LLBC_POverlapped ol = LLBC_New(LLBC_Overlapped);
     ol->opcode = _Opcode::Receive;
-    ol->sessionId = _session->GetId();
     ol->sock = _handle;
 
     LLBC_SockBuf buf = {0};
@@ -826,7 +824,6 @@ int LLBC_Socket::PostAsyncAccept()
 {
     LLBC_POverlapped ol = LLBC_New(LLBC_Overlapped);
     ol->opcode = LLBC_OverlappedOpcode::Accept;
-    ol->sessionId = _session->GetId();
     ol->sock = _handle;
     if (UNLIKELY((ol->acceptSock = 
             LLBC_CreateTcpSocketEx()) == 

--- a/llbc/src/common/SocketDataType.cpp
+++ b/llbc/src/common/SocketDataType.cpp
@@ -282,7 +282,6 @@ bool LLBC_SockAddr_IN::operator ==(const LLBC_SockAddr_IN &right) const
 
 LLBC_Overlapped::LLBC_Overlapped()
 : opcode(LLBC_OverlappedOpcode::End)
-, sessionId(0)
 , sock(LLBC_INVALID_SOCKET_HANDLE)
 , acceptSock(LLBC_INVALID_SOCKET_HANDLE)
 , data(NULL)

--- a/llbc/src/core/log/LogJsonMsg.cpp
+++ b/llbc/src/core/log/LogJsonMsg.cpp
@@ -49,6 +49,7 @@ LLBC_LogJsonMsg::LLBC_LogJsonMsg(bool loggerInited, LLBC_Logger *logger, const c
 , _lv(lv)
 , _doc(*LLBC_GetObjectFromUnsafetyPool<LLBC_Json::Document>())
 {
+    _doc.SetObject();
 }
 
 LLBC_LogJsonMsg::~LLBC_LogJsonMsg()


### PR DESCRIPTION
delete 'sessionId' variable