### PR TITLE
【llbc】App运行时能力扩充 - 只允许启动一个实例 #224

### DIFF
--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -26,8 +26,10 @@
 // Handle crash support macro define.
 #if LLBC_TARGET_PLATFORM_WIN32 || LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
  #define LLBC_SUPPORT_HANDLE_CRASH 1
+ #define LLBC_SUPPORT_SET_EXCLUSIVE 1
 #else // Non Win32 and Linux
  #define LLBC_SUPPORT_HANDLE_CRASH 0
+ #define LLBC_SUPPORT_SET_EXCLUSIVE 0
 #endif
 
 __LLBC_NS_BEGIN
@@ -50,4 +52,12 @@ LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
                                  const LLBC_Delegate<void(const char *stackBacktrace,
                                                           int sig)> &crashCallback = nullptr);
 
+/**
+ * Set process exclusive(only one instance of process can run).
+ * @param[in] pidFilePath  - the pid file path.
+ *                            in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
+ *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
+ * @return int - return 0 if success, otherwise return -1.
+ */
+LLBC_EXPORT int LLBC_SetExclusive(const LLBC_String &pidFilePath = "");
 __LLBC_NS_END

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -590,6 +590,12 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
                     SetFPS(cfgSecItem.second);
                     break;
                 }
+
+                if (cfgSecItem.first.AsStr().tolower() == "exclusive" && cfgSecItem.second.AsLooseBool())
+                {
+                    LLBC_ReturnIf(LLBC_SetExclusive() != LLBC_OK, LLBC_FAILED);
+                    break;
+                }
             }
 
             break;
@@ -599,6 +605,16 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
         {
             const auto& fps = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
             SetFPS(fps);
+            break;
+        }
+
+        if (cfgItem.first.AsStr().tolower() == "exclusive")
+        {
+            const auto& isExclusive = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
+            if (isExclusive.AsLooseBool())
+            {
+                LLBC_ReturnIf(LLBC_SetExclusive() != LLBC_OK, LLBC_FAILED);
+            }
             break;
         }
     }

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -558,7 +558,7 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
 
     // Open executable file by pid.
 #if LLBC_TARGET_PLATFORM_MAC
-    pidPathRet = proc_pidpath(atoi(pidBuf), runningExeFilePath, PATH_MAX);
+    int pidPathRet = proc_pidpath(atoi(pidBuf), runningExeFilePath, PATH_MAX);
     LLBC_DoIf(pidPathRet != -1, runningExeFilePath[pidPathRet] = '\0');
 #else
     llbc::LLBC_String runingExe;

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -492,14 +492,15 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     LLBC_String selfExeFilePath = LLBC_Directory::ModuleFilePath();
 
     // Set .pid file path
-    LLBC_String pidFile = LLBC_Directory::Join(pidFilePath, LLBC_Directory::ModuleFileName()).append(".pid");
+    LLBC_String pidFile = LLBC_Directory::Join(pidFilePath, LLBC_Directory::ModuleFileName());
     if (pidFilePath == "")
     {
-        pidFile = selfExeFilePath.append(".pid");
+        pidFile = selfExeFilePath;
     }
+    pidFile.append(".pid");
 
     // Create or read-lock .pid file
