### PR TITLE
去除thread_local前面多余的static #326

### DIFF
--- a/llbc/include/llbc/comm/ServiceInl.h
+++ b/llbc/include/llbc/comm/ServiceInl.h
@@ -224,7 +224,7 @@ LLBC_FORCE_INLINE int LLBC_Service::Multicast(const LLBC_SessionIds &sessionIds,
 
     // Encode coder.
     // TODO: Temporary code, will be optimized in later.
-    static thread_local LLBC_Packet pkt;
+    thread_local LLBC_Packet pkt;
     if (UNLIKELY(!pkt.GetPayload()))
         pkt.SetPayload(new LLBC_MessageBlock);
 
@@ -266,7 +266,7 @@ LLBC_FORCE_INLINE int LLBC_Service::Broadcast(int opcode, LLBC_Coder *coder, int
 
     // Encode coder.
     // TODO: Temporary code, will be optimized in later.
-    static thread_local LLBC_Packet pkt;
+    thread_local LLBC_Packet pkt;
     if (UNLIKELY(!pkt.GetPayload()))
         pkt.SetPayload(new LLBC_MessageBlock);
 

--- a/llbc/include/llbc/common/Macro.h
+++ b/llbc/include/llbc/common/Macro.h
@@ -229,19 +229,6 @@
     name(name &&) = delete;                \
     name &operator=(name &&) = delete      \
 
-// Thread local macro define.
-#if LLBC_TARGET_PLATFORM_LINUX
-#define LLBC_THREAD_LOCAL __thread
-#elif LLBC_TARGET_PLATFORM_WIN32
-#define LLBC_THREAD_LOCAL __declspec(thread)
-#elif LLBC_TARGET_PLATFORM_IPHONE
-#define LLBC_THREAD_LOCAL __thread
-#elif LLBC_TARGET_PLATFORM_MAC
-#define LLBC_THREAD_LOCAL __thread
-#elif LLBC_TARGET_PLATFORM_ANDROID
-#define LLBC_THREAD_LOCAL __thread
-#endif
-
 // Deprecated attribute macro define.
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
 #define LLBC_DEPRECATED __attribute__((deprecated))

--- a/llbc/include/llbc/core/variant/VariantInl.h
+++ b/llbc/include/llbc/core/variant/VariantInl.h
@@ -577,7 +577,7 @@ LLBC_Variant::operator _Ty *() const
 template <>
 inline LLBC_Variant::operator char *() const
 {
-    static thread_local char emptyMutableEmptyStr[1] = {'\0'};
+    thread_local char emptyMutableEmptyStr[1] = {'\0'};
     return IsStrX() ?  const_cast<char *>(_holder.data.obj.str->c_str()) : emptyMutableEmptyStr;
 }
 

--- a/llbc/src/comm/ServiceImpl.cpp
+++ b/llbc/src/comm/ServiceImpl.cpp
@@ -489,7 +489,7 @@ int LLBC_ServiceImpl::Broadcast(int opcode,
     }
 
     // Get all non-listen sessionIds.
-    static thread_local LLBC_SessionIds sessionIds;
+    thread_local LLBC_SessionIds sessionIds;
 
     _readySessionInfosLock.Lock();
     const auto readySessionInfosEndIt = _readySessionInfos.end();

--- a/llbc/src/core/os/OS_Console.cpp
+++ b/llbc/src/core/os/OS_Console.cpp
@@ -32,7 +32,7 @@ __LLBC_INTERNAL_NS_END
 
 #if LLBC_TARGET_PLATFORM_NON_WIN32
 __LLBC_INTERNAL_NS_BEGIN
-static LLBC_THREAD_LOCAL int __g_consoleColor[2];
+thread_local int __g_consoleColor[2];
 const static char *__g_consoleColorBeginFmt = "\033[";
 const static char *__g_consoleColorEndFmt = "\033[0m";
 

--- a/testsuite/core/thread/TestCase_Core_Thread_Task.cpp
+++ b/testsuite/core/thread/TestCase_Core_Thread_Task.cpp
@@ -41,10 +41,10 @@ public:
 
 private:
     const size_t _perThreadPopTimes;
-    static LLBC_THREAD_LOCAL int *_val;
+    static thread_local int *_val;
 };
 
-LLBC_THREAD_LOCAL int *BasicTestTask::_val = nullptr;
+thread_local int *BasicTestTask::_val = nullptr;
 
 BasicTestTask::BasicTestTask(size_t perThreadPopTimes)
 : _perThreadPopTimes(perThreadPopTimes)


### PR DESCRIPTION
# 改造内容
1、去除代码中已有的thread_local前的static，类成员thread_local必须有static。
2、去除项目中的LLBC_THREAD_LOCAL宏定义，替换为thread_local
## thread_local
`#define thread_local _Thread_local       (since C11)(removed in C23)`
thead_local 变量的表现如命名所述，取其地址得到的是当前线程中的该变量的地址。为thead_local变量分配的内存会随当前模块动态加载，在模块卸载的时候被释放。
## thread_local和__thread的区别
![image](https://github.com/user-attachments/assets/dfb0bd34-d60d-4c80-bef0-a02465f7084a)

# TLS原理相关

## 数据定义
链接器将把所有类型为 SHT_PROGBITS 且 SHF_TLS 标志设置为 .tdata 节的部分，以及所有类型为 SHT_NOBITS 且 SHF_TLS 设置为 .tbss 节的部分。
.tbss tdata段和普通的.bss .data段唯一区别是带上了flag SHF_TLS。二者都是静态内存分配
![Pasted image 20250113001354](https://github.com/user-attachments/assets/b993759f-5c70-4a8e-9c4a-712b6ae333aa)
.tdata段和.data段不同，动态链接器在启动时执行重定位时可能会修改该部分，但此后，该部分数据将作为初始化映像(initialization image)保留，不再被修改。对于每个线程（包括初始线程），都会分配新的内存，然后将初始化映像的内容复制到其中。这样保证了每个线程都是相同的初始状态。
由于线程局部变量没有与任何符号关联的地址，因此无法使用通常使用的符号表条目。在可执行文件中，st_value 字段将包含运行时变量的绝对地址。在 DSO 中，该值将和加载地址有关。两者都不适用于 TLS 变量。因此，引入了新的符号类型 STT_TLS。所有和线程本地存储的符号都会创建此类型的条目
在目标文件中，st_value 字段将包含 st_shndx 字段引用的部分开头的通常偏移量。 对于可执行文件和 DSO，st_value 字段包含 TLS 初始化映像中变量的偏移量
唯一允许使用 STT_TLS 类型符号的重定位是那些为处理 TLS 而引入的重定位。这些重定位不能使用任何其他类型的符号。
为了允许动态链接器执行初始化，必须在运行时知道初始化映像的位置。现有的节头不可用，所以创建一个新的程序头条目。内容如表 3 中所述。
![Pasted image 20250113001448](https://github.com/user-attachments/assets/ee878fcc-8803-4dea-b016-2e74d8ce7f58)
除了程序头条目之外，动态链接器所需的唯一其他信息是动态节中DT_FLAGS条目中的DF_STATIC_TLS 标志。此标志允许拒绝动态加载使用静态模型创建的模块。后续将介绍这两种模型。
每个线程局部变量都由从线程局部存储节开头的偏移量标识（在内存中，.tbss 节直接在 .tdata 节之后分配，并遵守对齐方式）。链接时无法计算虚拟地址，即使对于完全重定位的可执行文件也是如此。
## 运行时处理
线程本地存储的处理并不像普通数据那样简单，数据部分不能简单地提供给进程然后使用。使用前必须创建多个副本，所有副本都从相同的初始化映像初始化。
因此，运行时的处理应避免在没有必要的情况下创建线程本地存储。例如，加载的模块可能仅由组成进程的众多线程中的一个线程使用。为所有线程分配存储会浪费内存和时间。需要一种惰性方法。处理动态加载对象时已经要求识别尚未分配的存储，所以分配存储不会带来太多额外负担。这是停止所有线程并为所有线程分配存储然后再让它们再次运行的唯一替代方法。
但是出于性能原因，并不总是可以使用线程本地存储的惰性分配。至少应用程序本身和最初加载的 DSO 的线程本地存储通常总是立即分配。
讨论完内存分配，使用线程本地存储的问题尚未结束。 ELF 二进制格式定义的符号查找规则不允许在链接时确定包含所用定义的对象。如果不知道对象，则也无法确定对象线程本地存储部分内变量的偏移量。因此，正常的链接过程无法发生。所以线程本地变量由对对象的引用（以及对象的线程本地存储部分）和线程本地存储部分中变量的偏移量来标识。要将这些值映射到实际虚拟地址，运行时需要一些迄今为止不存在的数据结构。它们必须允许将对象引用映射到当前线程模块的相应线程本地存储部分的地址，为此，目前定义了两种变体，分别适配不同架构的 ABI 的细节（使用变体 ll 的一个原因是，由于历史原因，线程寄存器指向的内存布局与变体 l 不兼容。）。
![Pasted image 20250209164732](https://github.com/user-attachments/assets/8e00aa03-1f75-4c41-bfa8-62bd79846294)
线程本地存储数据结构的变体 I（见图 1）是作为 IA-64 ABI 的一部分开发的。由于是全新的结构，兼容性不会有问题。线程 t 的线程寄存器用 tp<sub>t</sub> 表示。它指向一个线程控制块 (TCB)，该块在偏移量零处包含指向该线程的动态线程数组 dtv<sub>t</sub> 的指针。
动态线程向量在第一个字段中包含一个生成编号gen<sub>t</sub>，用于后续调整dtv<sub>t</sub> 的大小和分配下面描述的 TLS 块。其他字段包含指向已加载的各种模块的 TLS 块的指针，启动时加载的模块的 TLS 块位于 TCB 之后，因此具有与线程指针地址相关的固定偏移量，对于所有最初可用的模块，任何 TLS 块（以及线程本地变量）与 TCB 的偏移量必须在程序启动后固定。
![Pasted image 20250209165218](https://github.com/user-attachments/assets/053aaa0a-c6cb-4ce4-bce7-83f82f99532b)

变体 ll 具有类似的结构。唯一的区别是线程指针指向未指定大小和内容的TCB。TCB中的某个地方包含指向动态线程数组的指针，但未指定在哪里。这受运行时环境的控制，并且不能假定指针可以直接访问：不允许编译器emit直接访问dtv<sub>t</sub> 的代码。
可执行文件本身的 TLS 块和启动时加载的所有模块都位于线程指针指向的地址下方。这允许编译器emit直接访问此内存的代码。这样可以通过动态线程数组(dtv)访问 TLS 块，该数组具有与变体 I 相同的结构，也相对于线程指针具有一些偏移量，该偏移量在程序启动后固定。可执行文件本身的 TLS 数据偏移量甚至在链接时也是已知的。
在程序启动时，将为主线程创建 TCB 以及动态线程数组dtv。各个模块的 TLS 块的位置是使用基于相应 TLS 块的大小和对齐要求（tlssize. 和 align.）的架构特定公式计算的。在特定架构中使用函数“round”，该函数返回其第一个参数，并将其向上舍入为其第二个参数的下一个倍数：
$$ round(x,y) = y ×[x/y]$$
TLS 块的内存不一定必须立即分配。这取决于模块编译时的模型（静态或动态），是否需要分配内存。如果使用静态模型，则地址（更确切地说，是线程指针 tp 的偏移量）由动态链接器在程序启动时使用重定位计算，并且编译器生成的代码直接使用这些偏移量来查找变量地址。在这种情况下，必须立即分配内存。在动态模型中，查找变量的地址被推迟到运行时环境提供的名为_tls_get_addr 的函数。此函数会分配和初始化必要的内存。
### 启动之后
对于使用线程本地存储的程序，启动代码必须在转移控制权之前为初始线程设置内存。静态链接应用程序中对线程本地存储的支持有限。某些平台（如 IA-64）未在 ABI 中定义静态链接（如果支持，则为非标准），其他平台（如 Sun）不鼓励使用静态链接，因为只有有限的功能可用。无论如何，在静态链接代码中动态加载模块受到严重限制或完全不可用。因此，线程本地存储的处理非常简单，因为只有一个模块，即可执行文件本身。
更有趣的情况是在动态链接代码中处理线程本地存储。在这种情况下，动态链接器必须包括对处理此类数据部分的支持。后续将介绍动态加载使用线程本地存储的代码的能力的额外要求。
要为线程本地存储设置内存，动态链接器会从程序头中的PT_TLS条目中获取有关每个模块的线程本地存储要求的信息（参见表 3）。收集所有模块的信息后可以使用包含以下信息的链表来记录：
a pointer to the TLS initialization image.
the size of the TLS initialization image.
the tlsoffset<sub>m</sub> for the module,
a flag indicating whether the module uses the static TLS model (only if the ar-
chitecture supports the static TLS model).
动态加载附加模块时，此链表将会扩展，线程库将使用它来为新创建的线程设置 TLS 块。还可以合并初始模块集的两个或多个初始化记录以缩短列表。
如果必须在启动时分配所有 TLS 内存，则总大小将是 $$tlssize_s = tlsofset_m + tlssize_m$$，其中 m 是启动时存在的模块数。除非为静态模型编译了一个模块，否则没有必要立即分配所有这些内存。如果所有模块都使用动态模型，则可以推迟分配。优化后的实现不会盲目遵循指示使用静态模型的flag。如果所需的内存量很小，可能不值得推迟分配，就可以节省时间和资源。
线程本地存储中的变量由对模块的引用和 TLS 块中的偏移量指定。给定动态线程数组，我们可以将模块引用定义为从1开始的整数，可用于索引dtv<sub>t</sub>数组。每个模块接收的数字取决于运行时环境。只有可执行文件本身必须接收固定数字 1，所有其他加载的模块必须具有不同的数字。
因此，计算 TLS 变量的线程特定地址是一个简单的操作，可以由使用变体 I 的编译器生成的代码执行。但对于遵循变体 Il 的体系结构，编译器无法做到这一点，而且也有好处不这样做：延迟分配（见下文）。
定义了一个名为__tls_get_addr 的函数，理论上可以像这样实现（这是该函数在IA-64的实现：其他架构可能使用不同的接口）：
~~~
void *
__tls_get_addr(size_t m,size t offset)
{
	char *tls_block= dtv[thread_id][m];
	
	return tls_block + offset;
}
~~~
数组dtv[thread_id] 的位置取决于架构。这部分仅作示例，可以将表达式 dtv[thread id] 视为获取thread_id对应动态线程数组的符号表示。m 是模块 ID，由动态链接器在加载模块（应用程序本身或 DSO）时分配。
使用__tls_get_addr函数具有额外的优势：可以实现动态模型（TLS 块的分配推迟到第一次使用）。只需用一个特殊值填充dtv[thread_id] 数组，该值可以与任何常规值区分开来，也可能是指示空条目的值。更改__tls_get_addr的实现以完成额外工作很简单：
~~~
void *
__tls_get_addr(size_t m,size t offset)
{
	char *tls_block= dtv[thread_id][m];
	
	if (tls_block == UNALLOCATED_TLS_BLOCK)
		tls_block = dtv[thread_id][m] = allocate_tls(m);
		
	return tls_block + offset;
}
~~~
函数 allocate_tls 需要确定模块 m 的 TLS 的内存要求并对其进行适当的初始化。有已初始化和未初始化这两种类型的数据。已初始化的数据必须从加载模块 m 时设置的重定位初始化映像中复制，未初始化的数据必须设置为零。实现可能如下所示：
~~~
void *
allocate_tls(size t m)
{
	void *mem = malloc (tlssizelm]);
	memset (mempcpy (mem,tlsinit_image[m],tlsinit_size[m]),
	'\0',tlssize[m]-tlsinit_size[m]);
	return mem;
}
~~~
tlssize[m]、tlsinit_size[m] 和 tlsinit_image[m] 的值取决于实现方式。在加载模块 m 后，它们都是已知的。请注意，所有线程在创建时都使用相同的映像 tlsinit_image[m]。线程不会从其父级继承数据。存储数据结构的两种变体都允许使用静态模型。以这种方式编译的模块可以通过动态部分的DT_FLAGS的DF_STATIC_TLS 标志识别。如果此类模块是初始化模块集合的一部分（此类模块无法动态加载），则必须在启动时立即为初始线程分配 TLS 块的内存，并且每当为此新线程创建新线程时也是如此。除此之外的情况可以推迟分配，并将 dtv<sub>t</sub> 的元素设置为实现定义的值（上述示例代码中的UNALLOCATED_TLS_BLOCK）。
### 动态加载
模块的动态加载更加复杂。首先，不应限制加载的使用线程本地存储的模块数量，这意味着dtv<sub>t</sub>数组在必要时必须扩大，同时还要避免内存泄漏。在优化实现速度时必须牢记这一点。当释放已卸载模块的 TLS 块的内存时，会出现速度问题。动态线程数组dtv中的成员迟早必须重新使用，也就是需要在加载新模块时不断扩展数组。
由于释放和重新分配内存的成本很高，尤其是因为必须为每个单独的线程执行此操作，因此可能希望通过保留内存来避免成本。需要注意的是多次加载和卸载同一个模块的情况下，不能出现内存泄漏。
现在，实现的限制已经明确，接下来就是确定要执行的实际工作。需要一个应用程序管理动态加载包含线程本地存储的模块时的内存，以便当前正在运行的线程和所有未来的线程都可以使用此内存。所以需要将有关新TLS块的信息添加到初始化记录列表中，并且增加已加载模块数 M 的计数器。对于创建的线程和正在运行的线程都是如此。
加载新模块可能意味着为任何给定线程分配的动态线程数组可能太小。可以使用每个dtv<sub>t</sub>中的生成计数器gen<sub>t</sub>来检测。访问数组时，首先要做的是确保生成号是最新的，如果不是，则分配一个更大的数组。虽然理论上这可以由创建新线程的线程（或新线程本身）来完成，但如果线程不使用任何线程本地存储，这只会导致同步问题和不必要的工作。由于动态加载的模块不能使用静态模型，因此永远不需要立即在dtv<sub>t</sub> 中分配新元素。总是可以将其推迟到第一次使用，就像在__tls_get_addr中那样。
### 静态链接应用程序
静态链接应用程序中的 TLS 处理比动态链接代码简单得多。至少如果确定静态链接应用程序无法动态加载更多模块的话。即使在某些情况下允许动态加载的系统（例如使用 GNU C 库的系统），动态加载也可能仅限于加载到非常基本的模块，并且不允许包含使用或定义线程本地存储的代码的模块。
因此，静态链接代码始终只有一个 TLS 块。而且由于只使用一个模块，因此变量偏移量也不存在问题。由于所有线程本地变量都必须包含在这一个 TLS 块中，因此在链接时偏移量也是已知的。
链接器将始终能够填充模块 ID 和偏移量并执行代码放宽。启动代码除了为初始线程设置 TLS 块之外无需做任何工作。线程库必须对新创建的线程执行相同操作。这是一项简单的任务，因为只有一个初始化映像。
可以看到，TLS 块的访问非常简单，因为tlsoffset<sub>1</sub>值在链接时已知，通过线程指针、tlsoffset<sub>1</sub>值和变量偏移量可以计算得到变量的地址。对于某些架构，链接器可以还会重写编译器生成的代码来自动帮助改进代码。

参考文献：
https://[uclibc.org/docs/tls.pdf](https://uclibc.org/docs/tls.pdf)
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1966.html
https://www.cnblogs.com/lizhaolong/p/16437261.html