### PR TITLE
删除 std::binary_function

### DIFF
--- a/llbc/include/llbc/core/objbase/KeyHashAlgorithm.h
+++ b/llbc/include/llbc/core/objbase/KeyHashAlgorithm.h
@@ -83,14 +83,9 @@ public:
 
 private:
     /**
-     * Define Hash base class. 
-     */
-    typedef std::binary_function<const void *, size_t, uint32> _HashBase;
-
-    /**
      * BKDR hash algorithm.
      */
-    struct _BKDRHash : public _HashBase
+    struct _BKDRHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };
@@ -98,7 +93,7 @@ private:
     /**
      * DJB hash algorithm.
      */
-    struct _DJBHash : public _HashBase
+    struct _DJBHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };
@@ -106,7 +101,7 @@ private:
     /**
      * SDBM hash algorithm.
      */
-    struct _SDBMHash : public _HashBase
+    struct _SDBMHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };
@@ -114,7 +109,7 @@ private:
     /**
      * RS hash algorithm.
      */
-    struct _RSHash : public _HashBase
+    struct _RSHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };
@@ -122,7 +117,7 @@ private:
     /**
      * JS hash algorithm.
      */
-    struct _JSHash : public _HashBase
+    struct _JSHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };
@@ -130,7 +125,7 @@ private:
     /**
      * P. J. Weinberger hash algorithm.
      */
-    struct _PJHash : public _HashBase
+    struct _PJHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };
@@ -138,7 +133,7 @@ private:
     /**
      * ELF hash algorithm.
      */
-    struct _ELFHash : public _HashBase
+    struct _ELFHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };
@@ -146,7 +141,7 @@ private:
     /**
      * AP hash algorithm.
      */
-    struct _APHash : public _HashBase
+    struct _APHash
     {
         uint32 operator()(const void *buf, size_t size) const;
     };

--- a/llbc/include/llbc/core/timer/TimerData.h
+++ b/llbc/include/llbc/core/timer/TimerData.h
@@ -75,10 +75,9 @@ namespace std
  * \brief The std::less<T> template class specialization: std::less<LLBC_TimerData *>.
  */
 template <>
-struct less<LLBC_NS LLBC_TimerData *> :
-    public binary_function<LLBC_NS LLBC_TimerData *, LLBC_NS LLBC_TimerData *, bool>
+struct less<LLBC_NS LLBC_TimerData *>
 {
-    bool operator()(LLBC_NS LLBC_TimerData * const &t1, LLBC_NS LLBC_TimerData * const &t2)
+    bool operator()(LLBC_NS LLBC_TimerData * const &t1, LLBC_NS LLBC_TimerData * const &t2) const
     {
         return t1->handle < t2->handle;
     }
@@ -88,10 +87,9 @@ struct less<LLBC_NS LLBC_TimerData *> :
  * \brief The std::greater<T> template class specialization: std::greater<LLBC_TimerData *>.
  */
 template <>
-struct greater<LLBC_NS LLBC_TimerData *> :
-    public binary_function<LLBC_NS LLBC_TimerData *, LLBC_NS LLBC_TimerData *, bool>
+struct greater<LLBC_NS LLBC_TimerData *>
 {
-    bool operator()(LLBC_NS LLBC_TimerData * const &t1, LLBC_NS LLBC_TimerData * const &t2)
+    bool operator()(LLBC_NS LLBC_TimerData * const &t1, LLBC_NS LLBC_TimerData * const &t2) const
     {
         return t1->handle > t2->handle;
     }


### PR DESCRIPTION
std::binary_function 已被 c++ 标准弃用, 删除该使用以使 mac 平台编译通过