-    HANDLE file = CreateFileA(exePidFilePath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE file = CreateFileA(pidFile.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     LLBC_ReturnIf(file == INVALID_HANDLE_VALUE, LLBC_FAILED);
     LLBC_Defer(CloseHandle(file));
 
@@ -515,14 +516,14 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     if (processHandle != NULL)
     {
         // Get executable file path refer to pid.
-        getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
+        DWORD getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
         CloseHandle(processHandle);
         LLBC_ReturnIf(getModuleFileNameRet == 0, LLBC_FAILED);
         runningExeFilePath[getModuleFileNameRet] = '\0';
     }
 
     // Compare self name and running process path
-    LLBC_ReturnIf(strcmp(runningExeFilePath, selfExeFilePath) == 0, LLBC_FAILED);
+    LLBC_ReturnIf(runningExeFilePath == selfExeFilePath, LLBC_FAILED);
 
     // Clear .pid file and write pid into it
     SetFilePointer(file, 0, NULL, FILE_BEGIN);

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -566,7 +566,7 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     ssize_t readLinkRet = readlink(runingExe.c_str(), runningExeFilePath, PATH_MAX);
     LLBC_DoIf(readLinkRet != -1, runningExeFilePath[readLinkRet] = '\0');
 #endif
-    LLBC_ReturnIf(selfExeFilePath == runningExeFilePath, LLBC_FAILED);
+    LLBC_ReturnIf(strcmp(selfExeFilePath.c_str(), runningExeFilePath) == 0, LLBC_FAILED);
 
     // Try to lock pid file
     struct flock fl;

--- a/testsuite/app/AppCfgTest.cfg
+++ b/testsuite/app/AppCfgTest.cfg
@@ -8,6 +8,7 @@ x.y.k = hey judy
 
 # App Fps
 Fps = 2
+Exclusive = 0
 
 # Service: TestSvc1 config.
 TestSvc1.Fps = 88

--- a/testsuite/app/AppCfgTest.ini
+++ b/testsuite/app/AppCfgTest.ini
@@ -1,5 +1,6 @@
 [App]
 fps = 44
+exclusive = 0
 
 [section_a]
 a = 3

--- a/testsuite/app/AppCfgTest.properties
+++ b/testsuite/app/AppCfgTest.properties
@@ -7,6 +7,7 @@ x.y.j = 6
 x.y.k = hey judy
 
 Fps = 2
+Exclusive = 0
 
 TestSvc1.TestCompA.a = 3
 TestSvc1.TestCompA.bb = 4

--- a/testsuite/app/AppCfgTest.xml
+++ b/testsuite/app/AppCfgTest.xml
@@ -2,6 +2,7 @@
 <b b_attr1 = "5" b_attr2 = "6" />
 
 <Fps>33</Fps>
+<Exclusive>0</Exclusive>
 
 <Service Name = "TestSvc1">
     <FPS>88</FPS>

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -26,6 +26,10 @@ int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
 {
     std::cout <<"core/os/process test:" <<std::endl;
 
+    // Test set exclusive
+    if (TestSetExclusive() != LLBC_OK)
+        return LLBC_FAILED;
+
     // Test crash hook.
     if (TestCrash() != LLBC_OK)
         return LLBC_FAILED;
@@ -83,4 +87,46 @@ void TestCase_Core_OS_Process::TestCrash_InvalidPtrRead()
     int *invalidPtr4Write = nullptr;
     std::cout << *invalidPtr4Write << std::endl;
 }
- 
+
+int TestCase_Core_OS_Process::TestSetExclusive()
+{
+    std::cout << "Set exclusive test:" << std::endl;
+
+#if LLBC_SUPPORT_SET_EXCLUSIVE
+    // Set exclusive
+    std::cout << "Set exclusive..." << std::endl;
+    if (LLBC_SetExclusive() != LLBC_OK)
+    {
+        std::cerr << "Set exclusive failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+
+#if LLBC_TARGET_PLATFORM_WIN32
+    if (LLBC_SetExclusive() == LLBC_OK)
+    {
+        std::cerr << "Another Process Set exclusive success, err:"
+                  << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+#else
+    if (fork() != -1)
+    {
+        if (LLBC_SetExclusive() == LLBC_OK)
+        {
+            std::cerr << "Another Process Set exclusive success, err:"
+                      << LLBC_FormatLastError() << std::endl;
+            exit(-1);
+        }
+    }
+    else
+    {
+        std::cout << "Fork failed!" << std::endl;
+        return LLBC_FAILED;
+    }
+#endif
+    return LLBC_OK;
+#else
+    // Unsupported set exclusive.
+    return LLBC_OK;
+#endif
+}

--- a/testsuite/core/os/TestCase_Core_OS_Process.h
+++ b/testsuite/core/os/TestCase_Core_OS_Process.h
@@ -39,5 +39,7 @@ private:
     void TestCrash_DivisionByZero();
     void TestCrash_InvalidPtrWrite();
     void TestCrash_InvalidPtrRead();
+    
+    int TestSetExclusive();
 };
 


### PR DESCRIPTION
## 可选方案
1、文件锁
优点：
标准化实现，可拓展
tip:目录+pid保证原子性，检查/proc/<PID>/exe来保证进程指向验证
缺点：
crash之后需要额外处理
2、POSIX named semaphores
优点：
实现简单，原子性保证
缺点：
具有内核生命周期，系统重启前都无法被清理
3、bind a port
优点：
进程关闭后内核会自动关闭文件描述符，简单
如果进程本身就已经绑定了一个port，那完全无需改动
缺点：
对于不需要绑定port的进程也需要绑定port
port是系统资源，对于运行多个程序的系统，依赖单一的port不太可控
文件描述符会传递给子进程
依赖网络功能
4、mutex in shared memory
优点：
基于共享内存，原子性保证
缺点：
crash之后需要额外处理

## 方案选取
方案2，4在crash之后都会有数据残留且难以清除的问题。
接下来是在方案1和3里面选，两个方案其实都是操作系统提供的支持，一个是文件模块，一个是网络模块。
考虑到网络模块是对外模块，采用使用文件模块的方案一更稳定一些，最终决定使用方案一

## 功能实现
在Mac和Linux下，分为三步，
1、判断.pid文件是否存在，存在就读取pid判断是否同名进程运行中。不存在则创建文件并直接进入下一步
2、设置.pid文件锁，写入当前进程pid到.pid文件中
3、关闭文件解锁，设置进程结束回调删除.pid文件（暂时没做）