### PR TITLE
feat:premake安装；对象池对象管理限制

### DIFF
--- a/llbc/include/llbc/core/objpool/ObjPool.h
+++ b/llbc/include/llbc/core/objpool/ObjPool.h
@@ -448,7 +448,7 @@ public:
     {
         if constexpr (std::is_base_of_v<LLBC_Object, Obj>)
         {
-            // 引用计数对象执行引用计数减1
+            // add obj to gc-pool, if already do nothing
             obj->AutoRelease();
             return;
         }
@@ -468,11 +468,11 @@ public:
     {
         if constexpr (std::is_base_of_v<LLBC_Object, Obj>)
         {
-            // 引用计数对象执行引用计数减1
+            // add obj to gc-pool, if already do nothing
             obj->AutoRelease();
             return;
         }
-        
+
         RecycleInl<Obj>(obj, 0);
     }
 

--- a/llbc/include/llbc/core/objpool/ObjPool.h
+++ b/llbc/include/llbc/core/objpool/ObjPool.h
@@ -450,7 +450,9 @@ public:
         {
             // 引用计数对象执行引用计数减1
             obj->AutoRelease();
+            return;
         }
+
         LLBC_TypedObjPool<Obj> *typedObjPool =
             reinterpret_cast<LLBC_TypedObjPool<Obj> *>(obj->GetTypedObjPool());
         if (typedObjPool)
@@ -468,7 +470,9 @@ public:
         {
             // 引用计数对象执行引用计数减1
             obj->AutoRelease();
+            return;
         }
+        
         RecycleInl<Obj>(obj, 0);
     }
 

--- a/testsuite/core/objpool/TestCase_Core_ObjPool.h
+++ b/testsuite/core/objpool/TestCase_Core_ObjPool.h
@@ -45,6 +45,7 @@ public:
     int GuardedPoolObjTest();
     int LibSupportedObjPoolClassesTest();
     int CommonClassTest_Stream();
+    int RecycleTest();
 
     template <typename Obj>
     static void RandAllocAndRelease(LLBC_ObjPool &objPool,

--- a/tools/premake/premake5.lua
+++ b/tools/premake/premake5.lua
@@ -556,9 +556,15 @@ project "pyllbc"
     -- link cpython lib.
     -- local py_ver_str = os_capture('python --version')
     -- local py_ver_match_str = '(%w+ )(%d+).(%d+).(%d+)'
+    local py_ver_str = '2.7.18'
     local cpython_readme_file = io.open(llbc_py_wrap_path .. '/cpython/README', 'r')
-    local py_ver_str = cpython_readme_file:read()
-    cpython_readme_file:close()
+    if not cpython_readme_file then
+        io.stderr:write(string.format('Could not open cpython README file, set set python version to:%s\n', py_ver_str))
+    else
+        py_ver_str = cpython_readme_file:read()
+        cpython_readme_file:close()
+    end
+
     local py_ver_match_str = '(.*)(%d+).(%d+).(%d+).*'
     local py_major_ver = string.gsub(py_ver_str, py_ver_match_str, '%2')
     local py_minor_ver = string.gsub(py_ver_str, py_ver_match_str, '%3')


### PR DESCRIPTION
1.premake允许用户使用内建的cpython库
2.对象池对象不允许继承自引用计数对象LLBC_Object
3.LLBC_Recycle支持引用计数对象释放