### PR TITLE
LLBC_Num2Str去除或优化

### DIFF
--- a/llbc/include/llbc/core/utils/Util_TextInl.h
+++ b/llbc/include/llbc/core/utils/Util_TextInl.h
@@ -260,9 +260,16 @@ inline LLBC_String LLBC_NumToStrInHex(uint8 val)
     return LLBC_INTERNAL_NS LLBC_IntegralToStringInHex(val);
 }
 
-
 template<>
 inline LLBC_String LLBC_NumToStrInHex(void *val)
+{
+    uint64 ptrVal = 0;
+    memcpy(&ptrVal, &val, sizeof(uint64));
+    return LLBC_INTERNAL_NS LLBC_IntegralToStringInHex<uint64>(ptrVal);
+}
+
+template<>
+inline LLBC_String LLBC_NumToStrInHex(const void *val)
 {
     uint64 ptrVal = 0;
     memcpy(&ptrVal, &val, sizeof(uint64));

--- a/llbc/include/llbc/core/utils/Util_TextInl.h
+++ b/llbc/include/llbc/core/utils/Util_TextInl.h
@@ -271,8 +271,6 @@ inline LLBC_String LLBC_NumToStrInHex(void *val)
 template<>
 inline LLBC_String LLBC_NumToStrInHex(const void *val)
 {
-    uint64 ptrVal = 0;
-    memcpy(&ptrVal, &val, sizeof(uint64));
-    return LLBC_INTERNAL_NS LLBC_IntegralToStringInHex<uint64>(ptrVal);
+    return LLBC_NumToStrInHex(const_cast<void *>(val));
 }
 __LLBC_NS_END

--- a/testsuite/core/utils/TestCase_Core_Utils_Text.cpp
+++ b/testsuite/core/utils/TestCase_Core_Utils_Text.cpp
@@ -122,7 +122,7 @@ int TestCase_Core_Utils_Text::Run(int argc, char *argv[])
             intPtr, LLBC_NumToStrInHex(static_cast<void*>(intPtr)).c_str());
 
         sint64 voidPtrAddr = 0xfffffffe;
-        void *voidPtr; memcpy(&voidPtr, &voidPtrAddr, sizeof(void *));
+        const void *voidPtr; memcpy(&voidPtr, &voidPtrAddr, sizeof(void *));
         LLBC_PrintLn("LLBC_Num2Str<void *>()[%p] -> string: %s",
             voidPtr, LLBC_NumToStrInHex(voidPtr).c_str());
     }

--- a/testsuite/core/utils/TestCase_Core_Utils_Text.cpp
+++ b/testsuite/core/utils/TestCase_Core_Utils_Text.cpp
@@ -123,7 +123,7 @@ int TestCase_Core_Utils_Text::Run(int argc, char *argv[])
 
         sint64 voidPtrAddr = 0xfffffffe;
         const void *voidPtr; memcpy(&voidPtr, &voidPtrAddr, sizeof(void *));
-        LLBC_PrintLn("LLBC_Num2Str<void *>()[%p] -> string: %s",
+        LLBC_PrintLn("LLBC_Num2Str<const void *>()[%p] -> string: %s",
             voidPtr, LLBC_NumToStrInHex(voidPtr).c_str());
     }
 


### PR DESCRIPTION
NumToStrHex 支持 const void* 特化