### PR TITLE
LLBC_SplitString 方法

### DIFF
--- a/llbc/src/core/utils/Util_Text.cpp
+++ b/llbc/src/core/utils/Util_Text.cpp
@@ -127,7 +127,10 @@ void LLBC_SplitString(const LLBC_String &str,
         return;
 
     if (UNLIKELY(separator.empty()))
+    {
         destStrList.push_back(str);
+        return;
+    }
 
     LLBC_String::size_type curPos = 0;
     LLBC_String::size_type prevPos = 0;


### PR DESCRIPTION
fix LLBC_SplitString 方法当 separator为空时陷入死循环