### PR TITLE
feat: 增加 LLBC_WARN_UNUSED_RESULT #376

### DIFF
--- a/llbc/include/llbc/app/App.h
+++ b/llbc/include/llbc/app/App.h
@@ -57,14 +57,14 @@ public:
      * @param[in] cfgType - the application config type.
      * @return const LLBC_Strings & - the config suffixex.
      */
-    static const LLBC_Strings &GetConfigSuffixes(int cfgType);
+    LLBC_WARN_UNUSED_RESULT static const LLBC_Strings &GetConfigSuffixes(int cfgType);
 
     /**
      * Get config type. 
      * @param cfgSuffix - the config suffix, case insensitive.
      * @return ENUM - the config type, if unsupported application config, return End.
      */
-    static ENUM GetConfigType(const LLBC_String &cfgSuffix);
+    LLBC_WARN_UNUSED_RESULT static ENUM GetConfigType(const LLBC_String &cfgSuffix);
 };
 
 /**
@@ -183,8 +183,8 @@ public:
      * @return App * - this application.
      */
     template <typename App>
-    static App *ThisApp() { return static_cast<App *>(_thisApp); }
-    static LLBC_App *ThisApp() { return _thisApp; }
+    LLBC_WARN_UNUSED_RESULT static App *ThisApp() { return static_cast<App *>(_thisApp); }
+    LLBC_WARN_UNUSED_RESULT static LLBC_App *ThisApp() { return _thisApp; }
 
 public:
     /**
@@ -363,7 +363,7 @@ private:
      * @param[out] cfgType - the application config type.
      * @return LLBC_String - the application config path, return empty string if failed.
      */
-    static LLBC_String LocateConfigPath(const LLBC_String &appName, int &cfgType);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String LocateConfigPath(const LLBC_String &appName, int &cfgType);
 
     /**
      * Application reload implement method.

--- a/llbc/include/llbc/app/App.h
+++ b/llbc/include/llbc/app/App.h
@@ -57,14 +57,14 @@ public:
      * @param[in] cfgType - the application config type.
      * @return const LLBC_Strings & - the config suffixex.
      */
-    LLBC_WARN_UNUSED_RESULT static const LLBC_Strings &GetConfigSuffixes(int cfgType);
+    LLBC_NO_DISCARD static const LLBC_Strings &GetConfigSuffixes(int cfgType);
 
     /**
      * Get config type. 
      * @param cfgSuffix - the config suffix, case insensitive.
      * @return ENUM - the config type, if unsupported application config, return End.
      */
-    LLBC_WARN_UNUSED_RESULT static ENUM GetConfigType(const LLBC_String &cfgSuffix);
+    LLBC_NO_DISCARD static ENUM GetConfigType(const LLBC_String &cfgSuffix);
 };
 
 /**
@@ -183,8 +183,8 @@ public:
      * @return App * - this application.
      */
     template <typename App>
-    LLBC_WARN_UNUSED_RESULT static App *ThisApp() { return static_cast<App *>(_thisApp); }
-    LLBC_WARN_UNUSED_RESULT static LLBC_App *ThisApp() { return _thisApp; }
+    LLBC_NO_DISCARD static App *ThisApp() { return static_cast<App *>(_thisApp); }
+    LLBC_NO_DISCARD static LLBC_App *ThisApp() { return _thisApp; }
 
 public:
     /**
@@ -363,7 +363,7 @@ private:
      * @param[out] cfgType - the application config type.
      * @return LLBC_String - the application config path, return empty string if failed.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String LocateConfigPath(const LLBC_String &appName, int &cfgType);
+    LLBC_NO_DISCARD static LLBC_String LocateConfigPath(const LLBC_String &appName, int &cfgType);
 
     /**
      * Application reload implement method.

--- a/llbc/include/llbc/comm/BasePoller.h
+++ b/llbc/include/llbc/comm/BasePoller.h
@@ -63,7 +63,7 @@ public:
      * @param[in] type - the poller type.
      * @return This * - the poller, if failed, return nullptr.
      */
-    static This *Create(int type);
+    LLBC_WARN_UNUSED_RESULT static This *Create(int type);
 
 public:
     /**

--- a/llbc/include/llbc/comm/BasePoller.h
+++ b/llbc/include/llbc/comm/BasePoller.h
@@ -63,7 +63,7 @@ public:
      * @param[in] type - the poller type.
      * @return This * - the poller, if failed, return nullptr.
      */
-    LLBC_WARN_UNUSED_RESULT static This *Create(int type);
+    LLBC_NO_DISCARD static This *Create(int type);
 
 public:
     /**

--- a/llbc/include/llbc/comm/PollerEvent.h
+++ b/llbc/include/llbc/comm/PollerEvent.h
@@ -92,49 +92,49 @@ public:
     /**
      * Build AddSock event.
      */
-    static LLBC_MessageBlock *BuildAddSockEv(LLBC_Socket *sock,
-                                             int sessionId,
-                                             const LLBC_SessionOpts &sessionOpts);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAddSockEv(LLBC_Socket *sock,
+                                                                     int sessionId,
+                                                                     const LLBC_SessionOpts &sessionOpts);
     
     /**
      * Build Async-Conn event.
      */
-    static LLBC_MessageBlock *BuildAsyncConnEv(int sessionId,
-                                               const LLBC_SessionOpts &sessionOpts,
-                                               const LLBC_SockAddr_IN &peerAddr);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAsyncConnEv(int sessionId,
+                                                                       const LLBC_SessionOpts &sessionOpts,
+                                                                       const LLBC_SockAddr_IN &peerAddr);
 
     /**
      * Build Send event.
      */
-    static LLBC_MessageBlock *BuildSendEv(LLBC_Packet *packet);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSendEv(LLBC_Packet *packet);
 
     /**
      * Build close event.
      */
-    static LLBC_MessageBlock *BuildCloseEv(int sessionId, const char *reason);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildCloseEv(int sessionId, const char *reason);
 
     /**
      * Build Iocp monitor event.
      */
 #if LLBC_TARGET_PLATFORM_WIN32
-    static LLBC_MessageBlock *BuildIocpMonitorEv(int ret, LLBC_POverlapped ol, int errNo, int subErrNo);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildIocpMonitorEv(int ret, LLBC_POverlapped ol, int errNo, int subErrNo);
 #endif
     /**
      * Build Epoll monitor event.
      */
 #if LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_ANDROID
-    static LLBC_MessageBlock *BuildEpollMonitorEv(const LLBC_EpollEvent *evs, int count);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildEpollMonitorEv(const LLBC_EpollEvent *evs, int count);
 #endif
 
     /**
      * Build take over session event.
      */
-    static LLBC_MessageBlock *BuildTakeOverSessionEv(LLBC_Session *session);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildTakeOverSessionEv(LLBC_Session *session);
 
     /**
      * Build control protocol stack event.
      */
-    static LLBC_MessageBlock *BuildCtrlProtocolStackEv(int sessionId,
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildCtrlProtocolStackEv(int sessionId,
                                                        int ctrlCmd,
                                                        const LLBC_Variant &ctrlData);
 

--- a/llbc/include/llbc/comm/PollerEvent.h
+++ b/llbc/include/llbc/comm/PollerEvent.h
@@ -92,52 +92,52 @@ public:
     /**
      * Build AddSock event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAddSockEv(LLBC_Socket *sock,
-                                                                     int sessionId,
-                                                                     const LLBC_SessionOpts &sessionOpts);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildAddSockEv(LLBC_Socket *sock,
+                                                             int sessionId,
+                                                             const LLBC_SessionOpts &sessionOpts);
     
     /**
      * Build Async-Conn event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAsyncConnEv(int sessionId,
-                                                                       const LLBC_SessionOpts &sessionOpts,
-                                                                       const LLBC_SockAddr_IN &peerAddr);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildAsyncConnEv(int sessionId,
+                                                               const LLBC_SessionOpts &sessionOpts,
+                                                               const LLBC_SockAddr_IN &peerAddr);
 
     /**
      * Build Send event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSendEv(LLBC_Packet *packet);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildSendEv(LLBC_Packet *packet);
 
     /**
      * Build close event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildCloseEv(int sessionId, const char *reason);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildCloseEv(int sessionId, const char *reason);
 
     /**
      * Build Iocp monitor event.
      */
 #if LLBC_TARGET_PLATFORM_WIN32
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_MessageBlock *BuildIocpMonitorEv(int ret, LLBC_POverlapped ol, int errNo, int subErrNo);
 #endif
     /**
      * Build Epoll monitor event.
      */
 #if LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_ANDROID
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildEpollMonitorEv(const LLBC_EpollEvent *evs, int count);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildEpollMonitorEv(const LLBC_EpollEvent *evs, int count);
 #endif
 
     /**
      * Build take over session event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildTakeOverSessionEv(LLBC_Session *session);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildTakeOverSessionEv(LLBC_Session *session);
 
     /**
      * Build control protocol stack event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildCtrlProtocolStackEv(int sessionId,
-                                                                               int ctrlCmd,
-                                                                               const LLBC_Variant &ctrlData);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildCtrlProtocolStackEv(int sessionId,
+                                                                       int ctrlCmd,
+                                                                       const LLBC_Variant &ctrlData);
 
 public:
     /**

--- a/llbc/include/llbc/comm/PollerEvent.h
+++ b/llbc/include/llbc/comm/PollerEvent.h
@@ -117,7 +117,8 @@ public:
      * Build Iocp monitor event.
      */
 #if LLBC_TARGET_PLATFORM_WIN32
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildIocpMonitorEv(int ret, LLBC_POverlapped ol, int errNo, int subErrNo);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_MessageBlock *BuildIocpMonitorEv(int ret, LLBC_POverlapped ol, int errNo, int subErrNo);
 #endif
     /**
      * Build Epoll monitor event.
@@ -135,8 +136,8 @@ public:
      * Build control protocol stack event.
      */
     LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildCtrlProtocolStackEv(int sessionId,
-                                                       int ctrlCmd,
-                                                       const LLBC_Variant &ctrlData);
+                                                                               int ctrlCmd,
+                                                                               const LLBC_Variant &ctrlData);
 
 public:
     /**

--- a/llbc/include/llbc/comm/PollerMgr.h
+++ b/llbc/include/llbc/comm/PollerMgr.h
@@ -181,7 +181,7 @@ private:
     /**
      * Get address info from given ip and port.
      */
-    static int GetAddr(const char *ip, uint16 port, LLBC_SockAddr_IN &addr);
+    LLBC_WARN_UNUSED_RESULT static int GetAddr(const char *ip, uint16 port, LLBC_SockAddr_IN &addr);
 
 private:
     /**

--- a/llbc/include/llbc/comm/PollerMgr.h
+++ b/llbc/include/llbc/comm/PollerMgr.h
@@ -181,7 +181,7 @@ private:
     /**
      * Get address info from given ip and port.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetAddr(const char *ip, uint16 port, LLBC_SockAddr_IN &addr);
+    static int GetAddr(const char *ip, uint16 port, LLBC_SockAddr_IN &addr);
 
 private:
     /**

--- a/llbc/include/llbc/comm/PollerType.h
+++ b/llbc/include/llbc/comm/PollerType.h
@@ -51,21 +51,21 @@ public:
      * @param[in] type - the poller type, see above type enumeration.
      * @return bool - return true if validate, otherwise return false.
      */
-    static bool IsValid(int type);
+    LLBC_WARN_UNUSED_RESULT static bool IsValid(int type);
 
     /**
      * Get poller type string representation.
      * @param[in] type - the poller type, see above type enumeration.
      * return const LLBC_String & - the poller type string representation.
      */
-    static const LLBC_String &Type2Str(int type);
+    LLBC_WARN_UNUSED_RESULT static const LLBC_String &Type2Str(int type);
 
     /**
      * Get poller type enumeration from string representation.
      * @param[in] typeStr - the poller type string representation.
      * @return int - the poller type, if error occurred, return End value.
      */
-    static int Str2Type(const LLBC_String &typeStr);
+    LLBC_WARN_UNUSED_RESULT static int Str2Type(const LLBC_String &typeStr);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/comm/PollerType.h
+++ b/llbc/include/llbc/comm/PollerType.h
@@ -51,21 +51,21 @@ public:
      * @param[in] type - the poller type, see above type enumeration.
      * @return bool - return true if validate, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static bool IsValid(int type);
+    LLBC_NO_DISCARD static bool IsValid(int type);
 
     /**
      * Get poller type string representation.
      * @param[in] type - the poller type, see above type enumeration.
      * return const LLBC_String & - the poller type string representation.
      */
-    LLBC_WARN_UNUSED_RESULT static const LLBC_String &Type2Str(int type);
+    LLBC_NO_DISCARD static const LLBC_String &Type2Str(int type);
 
     /**
      * Get poller type enumeration from string representation.
      * @param[in] typeStr - the poller type string representation.
      * @return int - the poller type, if error occurred, return End value.
      */
-    LLBC_WARN_UNUSED_RESULT static int Str2Type(const LLBC_String &typeStr);
+    LLBC_NO_DISCARD static int Str2Type(const LLBC_String &typeStr);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/comm/Service.h
+++ b/llbc/include/llbc/comm/Service.h
@@ -93,21 +93,21 @@ public:
      * @param[in] runningPhase - the running phase.
      * @return bool - failed phase flag.
      */
-    LLBC_WARN_UNUSED_RESULT static constexpr bool IsFailedPhase(int runningPhase);
+    LLBC_NO_DISCARD static constexpr bool IsFailedPhase(int runningPhase);
 
     /**
      * Check given running phase is stopping phase or not.
      * @param[in] runningPhase - the running phase.
      * @return bool - stopping phase flag.
      */
-    LLBC_WARN_UNUSED_RESULT static constexpr bool IsStoppingPhase(int runningPhase);
+    LLBC_NO_DISCARD static constexpr bool IsStoppingPhase(int runningPhase);
 
     /**
      * Check given running phase is failed/stopping phase or not.
      * @param[in] runningPhase - the running phase.
      * @return bool - failed/stopping phase flag.
      */
-    LLBC_WARN_UNUSED_RESULT static constexpr bool IsFailedOrStoppingPhase(int runningPhase);
+    LLBC_NO_DISCARD static constexpr bool IsFailedOrStoppingPhase(int runningPhase);
 };
 
 /**
@@ -132,7 +132,7 @@ public:
      * @param[in] driveMode - the service drive mode.
      * @return bool - return true if validate, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static constexpr bool IsValid(int driveMode);
+    LLBC_NO_DISCARD static constexpr bool IsValid(int driveMode);
 };
 
 /**
@@ -156,9 +156,9 @@ public:
      * @param[in] fullStack          - the full stack option, default is true.
      * @return LLBC_Service * - new service.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Service *Create(const LLBC_String &name = "",
-                                                        LLBC_IProtocolFactory *dftProtocolFactory = nullptr,
-                                                        bool fullStack = true);
+    LLBC_NO_DISCARD static LLBC_Service *Create(const LLBC_String &name = "",
+                                                LLBC_IProtocolFactory *dftProtocolFactory = nullptr,
+                                                bool fullStack = true);
 
 public:
     /**

--- a/llbc/include/llbc/comm/Service.h
+++ b/llbc/include/llbc/comm/Service.h
@@ -93,21 +93,21 @@ public:
      * @param[in] runningPhase - the running phase.
      * @return bool - failed phase flag.
      */
-    static constexpr bool IsFailedPhase(int runningPhase);
+    LLBC_WARN_UNUSED_RESULT static constexpr bool IsFailedPhase(int runningPhase);
 
     /**
      * Check given running phase is stopping phase or not.
      * @param[in] runningPhase - the running phase.
      * @return bool - stopping phase flag.
      */
-    static constexpr bool IsStoppingPhase(int runningPhase);
+    LLBC_WARN_UNUSED_RESULT static constexpr bool IsStoppingPhase(int runningPhase);
 
     /**
      * Check given running phase is failed/stopping phase or not.
      * @param[in] runningPhase - the running phase.
      * @return bool - failed/stopping phase flag.
      */
-    static constexpr bool IsFailedOrStoppingPhase(int runningPhase);
+    LLBC_WARN_UNUSED_RESULT static constexpr bool IsFailedOrStoppingPhase(int runningPhase);
 };
 
 /**
@@ -132,7 +132,7 @@ public:
      * @param[in] driveMode - the service drive mode.
      * @return bool - return true if validate, otherwise return false.
      */
-    static constexpr bool IsValid(int driveMode);
+    LLBC_WARN_UNUSED_RESULT static constexpr bool IsValid(int driveMode);
 };
 
 /**
@@ -156,9 +156,9 @@ public:
      * @param[in] fullStack          - the full stack option, default is true.
      * @return LLBC_Service * - new service.
      */
-    static LLBC_Service *Create(const LLBC_String &name = "",
-                                LLBC_IProtocolFactory *dftProtocolFactory = nullptr,
-                                bool fullStack = true);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Service *Create(const LLBC_String &name = "",
+                                                        LLBC_IProtocolFactory *dftProtocolFactory = nullptr,
+                                                        bool fullStack = true);
 
 public:
     /**

--- a/llbc/include/llbc/comm/ServiceEvent.h
+++ b/llbc/include/llbc/comm/ServiceEvent.h
@@ -231,87 +231,86 @@ public:
     /**
      * Build session create event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSessionCreateEv(const LLBC_SockAddr_IN &local,
-                                                                           const LLBC_SockAddr_IN &peer,
-                                                                           bool isListen,
-                                                                           int sessionId,
-                                                                           int acceptSessionId,
-                                                                           LLBC_SocketHandle handle);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildSessionCreateEv(const LLBC_SockAddr_IN &local,
+                                                                   const LLBC_SockAddr_IN &peer,
+                                                                   bool isListen,
+                                                                   int sessionId,
+                                                                   int acceptSessionId,
+                                                                   LLBC_SocketHandle handle);
 
     /**
      * Build session destroy event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSessionDestroyEv(const LLBC_SockAddr_IN &local,
-                                                                            const LLBC_SockAddr_IN &peer,
-                                                                            bool isListen,
-                                                                            int sessionId,
-                                                                            int acceptSessionId,
-                                                                            LLBC_SocketHandle handle,
-                                                                            LLBC_SessionCloseInfo *closeInfo);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildSessionDestroyEv(const LLBC_SockAddr_IN &local,
+                                                                    const LLBC_SockAddr_IN &peer,
+                                                                    bool isListen,
+                                                                    int sessionId,
+                                                                    int acceptSessionId,
+                                                                    LLBC_SocketHandle handle,
+                                                                    LLBC_SessionCloseInfo *closeInfo);
 
     /**
      * Build async-connect result event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAsyncConnResultEv(int sessionId,
-                                                                             bool connected,
-                                                                             const LLBC_String &reason,
-                                                                             const LLBC_SockAddr_IN &peer);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildAsyncConnResultEv(int sessionId,
+                                                                     bool connected,
+                                                                     const LLBC_String &reason,
+                                                                     const LLBC_SockAddr_IN &peer);
 
     /**
      * Build Data-Arrival event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildDataArrivalEv(LLBC_Packet *packet);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildDataArrivalEv(LLBC_Packet *packet);
 
     /**
      * Build subscribe-event event.
      */
-    LLBC_WARN_UNUSED_RESULT static
-    LLBC_MessageBlock *BuildSubscribeEventEv(int id,
-                                             const LLBC_ListenerStub &stub,
-                                             const LLBC_Delegate<void(LLBC_Event &)> &deleg,
-                                             LLBC_EventListener *listener);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildSubscribeEventEv(int id,
+                                                                    const LLBC_ListenerStub &stub,
+                                                                    const LLBC_Delegate<void(LLBC_Event &)> &deleg,
+                                                                    LLBC_EventListener *listener);
 
     /**
      * Build proto-report event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildProtoReportEv(int sessionId,
-                                                                         int opcode,
-                                                                         int layer,
-                                                                         int level,
-                                                                         const LLBC_String &report);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildProtoReportEv(int sessionId,
+                                                                 int opcode,
+                                                                 int layer,
+                                                                 int level,
+                                                                 const LLBC_String &report);
 
     /**
      * Build unsubscribe-event event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildUnsubscribeEventEv(int id, const LLBC_ListenerStub &stub);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildUnsubscribeEventEv(int id, const LLBC_ListenerStub &stub);
 
     /**
      * Build fire-event event.
      */
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_MessageBlock *BuildFireEventEv(LLBC_Event *ev, const LLBC_Delegate<void(LLBC_Event *)> &dequeueHandler);
 
     /**
      * Build application phase event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAppPhaseEv(bool willStart,
-                                                                      bool startFailed,
-                                                                      bool startFinished,
-                                                                      bool willStop,
-                                                                      int cfgType,
-                                                                      const LLBC_Variant &cfg = LLBC_Variant::nil);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildAppPhaseEv(bool willStart,
+                                                              bool startFailed,
+                                                              bool startFinished,
+                                                              bool willStop,
+                                                              int cfgType,
+                                                              const LLBC_Variant &cfg = LLBC_Variant::nil);
 
     /**
      * Build application reloaded event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAppReloadedEv(int cfgType,
-                                                                         const LLBC_Variant &cfg);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildAppReloadedEv(int cfgType,
+                                                                 const LLBC_Variant &cfg);
 
     /**
      * Build component event ev.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildComponentEventEv(int eventType,
-                                                                            const LLBC_Variant &eventParams);
+    LLBC_NO_DISCARD static LLBC_MessageBlock *BuildComponentEventEv(int eventType,
+                                                                    const LLBC_Variant &eventParams);
 
 public:
     /**

--- a/llbc/include/llbc/comm/ServiceEvent.h
+++ b/llbc/include/llbc/comm/ServiceEvent.h
@@ -265,10 +265,11 @@ public:
     /**
      * Build subscribe-event event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSubscribeEventEv(int id,
-                                                                            const LLBC_ListenerStub &stub,
-                                                                            const LLBC_Delegate<void(LLBC_Event &)> &deleg,
-                                                                            LLBC_EventListener *listener);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_MessageBlock *BuildSubscribeEventEv(int id,
+                                             const LLBC_ListenerStub &stub,
+                                             const LLBC_Delegate<void(LLBC_Event &)> &deleg,
+                                             LLBC_EventListener *listener);
 
     /**
      * Build proto-report event.
@@ -287,8 +288,8 @@ public:
     /**
      * Build fire-event event.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildFireEventEv(LLBC_Event *ev,
-                                               const LLBC_Delegate<void(LLBC_Event *)> &dequeueHandler);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_MessageBlock *BuildFireEventEv(LLBC_Event *ev, const LLBC_Delegate<void(LLBC_Event *)> &dequeueHandler);
 
     /**
      * Build application phase event.

--- a/llbc/include/llbc/comm/ServiceEvent.h
+++ b/llbc/include/llbc/comm/ServiceEvent.h
@@ -231,86 +231,86 @@ public:
     /**
      * Build session create event.
      */
-    static LLBC_MessageBlock *BuildSessionCreateEv(const LLBC_SockAddr_IN &local,
-                                                   const LLBC_SockAddr_IN &peer,
-                                                   bool isListen,
-                                                   int sessionId,
-                                                   int acceptSessionId,
-                                                   LLBC_SocketHandle handle);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSessionCreateEv(const LLBC_SockAddr_IN &local,
+                                                                           const LLBC_SockAddr_IN &peer,
+                                                                           bool isListen,
+                                                                           int sessionId,
+                                                                           int acceptSessionId,
+                                                                           LLBC_SocketHandle handle);
 
     /**
      * Build session destroy event.
      */
-    static LLBC_MessageBlock *BuildSessionDestroyEv(const LLBC_SockAddr_IN &local,
-                                                    const LLBC_SockAddr_IN &peer,
-                                                    bool isListen,
-                                                    int sessionId,
-                                                    int acceptSessionId,
-                                                    LLBC_SocketHandle handle,
-                                                    LLBC_SessionCloseInfo *closeInfo);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSessionDestroyEv(const LLBC_SockAddr_IN &local,
+                                                                            const LLBC_SockAddr_IN &peer,
+                                                                            bool isListen,
+                                                                            int sessionId,
+                                                                            int acceptSessionId,
+                                                                            LLBC_SocketHandle handle,
+                                                                            LLBC_SessionCloseInfo *closeInfo);
 
     /**
      * Build async-connect result event.
      */
-    static LLBC_MessageBlock *BuildAsyncConnResultEv(int sessionId,
-                                                     bool connected,
-                                                     const LLBC_String &reason,
-                                                     const LLBC_SockAddr_IN &peer);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAsyncConnResultEv(int sessionId,
+                                                                             bool connected,
+                                                                             const LLBC_String &reason,
+                                                                             const LLBC_SockAddr_IN &peer);
 
     /**
      * Build Data-Arrival event.
      */
-    static LLBC_MessageBlock *BuildDataArrivalEv(LLBC_Packet *packet);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildDataArrivalEv(LLBC_Packet *packet);
 
     /**
      * Build subscribe-event event.
      */
-    static LLBC_MessageBlock *BuildSubscribeEventEv(int id,
-                                                    const LLBC_ListenerStub &stub,
-                                                    const LLBC_Delegate<void(LLBC_Event &)> &deleg,
-                                                    LLBC_EventListener *listener);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildSubscribeEventEv(int id,
+                                                                            const LLBC_ListenerStub &stub,
+                                                                            const LLBC_Delegate<void(LLBC_Event &)> &deleg,
+                                                                            LLBC_EventListener *listener);
 
     /**
      * Build proto-report event.
      */
-    static LLBC_MessageBlock *BuildProtoReportEv(int sessionId,
-                                                 int opcode,
-                                                 int layer,
-                                                 int level,
-                                                 const LLBC_String &report);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildProtoReportEv(int sessionId,
+                                                                         int opcode,
+                                                                         int layer,
+                                                                         int level,
+                                                                         const LLBC_String &report);
 
     /**
      * Build unsubscribe-event event.
      */
-    static LLBC_MessageBlock *BuildUnsubscribeEventEv(int id, const LLBC_ListenerStub &stub);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildUnsubscribeEventEv(int id, const LLBC_ListenerStub &stub);
 
     /**
      * Build fire-event event.
      */
-    static LLBC_MessageBlock *BuildFireEventEv(LLBC_Event *ev,
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildFireEventEv(LLBC_Event *ev,
                                                const LLBC_Delegate<void(LLBC_Event *)> &dequeueHandler);
 
     /**
      * Build application phase event.
      */
-    static LLBC_MessageBlock *BuildAppPhaseEv(bool willStart,
-                                              bool startFailed,
-                                              bool startFinished,
-                                              bool willStop,
-                                              int cfgType,
-                                              const LLBC_Variant &cfg = LLBC_Variant::nil);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAppPhaseEv(bool willStart,
+                                                                      bool startFailed,
+                                                                      bool startFinished,
+                                                                      bool willStop,
+                                                                      int cfgType,
+                                                                      const LLBC_Variant &cfg = LLBC_Variant::nil);
 
     /**
      * Build application reloaded event.
      */
-    static LLBC_MessageBlock *BuildAppReloadedEv(int cfgType,
-                                                 const LLBC_Variant &cfg);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildAppReloadedEv(int cfgType,
+                                                                         const LLBC_Variant &cfg);
 
     /**
      * Build component event ev.
      */
-    static LLBC_MessageBlock *BuildComponentEventEv(int eventType,
-                                                    const LLBC_Variant &eventParams);
+    LLBC_WARN_UNUSED_RESULT static LLBC_MessageBlock *BuildComponentEventEv(int eventType,
+                                                                            const LLBC_Variant &eventParams);
 
 public:
     /**

--- a/llbc/include/llbc/comm/ServiceMgr.h
+++ b/llbc/include/llbc/comm/ServiceMgr.h
@@ -143,9 +143,9 @@ private:
     LLBC_Service *GetServiceNonLock(int id);
     LLBC_Service *GetServiceNonLock(const LLBC_CString &name);
 
-    static bool InTls(const LLBC_Service *svc);
-    static bool InTls(const Id2Services &svcs);
-    static bool InTls(const Name2Services &svcs);
+    LLBC_WARN_UNUSED_RESULT static bool InTls(const LLBC_Service *svc);
+    LLBC_WARN_UNUSED_RESULT static bool InTls(const Id2Services &svcs);
+    LLBC_WARN_UNUSED_RESULT static bool InTls(const Name2Services &svcs);
 
 private:
     mutable LLBC_SpinLock _lock;

--- a/llbc/include/llbc/comm/ServiceMgr.h
+++ b/llbc/include/llbc/comm/ServiceMgr.h
@@ -143,9 +143,9 @@ private:
     LLBC_Service *GetServiceNonLock(int id);
     LLBC_Service *GetServiceNonLock(const LLBC_CString &name);
 
-    LLBC_WARN_UNUSED_RESULT static bool InTls(const LLBC_Service *svc);
-    LLBC_WARN_UNUSED_RESULT static bool InTls(const Id2Services &svcs);
-    LLBC_WARN_UNUSED_RESULT static bool InTls(const Name2Services &svcs);
+    static bool InTls(const LLBC_Service *svc);
+    static bool InTls(const Id2Services &svcs);
+    static bool InTls(const Name2Services &svcs);
 
 private:
     mutable LLBC_SpinLock _lock;

--- a/llbc/include/llbc/common/BasicString.h
+++ b/llbc/include/llbc/common/BasicString.h
@@ -964,7 +964,7 @@ public:
     }
 
     // isalpha/isupper/islower
-    LLBC_WARN_UNUSED_RESULT static bool isalpha(const _Elem &c)
+    LLBC_NO_DISCARD static bool isalpha(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -981,7 +981,7 @@ public:
         }
     }
 
-    LLBC_WARN_UNUSED_RESULT static bool isalpha(const _This &s)
+    LLBC_NO_DISCARD static bool isalpha(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1000,7 +1000,7 @@ public:
         return isalpha(*this);
     }
 
-    LLBC_WARN_UNUSED_RESULT static bool islower(const _Elem &c)
+    LLBC_NO_DISCARD static bool islower(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1017,7 +1017,7 @@ public:
         }
     }
 
-    LLBC_WARN_UNUSED_RESULT static bool islower(const _This &s)
+    LLBC_NO_DISCARD static bool islower(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1039,7 +1039,7 @@ public:
         return islower(*this);
     }
 
-    LLBC_WARN_UNUSED_RESULT static bool isupper(const _Elem &c)
+    LLBC_NO_DISCARD static bool isupper(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1056,7 +1056,7 @@ public:
         }
     }
 
-    LLBC_WARN_UNUSED_RESULT static bool isupper(const _This &s)
+    LLBC_NO_DISCARD static bool isupper(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1079,7 +1079,7 @@ public:
     }
 
     // isdigit
-    LLBC_WARN_UNUSED_RESULT static bool isdigit(const _Elem &c)
+    LLBC_NO_DISCARD static bool isdigit(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1096,7 +1096,7 @@ public:
         }
     }
 
-    LLBC_WARN_UNUSED_RESULT static bool isdigit(const _This &s)
+    LLBC_NO_DISCARD static bool isdigit(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1116,7 +1116,7 @@ public:
     }
 
     // isspace: space[' '],carriage return['\r'],line feed['\n'],form feed['\f'],horizontal tab['\t'],vertical tab['\v']
-    LLBC_WARN_UNUSED_RESULT static bool isspace(const _Elem &c)
+    LLBC_NO_DISCARD static bool isspace(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1133,7 +1133,7 @@ public:
         }
     }
 
-    LLBC_WARN_UNUSED_RESULT static bool isspace(const _This &s)
+    LLBC_NO_DISCARD static bool isspace(const _This &s)
     {
         if (s.empty())
             return false;

--- a/llbc/include/llbc/common/BasicString.h
+++ b/llbc/include/llbc/common/BasicString.h
@@ -964,7 +964,7 @@ public:
     }
 
     // isalpha/isupper/islower
-    static bool isalpha(const _Elem &c)
+    LLBC_WARN_UNUSED_RESULT static bool isalpha(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -981,7 +981,7 @@ public:
         }
     }
 
-    static bool isalpha(const _This &s)
+    LLBC_WARN_UNUSED_RESULT static bool isalpha(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1000,7 +1000,7 @@ public:
         return isalpha(*this);
     }
 
-    static bool islower(const _Elem &c)
+    LLBC_WARN_UNUSED_RESULT static bool islower(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1017,7 +1017,7 @@ public:
         }
     }
 
-    static bool islower(const _This &s)
+    LLBC_WARN_UNUSED_RESULT static bool islower(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1039,7 +1039,7 @@ public:
         return islower(*this);
     }
 
-    static bool isupper(const _Elem &c)
+    LLBC_WARN_UNUSED_RESULT static bool isupper(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1056,7 +1056,7 @@ public:
         }
     }
 
-    static bool isupper(const _This &s)
+    LLBC_WARN_UNUSED_RESULT static bool isupper(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1079,7 +1079,7 @@ public:
     }
 
     // isdigit
-    static bool isdigit(const _Elem &c)
+    LLBC_WARN_UNUSED_RESULT static bool isdigit(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1096,7 +1096,7 @@ public:
         }
     }
 
-    static bool isdigit(const _This &s)
+    LLBC_WARN_UNUSED_RESULT static bool isdigit(const _This &s)
     {
         if (s.empty())
             return false;
@@ -1116,7 +1116,7 @@ public:
     }
 
     // isspace: space[' '],carriage return['\r'],line feed['\n'],form feed['\f'],horizontal tab['\t'],vertical tab['\v']
-    static bool isspace(const _Elem &c)
+    LLBC_WARN_UNUSED_RESULT static bool isspace(const _Elem &c)
     {
         if (sizeof(_Elem) == 1)
         {
@@ -1133,7 +1133,7 @@ public:
         }
     }
 
-    static bool isspace(const _This &s)
+    LLBC_WARN_UNUSED_RESULT static bool isspace(const _This &s)
     {
         if (s.empty())
             return false;

--- a/llbc/include/llbc/common/Endian.h
+++ b/llbc/include/llbc/common/Endian.h
@@ -50,13 +50,13 @@ public:
      * Check given endian type validate or not.
      * @return bool - return true if validate, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static constexpr bool IsValid(int endianType);
+    LLBC_NO_DISCARD static constexpr bool IsValid(int endianType);
 
     /**
      * Endian type/type describe convert support.
      */
-    LLBC_WARN_UNUSED_RESULT static const char *Type2Str(int endianType);
-    LLBC_WARN_UNUSED_RESULT static int Str2Type(const char *endianTypeStr);
+    LLBC_NO_DISCARD static const char *Type2Str(int endianType);
+    LLBC_NO_DISCARD static int Str2Type(const char *endianTypeStr);
 };
 
 /**

--- a/llbc/include/llbc/common/Endian.h
+++ b/llbc/include/llbc/common/Endian.h
@@ -50,13 +50,13 @@ public:
      * Check given endian type validate or not.
      * @return bool - return true if validate, otherwise return false.
      */
-    static constexpr bool IsValid(int endianType);
+    LLBC_WARN_UNUSED_RESULT static constexpr bool IsValid(int endianType);
 
     /**
      * Endian type/type describe convert support.
      */
-    static const char *Type2Str(int endianType);
-    static int Str2Type(const char *endianTypeStr);
+    LLBC_WARN_UNUSED_RESULT static const char *Type2Str(int endianType);
+    LLBC_WARN_UNUSED_RESULT static int Str2Type(const char *endianTypeStr);
 };
 
 /**

--- a/llbc/include/llbc/common/Macro.h
+++ b/llbc/include/llbc/common/Macro.h
@@ -240,11 +240,11 @@
 
 // WARN_UNUSED_RESULT macro define.
 #if defined(__GNUC__) || defined(__clang__)
- #define LLBC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+ #define LLBC_NO_DISCARD __attribute__((warn_unused_result))
 #elif defined(_MSC_VER) && _MSC_VER >= 1700 // VS 2012 or higher
- #define LLBC_WARN_UNUSED_RESULT _Check_return_
+ #define LLBC_NO_DISCARD _Check_return_
 #else
- #define LLBC_WARN_UNUSED_RESULT
+ #define LLBC_NO_DISCARD
 #endif
 
 // Unused param macro.

--- a/llbc/include/llbc/common/Macro.h
+++ b/llbc/include/llbc/common/Macro.h
@@ -232,10 +232,19 @@
 // Deprecated attribute macro define.
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
 #define LLBC_DEPRECATED __attribute__((deprecated))
-#elif _MSC_VER >= 1400 // VS 2005 or higher.
+#elif defined(_MSC_VER) && _MSC_VER >= 1400 // VS 2005 or higher.
 #define LLBC_DEPRECATED __declspec(deprecated)
 #else
 #define LLBC_DEPRECATED
+#endif
+
+// WARN_UNUSED_RESULT macro define.
+#if defined(__GNUC__) || defined(__clang__)
+ #define LLBC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && _MSC_VER >= 1700 // VS 2012 or higher
+ #define LLBC_WARN_UNUSED_RESULT _Check_return_
+#else
+ #define LLBC_WARN_UNUSED_RESULT
 #endif
 
 // Unused param macro.

--- a/llbc/include/llbc/common/StreamInl.h
+++ b/llbc/include/llbc/common/StreamInl.h
@@ -33,7 +33,7 @@ template <>
 struct LLBC_Stream::__LLBC_STLArrayReader<0>
 {
     template <typename Arr>
-    LLBC_WARN_UNUSED_RESULT static bool Read(Arr &arr, LLBC_NS LLBC_Stream &stream)
+    LLBC_NO_DISCARD static bool Read(Arr &arr, LLBC_NS LLBC_Stream &stream)
     {
         return true;
     }
@@ -58,7 +58,7 @@ template <>
 struct LLBC_Stream::__LLBC_TupleReader<0>
 {
     template <typename Tup>
-    LLBC_WARN_UNUSED_RESULT static bool Read(Tup &tup, LLBC_Stream &stream)
+    LLBC_NO_DISCARD static bool Read(Tup &tup, LLBC_Stream &stream)
     {
         return true;
     }

--- a/llbc/include/llbc/common/StreamInl.h
+++ b/llbc/include/llbc/common/StreamInl.h
@@ -33,7 +33,7 @@ template <>
 struct LLBC_Stream::__LLBC_STLArrayReader<0>
 {
     template <typename Arr>
-    static bool Read(Arr &arr, LLBC_NS LLBC_Stream &stream)
+    LLBC_WARN_UNUSED_RESULT static bool Read(Arr &arr, LLBC_NS LLBC_Stream &stream)
     {
         return true;
     }
@@ -58,7 +58,7 @@ template <>
 struct LLBC_Stream::__LLBC_TupleReader<0>
 {
     template <typename Tup>
-    static bool Read(Tup &tup, LLBC_Stream &stream)
+    LLBC_WARN_UNUSED_RESULT static bool Read(Tup &tup, LLBC_Stream &stream)
     {
         return true;
     }

--- a/llbc/include/llbc/core/bundle/Bundle.h
+++ b/llbc/include/llbc/core/bundle/Bundle.h
@@ -39,7 +39,7 @@ public:
      * Create main bundle(When llbc lib startup, will autocall this method).
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int CreateMainBundle();
+    LLBC_NO_DISCARD static int CreateMainBundle();
 
     /**
      * Destroy main bundle(When llbc lib cleanup, will autocall this method).
@@ -50,7 +50,7 @@ public:
      * Get main bundle.
      * @return const LLBC_Bundle * - main bundle object.
      */
-    LLBC_WARN_UNUSED_RESULT static const LLBC_Bundle *GetMainBundle();
+    LLBC_NO_DISCARD static const LLBC_Bundle *GetMainBundle();
 
 public:
     /**

--- a/llbc/include/llbc/core/bundle/Bundle.h
+++ b/llbc/include/llbc/core/bundle/Bundle.h
@@ -39,7 +39,7 @@ public:
      * Create main bundle(When llbc lib startup, will autocall this method).
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int CreateMainBundle();
+    LLBC_WARN_UNUSED_RESULT static int CreateMainBundle();
 
     /**
      * Destroy main bundle(When llbc lib cleanup, will autocall this method).
@@ -50,7 +50,7 @@ public:
      * Get main bundle.
      * @return const LLBC_Bundle * - main bundle object.
      */
-    static const LLBC_Bundle *GetMainBundle();
+    LLBC_WARN_UNUSED_RESULT static const LLBC_Bundle *GetMainBundle();
 
 public:
     /**

--- a/llbc/include/llbc/core/config/Properties.h
+++ b/llbc/include/llbc/core/config/Properties.h
@@ -48,9 +48,9 @@ public:
      * @param[in] errMsg     - the error message, if failed, will be set to this param, otherwise set to 'Success'.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int LoadFromFile(const LLBC_String &filePath,
-                                                    LLBC_Variant &properties,
-                                                    LLBC_String *errMsg = nullptr);
+    LLBC_NO_DISCARD static int LoadFromFile(const LLBC_String &filePath,
+                                            LLBC_Variant &properties,
+                                            LLBC_String *errMsg = nullptr);
 
     /**
      * Load properties from string content.
@@ -59,9 +59,9 @@ public:
      * @param[in] errMsg     - the error message, if failed, will be set to this param.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int LoadFromString(const LLBC_String &str,
-                                                      LLBC_Variant &properties,
-                                                      LLBC_String *errMsg = nullptr);
+    LLBC_NO_DISCARD static int LoadFromString(const LLBC_String &str,
+                                              LLBC_Variant &properties,
+                                              LLBC_String *errMsg = nullptr);
 
     /**
      * Save properties to file.
@@ -70,9 +70,9 @@ public:
      * @param[in] errMsg     - the error message, if failed, will be set to this param.
      * @return int - return 0 if success, otherwise return -1. 
      */
-    LLBC_WARN_UNUSED_RESULT static int SaveToFile(const LLBC_Variant &properties,
-                                                  const LLBC_String &filePath,
-                                                  LLBC_String *errMsg = nullptr);
+    LLBC_NO_DISCARD static int SaveToFile(const LLBC_Variant &properties,
+                                          const LLBC_String &filePath,
+                                          LLBC_String *errMsg = nullptr);
 
     /**
      * Write property to string content.
@@ -81,37 +81,37 @@ public:
      * @param[in]  errMsg     - the error message, if failed, will be set to this param.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int SaveToString(const LLBC_Variant &properties,
-                                                    LLBC_String &str,
-                                                    LLBC_String *errMsg = nullptr);
+    LLBC_NO_DISCARD static int SaveToString(const LLBC_Variant &properties,
+                                            LLBC_String &str,
+                                            LLBC_String *errMsg = nullptr);
 
 private:
     /**
      * Parse property line.
      */
-    LLBC_WARN_UNUSED_RESULT static int ParseLine(int lineNo,
-                                                 const LLBC_String &line,
-                                                 LLBC_Strings &keyItems,
-                                                 LLBC_String &value,
-                                                 LLBC_String *errMsg);
+    LLBC_NO_DISCARD static int ParseLine(int lineNo,
+                                         const LLBC_String &line,
+                                         LLBC_Strings &keyItems,
+                                         LLBC_String &value,
+                                         LLBC_String *errMsg);
 
     /**
      * Write property line.
      */
-    LLBC_WARN_UNUSED_RESULT static int SaveLine(const LLBC_String key,
-                                                const LLBC_Variant &property,
-                                                LLBC_String &str,
-                                                LLBC_String *errMsg);
+    LLBC_NO_DISCARD static int SaveLine(const LLBC_String key,
+                                        const LLBC_Variant &property,
+                                        LLBC_String &str,
+                                        LLBC_String *errMsg);
 
     /**
      * Check property key item.
      */
-    LLBC_WARN_UNUSED_RESULT static bool CheckKeyItem(const LLBC_String &keyItem);
+    LLBC_NO_DISCARD static bool CheckKeyItem(const LLBC_String &keyItem);
 
     /**
      * Check property key items.
      */
-    LLBC_WARN_UNUSED_RESULT static bool CheckKeyItems(const LLBC_Strings &keyItems);
+    LLBC_NO_DISCARD static bool CheckKeyItems(const LLBC_Strings &keyItems);
 
     /**
      * Escape property value.
@@ -120,10 +120,10 @@ private:
     /**
      * Unescape property value.
      */
-    LLBC_WARN_UNUSED_RESULT static int UnescapeValue(int lineNo,
-                                                     const LLBC_String &escapedValue,
-                                                     LLBC_String &rawValue,
-                                                     LLBC_String *errMsg);
+    LLBC_NO_DISCARD static int UnescapeValue(int lineNo,
+                                             const LLBC_String &escapedValue,
+                                             LLBC_String &rawValue,
+                                             LLBC_String *errMsg);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/config/Properties.h
+++ b/llbc/include/llbc/core/config/Properties.h
@@ -90,10 +90,10 @@ private:
      * Parse property line.
      */
     LLBC_WARN_UNUSED_RESULT static int ParseLine(int lineNo,
-                         const LLBC_String &line,
-                         LLBC_Strings &keyItems,
-                         LLBC_String &value,
-                         LLBC_String *errMsg);
+                                                 const LLBC_String &line,
+                                                 LLBC_Strings &keyItems,
+                                                 LLBC_String &value,
+                                                 LLBC_String *errMsg);
 
     /**
      * Write property line.

--- a/llbc/include/llbc/core/config/Properties.h
+++ b/llbc/include/llbc/core/config/Properties.h
@@ -48,9 +48,9 @@ public:
      * @param[in] errMsg     - the error message, if failed, will be set to this param, otherwise set to 'Success'.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int LoadFromFile(const LLBC_String &filePath,
-                            LLBC_Variant &properties,
-                            LLBC_String *errMsg = nullptr);
+    LLBC_WARN_UNUSED_RESULT static int LoadFromFile(const LLBC_String &filePath,
+                                                    LLBC_Variant &properties,
+                                                    LLBC_String *errMsg = nullptr);
 
     /**
      * Load properties from string content.
@@ -59,9 +59,9 @@ public:
      * @param[in] errMsg     - the error message, if failed, will be set to this param.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int LoadFromString(const LLBC_String &str,
-                              LLBC_Variant &properties,
-                              LLBC_String *errMsg = nullptr);
+    LLBC_WARN_UNUSED_RESULT static int LoadFromString(const LLBC_String &str,
+                                                      LLBC_Variant &properties,
+                                                      LLBC_String *errMsg = nullptr);
 
     /**
      * Save properties to file.
@@ -70,9 +70,9 @@ public:
      * @param[in] errMsg     - the error message, if failed, will be set to this param.
      * @return int - return 0 if success, otherwise return -1. 
      */
-    static int SaveToFile(const LLBC_Variant &properties,
-                          const LLBC_String &filePath,
-                          LLBC_String *errMsg = nullptr);
+    LLBC_WARN_UNUSED_RESULT static int SaveToFile(const LLBC_Variant &properties,
+                                                  const LLBC_String &filePath,
+                                                  LLBC_String *errMsg = nullptr);
 
     /**
      * Write property to string content.
@@ -81,15 +81,15 @@ public:
      * @param[in]  errMsg     - the error message, if failed, will be set to this param.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int SaveToString(const LLBC_Variant &properties,
-                            LLBC_String &str,
-                            LLBC_String *errMsg = nullptr);
+    LLBC_WARN_UNUSED_RESULT static int SaveToString(const LLBC_Variant &properties,
+                                                    LLBC_String &str,
+                                                    LLBC_String *errMsg = nullptr);
 
 private:
     /**
      * Parse property line.
      */
-    static int ParseLine(int lineNo,
+    LLBC_WARN_UNUSED_RESULT static int ParseLine(int lineNo,
                          const LLBC_String &line,
                          LLBC_Strings &keyItems,
                          LLBC_String &value,
@@ -98,20 +98,20 @@ private:
     /**
      * Write property line.
      */
-    static int SaveLine(const LLBC_String key,
-                        const LLBC_Variant &property,
-                        LLBC_String &str,
-                        LLBC_String *errMsg);
+    LLBC_WARN_UNUSED_RESULT static int SaveLine(const LLBC_String key,
+                                                const LLBC_Variant &property,
+                                                LLBC_String &str,
+                                                LLBC_String *errMsg);
 
     /**
      * Check property key item.
      */
-    static bool CheckKeyItem(const LLBC_String &keyItem);
+    LLBC_WARN_UNUSED_RESULT static bool CheckKeyItem(const LLBC_String &keyItem);
 
     /**
      * Check property key items.
      */
-    static bool CheckKeyItems(const LLBC_Strings &keyItems);
+    LLBC_WARN_UNUSED_RESULT static bool CheckKeyItems(const LLBC_Strings &keyItems);
 
     /**
      * Escape property value.
@@ -120,10 +120,10 @@ private:
     /**
      * Unescape property value.
      */
-    static int UnescapeValue(int lineNo,
-                             const LLBC_String &escapedValue,
-                             LLBC_String &rawValue,
-                             LLBC_String *errMsg);
+    LLBC_WARN_UNUSED_RESULT static int UnescapeValue(int lineNo,
+                                                     const LLBC_String &escapedValue,
+                                                     LLBC_String &rawValue,
+                                                     LLBC_String *errMsg);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/file/Directory.h
+++ b/llbc/include/llbc/core/file/Directory.h
@@ -36,21 +36,21 @@ public:
      * @param[in] path - the given path.
      * @return bool - return true if given path exists and is directory.
      */
-    static bool Exists(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static bool Exists(const LLBC_String &path);
 
     /**
      * Recursive create directory.
      * @param[in] path - the will create directory path.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int Create(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static int Create(const LLBC_String &path);
 
     /**
      * Recursive remove directory.
      * @param[in] path - the will remove path.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int Remove(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static int Remove(const LLBC_String &path);
 
 public:
     /**
@@ -58,13 +58,13 @@ public:
      * @param[in] path - the path.
      * @return bool - return true if given path is abs path, otherwise return false.
      */
-    static bool IsAbsPath(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static bool IsAbsPath(const LLBC_String &path);
 
     /**
      * Convert path to normalized absolutize path.
      * @return LLBC_String - the normalized absolutize path.
      */
-    static LLBC_String AbsPath(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String AbsPath(const LLBC_String &path);
 
     /**
      * Join one or more path components intelligently.
@@ -72,22 +72,22 @@ public:
      * @param[in] paths   - the paths list.
      * @return LLBC_String - the joined path.
      */
-    static LLBC_String Join(const LLBC_String &path1,
-                            const LLBC_String &path2);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_String &path1,
+                                                    const LLBC_String &path2);
 
-    static LLBC_String Join(const LLBC_Strings &paths);
-    static LLBC_String Join(const LLBC_String &path1,
-                            const LLBC_Strings &paths);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_Strings &paths);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_String &path1,
+                                                    const LLBC_Strings &paths);
 
     template<typename ...Args>
-    static LLBC_String Join(const LLBC_String &path1, const LLBC_String &path2, Args... args);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_String &path1, const LLBC_String &path2, Args... args);
 
     /**
      * Split file extension, always success.
      * @param[in] path - the file path.
      * @return LLBC_Strings - the splited parts, patrts[0] is not has extension path, parts[1] is the file extension.
      */
-    static LLBC_Strings SplitExt(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Strings SplitExt(const LLBC_String &path);
 
     /**
      * Get specific path's files, not include directory type files.
@@ -96,7 +96,7 @@ public:
      * @param[in] recursive  - recursive flag, if set to true, function will recursive scan path, default is false.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int GetFiles(const LLBC_String &path, LLBC_Strings &files, bool recursive = false);
+    LLBC_WARN_UNUSED_RESULT static int GetFiles(const LLBC_String &path, LLBC_Strings &files, bool recursive = false);
 
     /**
      * Get specific path's files, not include directory type files.
@@ -106,7 +106,7 @@ public:
      * @param[in] recursive  - recursive flag, if set to true, function will recursive scan path, default is false.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int GetFiles(const LLBC_String &path, LLBC_Strings &files, const LLBC_String &ext, bool recursive = false);
+    LLBC_WARN_UNUSED_RESULT static int GetFiles(const LLBC_String &path, LLBC_Strings &files, const LLBC_String &ext, bool recursive = false);
 
     /**
      * Recursive specific path's directories.
@@ -115,78 +115,78 @@ public:
      * @param[in] recursive    - recursive flag, default is false.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int GetDirectories(const LLBC_String &path, LLBC_Strings &directories, bool recursive = false);
+    LLBC_WARN_UNUSED_RESULT static int GetDirectories(const LLBC_String &path, LLBC_Strings &directories, bool recursive = false);
 
 public:
     /**
      * Get current executable module file directory.
      * @return LLBC_String - the module file directory.
      */
-    static LLBC_String ModuleFileDir();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String ModuleFileDir();
 
     /**
      * Get current executable module file name.
      * @return LLBC_String - the module file name.
      */
-    static LLBC_String ModuleFileName();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String ModuleFileName();
 
     /**
      * Get current executable module file path(dir + name).
      * @return LLBC_String - the module file path.
      */
-    static LLBC_String ModuleFilePath();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String ModuleFilePath();
 
     /**
      * Get given path directory name.
      * @param[in] path - the path.
      * @return LLBC_String - the directory name for the path.
      */
-    static LLBC_String DirName(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String DirName(const LLBC_String &path);
 
     /**
      * Get given path base name.
      * @param[in] path - the path.
      * @return LLBC_String - the base name for the path.
      */
-    static LLBC_String BaseName(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String BaseName(const LLBC_String &path);
 
 public:
     /**
      * Get current directory.
      * @return LLBC_String - current directory.
      */
-    static LLBC_String CurDir();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String CurDir();
 
     /**
      * Set current directory.
      * @param[in] path - the new current directory.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int SetCurDir(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static int SetCurDir(const LLBC_String &path);
 
     /**
      * Get document directory.
      * @return LLBC_String - document directory.
      */
-    static LLBC_String DocDir();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String DocDir();
 
     /**
      * Get home directory.
      * @return LLBC_String - the home directory.
      */
-    static LLBC_String HomeDir();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String HomeDir();
 
     /**
      * Get temporary directory.
      * @return LLBC_String - the temporary directory.
      */
-    static LLBC_String TempDir();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String TempDir();
 
     /**
      * Get cache directory.
      * @return LLBC_String - the cache directory.
      */
-    static LLBC_String CacheDir();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String CacheDir();
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/file/Directory.h
+++ b/llbc/include/llbc/core/file/Directory.h
@@ -36,21 +36,21 @@ public:
      * @param[in] path - the given path.
      * @return bool - return true if given path exists and is directory.
      */
-    LLBC_WARN_UNUSED_RESULT static bool Exists(const LLBC_String &path);
+    LLBC_NO_DISCARD static bool Exists(const LLBC_String &path);
 
     /**
      * Recursive create directory.
      * @param[in] path - the will create directory path.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int Create(const LLBC_String &path);
+    LLBC_NO_DISCARD static int Create(const LLBC_String &path);
 
     /**
      * Recursive remove directory.
      * @param[in] path - the will remove path.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int Remove(const LLBC_String &path);
+    LLBC_NO_DISCARD static int Remove(const LLBC_String &path);
 
 public:
     /**
@@ -58,13 +58,13 @@ public:
      * @param[in] path - the path.
      * @return bool - return true if given path is abs path, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static bool IsAbsPath(const LLBC_String &path);
+    LLBC_NO_DISCARD static bool IsAbsPath(const LLBC_String &path);
 
     /**
      * Convert path to normalized absolutize path.
      * @return LLBC_String - the normalized absolutize path.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String AbsPath(const LLBC_String &path);
+    LLBC_NO_DISCARD static LLBC_String AbsPath(const LLBC_String &path);
 
     /**
      * Join one or more path components intelligently.
@@ -72,22 +72,22 @@ public:
      * @param[in] paths   - the paths list.
      * @return LLBC_String - the joined path.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_String &path1,
+    LLBC_NO_DISCARD static LLBC_String Join(const LLBC_String &path1,
                                                     const LLBC_String &path2);
 
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_Strings &paths);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_String &path1,
+    LLBC_NO_DISCARD static LLBC_String Join(const LLBC_Strings &paths);
+    LLBC_NO_DISCARD static LLBC_String Join(const LLBC_String &path1,
                                                     const LLBC_Strings &paths);
 
     template<typename ...Args>
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Join(const LLBC_String &path1, const LLBC_String &path2, Args... args);
+    LLBC_NO_DISCARD static LLBC_String Join(const LLBC_String &path1, const LLBC_String &path2, Args... args);
 
     /**
      * Split file extension, always success.
      * @param[in] path - the file path.
      * @return LLBC_Strings - the splited parts, patrts[0] is not has extension path, parts[1] is the file extension.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Strings SplitExt(const LLBC_String &path);
+    LLBC_NO_DISCARD static LLBC_Strings SplitExt(const LLBC_String &path);
 
     /**
      * Get specific path's files, not include directory type files.
@@ -96,7 +96,7 @@ public:
      * @param[in] recursive  - recursive flag, if set to true, function will recursive scan path, default is false.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetFiles(const LLBC_String &path, LLBC_Strings &files, bool recursive = false);
+    LLBC_NO_DISCARD static int GetFiles(const LLBC_String &path, LLBC_Strings &files, bool recursive = false);
 
     /**
      * Get specific path's files, not include directory type files.
@@ -106,7 +106,8 @@ public:
      * @param[in] recursive  - recursive flag, if set to true, function will recursive scan path, default is false.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetFiles(const LLBC_String &path, LLBC_Strings &files, const LLBC_String &ext, bool recursive = false);
+    LLBC_NO_DISCARD static
+    int GetFiles(const LLBC_String &path, LLBC_Strings &files, const LLBC_String &ext, bool recursive = false);
 
     /**
      * Recursive specific path's directories.
@@ -115,78 +116,79 @@ public:
      * @param[in] recursive    - recursive flag, default is false.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetDirectories(const LLBC_String &path, LLBC_Strings &directories, bool recursive = false);
+    LLBC_NO_DISCARD static
+    int GetDirectories(const LLBC_String &path, LLBC_Strings &directories, bool recursive = false);
 
 public:
     /**
      * Get current executable module file directory.
      * @return LLBC_String - the module file directory.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String ModuleFileDir();
+    LLBC_NO_DISCARD static LLBC_String ModuleFileDir();
 
     /**
      * Get current executable module file name.
      * @return LLBC_String - the module file name.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String ModuleFileName();
+    LLBC_NO_DISCARD static LLBC_String ModuleFileName();
 
     /**
      * Get current executable module file path(dir + name).
      * @return LLBC_String - the module file path.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String ModuleFilePath();
+    LLBC_NO_DISCARD static LLBC_String ModuleFilePath();
 
     /**
      * Get given path directory name.
      * @param[in] path - the path.
      * @return LLBC_String - the directory name for the path.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String DirName(const LLBC_String &path);
+    LLBC_NO_DISCARD static LLBC_String DirName(const LLBC_String &path);
 
     /**
      * Get given path base name.
      * @param[in] path - the path.
      * @return LLBC_String - the base name for the path.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String BaseName(const LLBC_String &path);
+    LLBC_NO_DISCARD static LLBC_String BaseName(const LLBC_String &path);
 
 public:
     /**
      * Get current directory.
      * @return LLBC_String - current directory.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String CurDir();
+    LLBC_NO_DISCARD static LLBC_String CurDir();
 
     /**
      * Set current directory.
      * @param[in] path - the new current directory.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int SetCurDir(const LLBC_String &path);
+    LLBC_NO_DISCARD static int SetCurDir(const LLBC_String &path);
 
     /**
      * Get document directory.
      * @return LLBC_String - document directory.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String DocDir();
+    LLBC_NO_DISCARD static LLBC_String DocDir();
 
     /**
      * Get home directory.
      * @return LLBC_String - the home directory.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String HomeDir();
+    LLBC_NO_DISCARD static LLBC_String HomeDir();
 
     /**
      * Get temporary directory.
      * @return LLBC_String - the temporary directory.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String TempDir();
+    LLBC_NO_DISCARD static LLBC_String TempDir();
 
     /**
      * Get cache directory.
      * @return LLBC_String - the cache directory.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String CacheDir();
+    LLBC_NO_DISCARD static LLBC_String CacheDir();
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/file/File.h
+++ b/llbc/include/llbc/core/file/File.h
@@ -62,7 +62,7 @@ public:
      * @param[in] fileMode - the file mode.
      * @return LLBC_String - The file mode string representation.
      */
-    static LLBC_String GetFileModeDesc(int fileMode);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String GetFileModeDesc(int fileMode);
 };
 
 /**
@@ -206,7 +206,7 @@ public:
      * @return int - the file no, if failed, return -1.
      */
     int GetFileNo() const;
-    static int GetFileNo(LLBC_FileHandle handle);
+    LLBC_WARN_UNUSED_RESULT static int GetFileNo(LLBC_FileHandle handle);
 
     /**
      * Get file object wrapped file system level file handle, unsafe.
@@ -309,7 +309,7 @@ public:
      *                       otherwise return error a special error code.
      */
     LLBC_String ReadToEnd();
-    static LLBC_String ReadToEnd(const LLBC_String &filePath);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String ReadToEnd(const LLBC_String &filePath);
 
     /**
      * File bytes read method.
@@ -386,7 +386,7 @@ public:
      * @param[in] path - the file path.
      * @return bool - return true if the file exist, otherwise return false.
      */
-    static bool Exists(const LLBC_String &path);
+    LLBC_WARN_UNUSED_RESULT static bool Exists(const LLBC_String &path);
 
     /**
      * Get file attributes.
@@ -395,7 +395,7 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int GetFileAttributes(LLBC_FileAttributes &attrs);
-    static int GetFileAttributes(const LLBC_String &path, LLBC_FileAttributes &attrs);
+    LLBC_WARN_UNUSED_RESULT static int GetFileAttributes(const LLBC_String &path, LLBC_FileAttributes &attrs);
 
     /**
      * Touch file.
@@ -409,11 +409,11 @@ public:
      * @param[in] lastModifyTime       - the last modify time, if nullptr, will update to now.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int TouchFile(const LLBC_String &filePath,
-                         bool updateLastAccessTime = true,
-                         const timespec *lastAccessTime = nullptr,
-                         bool updateLastModifyTime = true,
-                         const timespec *lastModifyTime = nullptr);
+    LLBC_WARN_UNUSED_RESULT static int TouchFile(const LLBC_String &filePath,
+                                                 bool updateLastAccessTime = true,
+                                                 const timespec *lastAccessTime = nullptr,
+                                                 bool updateLastModifyTime = true,
+                                                 const timespec *lastModifyTime = nullptr);
 
 public:
     /**
@@ -426,7 +426,7 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int CopyFile(const LLBC_String &destFilePath, bool overlapped = false);
-    static int CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destFilePath, bool overlapped = false);
+    LLBC_WARN_UNUSED_RESULT static int CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destFilePath, bool overlapped = false);
 
     /**
      * Move file.
@@ -437,7 +437,7 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int MoveFile(const LLBC_String &toFilePath, bool overlapped = false);
-    static int MoveFile(const LLBC_String &fromFilePath, const LLBC_String &toFilePath, bool overlapped = false);
+    LLBC_WARN_UNUSED_RESULT static int MoveFile(const LLBC_String &fromFilePath, const LLBC_String &toFilePath, bool overlapped = false);
 
     /**
      * Delete file.
@@ -445,14 +445,14 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int DeleteFile();
-    static int DeleteFile(const LLBC_String &filePath);
+    LLBC_WARN_UNUSED_RESULT static int DeleteFile(const LLBC_String &filePath);
 
 private:
     /**
      * Parse file mode to system file access mode.
      * @return const char * - the system file string access mode.
      */
-    static const char *ParseFileMode(int mode);
+    LLBC_WARN_UNUSED_RESULT static const char *ParseFileMode(int mode);
 
     template <typename T>
     int ReadRawObj(T &obj);

--- a/llbc/include/llbc/core/file/File.h
+++ b/llbc/include/llbc/core/file/File.h
@@ -62,7 +62,7 @@ public:
      * @param[in] fileMode - the file mode.
      * @return LLBC_String - The file mode string representation.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String GetFileModeDesc(int fileMode);
+    LLBC_NO_DISCARD static LLBC_String GetFileModeDesc(int fileMode);
 };
 
 /**
@@ -206,7 +206,7 @@ public:
      * @return int - the file no, if failed, return -1.
      */
     int GetFileNo() const;
-    LLBC_WARN_UNUSED_RESULT static int GetFileNo(LLBC_FileHandle handle);
+    LLBC_NO_DISCARD static int GetFileNo(LLBC_FileHandle handle);
 
     /**
      * Get file object wrapped file system level file handle, unsafe.
@@ -309,7 +309,7 @@ public:
      *                       otherwise return error a special error code.
      */
     LLBC_String ReadToEnd();
-    LLBC_WARN_UNUSED_RESULT static LLBC_String ReadToEnd(const LLBC_String &filePath);
+    LLBC_NO_DISCARD static LLBC_String ReadToEnd(const LLBC_String &filePath);
 
     /**
      * File bytes read method.
@@ -386,7 +386,7 @@ public:
      * @param[in] path - the file path.
      * @return bool - return true if the file exist, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static bool Exists(const LLBC_String &path);
+    LLBC_NO_DISCARD static bool Exists(const LLBC_String &path);
 
     /**
      * Get file attributes.
@@ -395,7 +395,7 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int GetFileAttributes(LLBC_FileAttributes &attrs);
-    LLBC_WARN_UNUSED_RESULT static int GetFileAttributes(const LLBC_String &path, LLBC_FileAttributes &attrs);
+    LLBC_NO_DISCARD static int GetFileAttributes(const LLBC_String &path, LLBC_FileAttributes &attrs);
 
     /**
      * Touch file.
@@ -409,11 +409,11 @@ public:
      * @param[in] lastModifyTime       - the last modify time, if nullptr, will update to now.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int TouchFile(const LLBC_String &filePath,
-                                                 bool updateLastAccessTime = true,
-                                                 const timespec *lastAccessTime = nullptr,
-                                                 bool updateLastModifyTime = true,
-                                                 const timespec *lastModifyTime = nullptr);
+    LLBC_NO_DISCARD static int TouchFile(const LLBC_String &filePath,
+                                         bool updateLastAccessTime = true,
+                                         const timespec *lastAccessTime = nullptr,
+                                         bool updateLastModifyTime = true,
+                                         const timespec *lastModifyTime = nullptr);
 
 public:
     /**
@@ -426,7 +426,7 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int CopyFile(const LLBC_String &destFilePath, bool overlapped = false);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     int CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destFilePath, bool overlapped = false);
 
     /**
@@ -438,7 +438,8 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int MoveFile(const LLBC_String &toFilePath, bool overlapped = false);
-    LLBC_WARN_UNUSED_RESULT static int MoveFile(const LLBC_String &fromFilePath, const LLBC_String &toFilePath, bool overlapped = false);
+    LLBC_NO_DISCARD static
+    int MoveFile(const LLBC_String &fromFilePath, const LLBC_String &toFilePath, bool overlapped = false);
 
     /**
      * Delete file.
@@ -446,14 +447,14 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int DeleteFile();
-    LLBC_WARN_UNUSED_RESULT static int DeleteFile(const LLBC_String &filePath);
+    LLBC_NO_DISCARD static int DeleteFile(const LLBC_String &filePath);
 
 private:
     /**
      * Parse file mode to system file access mode.
      * @return const char * - the system file string access mode.
      */
-    LLBC_WARN_UNUSED_RESULT static const char *ParseFileMode(int mode);
+    static const char *ParseFileMode(int mode);
 
     template <typename T>
     int ReadRawObj(T &obj);

--- a/llbc/include/llbc/core/file/File.h
+++ b/llbc/include/llbc/core/file/File.h
@@ -426,7 +426,8 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      */
     int CopyFile(const LLBC_String &destFilePath, bool overlapped = false);
-    LLBC_WARN_UNUSED_RESULT static int CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destFilePath, bool overlapped = false);
+    LLBC_WARN_UNUSED_RESULT static
+    int CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destFilePath, bool overlapped = false);
 
     /**
      * Move file.

--- a/llbc/include/llbc/core/helper/GUIDHelper.h
+++ b/llbc/include/llbc/core/helper/GUIDHelper.h
@@ -35,20 +35,20 @@ public:
      * Generate GUID.
      * @return LLBC_GUID - GUID value.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_GUID Gen();
+    LLBC_NO_DISCARD static LLBC_GUID Gen();
 
     /**
      * Format GUID.
      * @param[in] guid - GUID value.
      * @return LLBC_String - formatted GUID value.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Format(LLBC_GUIDCRef guid);
+    LLBC_NO_DISCARD static LLBC_String Format(LLBC_GUIDCRef guid);
 
     /**
      * Generate GUID and Format the GUID structure data to string format.
      * @return LLBC_String - the string format guid.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String GenStr();
+    LLBC_NO_DISCARD static LLBC_String GenStr();
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/helper/GUIDHelper.h
+++ b/llbc/include/llbc/core/helper/GUIDHelper.h
@@ -35,20 +35,20 @@ public:
      * Generate GUID.
      * @return LLBC_GUID - GUID value.
      */
-    static LLBC_GUID Gen();
+    LLBC_WARN_UNUSED_RESULT static LLBC_GUID Gen();
 
     /**
      * Format GUID.
      * @param[in] guid - GUID value.
      * @return LLBC_String - formatted GUID value.
      */
-    static LLBC_String Format(LLBC_GUIDCRef guid);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Format(LLBC_GUIDCRef guid);
 
     /**
      * Generate GUID and Format the GUID structure data to string format.
      * @return LLBC_String - the string format guid.
      */
-    static LLBC_String GenStr();
+    LLBC_WARN_UNUSED_RESULT static LLBC_String GenStr();
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/log/BaseLogAppender.h
+++ b/llbc/include/llbc/core/log/BaseLogAppender.h
@@ -59,7 +59,7 @@ public:
      * Check givin appender type is valid or not.
      * @return bool - reutrn true if valid, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     constexpr bool IsValid(int appenderType) { return appenderType >= Begin && appenderType < End; }
 };
 

--- a/llbc/include/llbc/core/log/BaseLogAppender.h
+++ b/llbc/include/llbc/core/log/BaseLogAppender.h
@@ -59,7 +59,7 @@ public:
      * Check givin appender type is valid or not.
      * @return bool - reutrn true if valid, otherwise return false.
      */
-    static constexpr bool IsValid(int appenderType) { return appenderType >= Begin && appenderType < End; }
+    LLBC_WARN_UNUSED_RESULT static constexpr bool IsValid(int appenderType) { return appenderType >= Begin && appenderType < End; }
 };
 
 /**

--- a/llbc/include/llbc/core/log/BaseLogAppender.h
+++ b/llbc/include/llbc/core/log/BaseLogAppender.h
@@ -59,7 +59,8 @@ public:
      * Check givin appender type is valid or not.
      * @return bool - reutrn true if valid, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static constexpr bool IsValid(int appenderType) { return appenderType >= Begin && appenderType < End; }
+    LLBC_WARN_UNUSED_RESULT static
+    constexpr bool IsValid(int appenderType) { return appenderType >= Begin && appenderType < End; }
 };
 
 /**

--- a/llbc/include/llbc/core/log/LogLevel.h
+++ b/llbc/include/llbc/core/log/LogLevel.h
@@ -55,7 +55,7 @@ public:
      * @param[in] shortLevelStr - return short level string, default is false.
      * @return const LLBC_String & - level representation.
      */
-    LLBC_WARN_UNUSED_RESULT static const LLBC_CString &GetLevelStr(int level, bool shortLevelStr = false);
+    LLBC_NO_DISCARD static const LLBC_CString &GetLevelStr(int level, bool shortLevelStr = false);
 
 public:
     /**
@@ -63,14 +63,14 @@ public:
      * @param[in] levelStr - log level representation.
      * @return int - log level enum.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetLevelEnum(const LLBC_CString &levelStr);
+    LLBC_NO_DISCARD static int GetLevelEnum(const LLBC_CString &levelStr);
 
     /**
      * Check giving log level is validate or not.
      * @param[in] level - the given log level.
      * @return bool - return if log level is validate, otherwise return false.
      */
-    LLBC_WARN_UNUSED_RESULT static bool IsValid(int level);
+    LLBC_NO_DISCARD static bool IsValid(int level);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogLevel.h
+++ b/llbc/include/llbc/core/log/LogLevel.h
@@ -55,7 +55,7 @@ public:
      * @param[in] shortLevelStr - return short level string, default is false.
      * @return const LLBC_String & - level representation.
      */
-    static const LLBC_CString &GetLevelStr(int level, bool shortLevelStr = false);
+    LLBC_WARN_UNUSED_RESULT static const LLBC_CString &GetLevelStr(int level, bool shortLevelStr = false);
 
 public:
     /**
@@ -63,14 +63,14 @@ public:
      * @param[in] levelStr - log level representation.
      * @return int - log level enum.
      */
-    static int GetLevelEnum(const LLBC_CString &levelStr);
+    LLBC_WARN_UNUSED_RESULT static int GetLevelEnum(const LLBC_CString &levelStr);
 
     /**
      * Check giving log level is validate or not.
      * @param[in] level - the given log level.
      * @return bool - return if log level is validate, otherwise return false.
      */
-    static bool IsValid(int level);
+    LLBC_WARN_UNUSED_RESULT static bool IsValid(int level);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogRollingMode.h
+++ b/llbc/include/llbc/core/log/LogRollingMode.h
@@ -47,20 +47,20 @@ public:
      * @param[in] mode - the rolling mode.
      * @return const LLBC_CString & - the rolling mode string representation.
      */
-    LLBC_WARN_UNUSED_RESULT static const LLBC_CString &GetModeStr(int mode);
+    LLBC_NO_DISCARD static const LLBC_CString &GetModeStr(int mode);
 
     /**
      * Get rolling mode by rolling mode string.
      * @param[in] modeStr - the rolling mode string.
      * @return int - the rolling mode.
      */
-    LLBC_WARN_UNUSED_RESULT static int Str2Mode(const LLBC_CString &modeStr);
+    LLBC_NO_DISCARD static int Str2Mode(const LLBC_CString &modeStr);
 
     /**
      * Check given rolling mode is validate or not.
      * @param[in] mode - the rolling mode.
      */
-    LLBC_WARN_UNUSED_RESULT static bool IsValid(int mode);
+    LLBC_NO_DISCARD static bool IsValid(int mode);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogRollingMode.h
+++ b/llbc/include/llbc/core/log/LogRollingMode.h
@@ -47,20 +47,20 @@ public:
      * @param[in] mode - the rolling mode.
      * @return const LLBC_CString & - the rolling mode string representation.
      */
-    static const LLBC_CString &GetModeStr(int mode);
+    LLBC_WARN_UNUSED_RESULT static const LLBC_CString &GetModeStr(int mode);
 
     /**
      * Get rolling mode by rolling mode string.
      * @param[in] modeStr - the rolling mode string.
      * @return int - the rolling mode.
      */
-    static int Str2Mode(const LLBC_CString &modeStr);
+    LLBC_WARN_UNUSED_RESULT static int Str2Mode(const LLBC_CString &modeStr);
 
     /**
      * Check given rolling mode is validate or not.
      * @param[in] mode - the rolling mode.
      */
-    static bool IsValid(int mode);
+    LLBC_WARN_UNUSED_RESULT static bool IsValid(int mode);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/objbase/AutoReleasePoolStack.h
+++ b/llbc/include/llbc/core/objbase/AutoReleasePoolStack.h
@@ -90,7 +90,7 @@ public:
      * Get current thread release pool stack.
      * @return _This * - the current thread release pool stack.
      */
-    LLBC_WARN_UNUSED_RESULT static _This *GetCurrentThreadReleasePoolStack();
+    LLBC_NO_DISCARD static _This *GetCurrentThreadReleasePoolStack();
 
 private:
     LLBC_AutoReleasePool *_head;

--- a/llbc/include/llbc/core/objbase/AutoReleasePoolStack.h
+++ b/llbc/include/llbc/core/objbase/AutoReleasePoolStack.h
@@ -90,7 +90,7 @@ public:
      * Get current thread release pool stack.
      * @return _This * - the current thread release pool stack.
      */
-    static _This *GetCurrentThreadReleasePoolStack();
+    LLBC_WARN_UNUSED_RESULT static _This *GetCurrentThreadReleasePoolStack();
 
 private:
     LLBC_AutoReleasePool *_head;

--- a/llbc/include/llbc/core/objpool/ObjPool.h
+++ b/llbc/include/llbc/core/objpool/ObjPool.h
@@ -378,7 +378,7 @@ private:
 public:
     // GetStripeCapacity.
     template <typename Obj>
-    static size_t GetStripeCapacity()
+    LLBC_WARN_UNUSED_RESULT static size_t GetStripeCapacity()
     {
         return GetStripeCapacityInl<Obj>(0);
     }
@@ -388,14 +388,14 @@ private:
     struct stripe_capacity_detectable_type;
 
     template <typename Obj>
-    static size_t GetStripeCapacityInl(
+    LLBC_WARN_UNUSED_RESULT static size_t GetStripeCapacityInl(
         stripe_capacity_detectable_type<Obj, &Obj::GetStripeCapacity> *)
     {
         return reinterpret_cast<Obj *>(NULL)->GetStripeCapacity();
     }
 
     template <typename Obj>
-    static constexpr size_t GetStripeCapacityInl(...)
+    LLBC_WARN_UNUSED_RESULT static constexpr size_t GetStripeCapacityInl(...)
     {
         return LLBC_CFG_CORE_OBJPOOL_STRIPE_CAPACITY;
     }
@@ -673,8 +673,8 @@ private:
     static void Collect_s(void *typedObjPool, bool deep);
 
     // Get typed object pool statistics static method.
-    static LLBC_Json::Value GetStatistics_s(void *typedObjPool,
-                                            LLBC_Json::MemoryPoolAllocator<> &jsonAlloc);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Json::Value GetStatistics_s(void *typedObjPool,
+                                                                    LLBC_Json::MemoryPoolAllocator<> &jsonAlloc);
 
     // Find free stripe.
     _ObjStripe *FindFreeStripe();

--- a/llbc/include/llbc/core/objpool/ObjPool.h
+++ b/llbc/include/llbc/core/objpool/ObjPool.h
@@ -388,8 +388,8 @@ private:
     struct stripe_capacity_detectable_type;
 
     template <typename Obj>
-    LLBC_WARN_UNUSED_RESULT static size_t GetStripeCapacityInl(
-        stripe_capacity_detectable_type<Obj, &Obj::GetStripeCapacity> *)
+    LLBC_WARN_UNUSED_RESULT static
+    size_t GetStripeCapacityInl(stripe_capacity_detectable_type<Obj, &Obj::GetStripeCapacity> *)
     {
         return reinterpret_cast<Obj *>(NULL)->GetStripeCapacity();
     }
@@ -673,8 +673,8 @@ private:
     static void Collect_s(void *typedObjPool, bool deep);
 
     // Get typed object pool statistics static method.
-    LLBC_WARN_UNUSED_RESULT static LLBC_Json::Value GetStatistics_s(void *typedObjPool,
-                                                                    LLBC_Json::MemoryPoolAllocator<> &jsonAlloc);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_Json::Value GetStatistics_s(void *typedObjPool, LLBC_Json::MemoryPoolAllocator<> &jsonAlloc);
 
     // Find free stripe.
     _ObjStripe *FindFreeStripe();

--- a/llbc/include/llbc/core/objpool/ObjPool.h
+++ b/llbc/include/llbc/core/objpool/ObjPool.h
@@ -378,7 +378,7 @@ private:
 public:
     // GetStripeCapacity.
     template <typename Obj>
-    LLBC_WARN_UNUSED_RESULT static size_t GetStripeCapacity()
+    LLBC_NO_DISCARD static size_t GetStripeCapacity()
     {
         return GetStripeCapacityInl<Obj>(0);
     }
@@ -388,14 +388,13 @@ private:
     struct stripe_capacity_detectable_type;
 
     template <typename Obj>
-    LLBC_WARN_UNUSED_RESULT static
-    size_t GetStripeCapacityInl(stripe_capacity_detectable_type<Obj, &Obj::GetStripeCapacity> *)
+    static size_t GetStripeCapacityInl(stripe_capacity_detectable_type<Obj, &Obj::GetStripeCapacity> *)
     {
         return reinterpret_cast<Obj *>(NULL)->GetStripeCapacity();
     }
 
     template <typename Obj>
-    LLBC_WARN_UNUSED_RESULT static constexpr size_t GetStripeCapacityInl(...)
+    static constexpr size_t GetStripeCapacityInl(...)
     {
         return LLBC_CFG_CORE_OBJPOOL_STRIPE_CAPACITY;
     }
@@ -412,8 +411,8 @@ private:
     struct typed_obj_pool_created_ev_handler;
 
     template <typename Obj>
-    static void OnTypedObjPoolCreatedInl(
-        LLBC_TypedObjPool<Obj> *typedObjPool, typed_obj_pool_created_ev_handler<Obj, &Obj::OnTypedObjPoolCreated> *)
+    static void OnTypedObjPoolCreatedInl(LLBC_TypedObjPool<Obj> *typedObjPool,
+                                         typed_obj_pool_created_ev_handler<Obj, &Obj::OnTypedObjPoolCreated> *)
     {
         return reinterpret_cast<Obj *>(NULL)->OnTypedObjPoolCreated(typedObjPool);
     }
@@ -673,8 +672,7 @@ private:
     static void Collect_s(void *typedObjPool, bool deep);
 
     // Get typed object pool statistics static method.
-    LLBC_WARN_UNUSED_RESULT static
-    LLBC_Json::Value GetStatistics_s(void *typedObjPool, LLBC_Json::MemoryPoolAllocator<> &jsonAlloc);
+    static LLBC_Json::Value GetStatistics_s(void *typedObjPool, LLBC_Json::MemoryPoolAllocator<> &jsonAlloc);
 
     // Find free stripe.
     _ObjStripe *FindFreeStripe();

--- a/llbc/include/llbc/core/objpool/ThreadSpecObjPool.h
+++ b/llbc/include/llbc/core/objpool/ThreadSpecObjPool.h
@@ -95,13 +95,15 @@ public:
      * @return LLBC_GuardedPoolObj<T> - the guarded object.
      */
     template<typename T>
-    LLBC_WARN_UNUSED_RESULT static LLBC_GuardedPoolObj<T> GuardedSafeAcquire() { return GetSafeObjPool()->AcquireGuarded<T>(); }
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_GuardedPoolObj<T> GuardedSafeAcquire() { return GetSafeObjPool()->AcquireGuarded<T>(); }
 
     /**
      * Acquire guarded object in thread-unsafe object pool.
      * @return LLBC_GuardedPoolObj<T> - the guarded object.
      */
     template<typename T>
-    LLBC_WARN_UNUSED_RESULT static LLBC_GuardedPoolObj<T> GuardedUnsafeAcquire() { return GetUnsafeObjPool()->AcquireGuarded<T>(); }
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_GuardedPoolObj<T> GuardedUnsafeAcquire() { return GetUnsafeObjPool()->AcquireGuarded<T>(); }
 };
 __LLBC_NS_END

--- a/llbc/include/llbc/core/objpool/ThreadSpecObjPool.h
+++ b/llbc/include/llbc/core/objpool/ThreadSpecObjPool.h
@@ -32,7 +32,7 @@ public:
      * Initialize thread-spec object pool.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int Initialize();
+    LLBC_WARN_UNUSED_RESULT static int Initialize();
 
     /**
      * Finalize thread-spec object pool.
@@ -44,7 +44,7 @@ public:
      * Get current thread thread-safe object pool.
      * @return LLBC_ObjPool * - the current thread thread-safe object pool.
      */
-    static LLBC_ObjPool *GetSafeObjPool()
+    LLBC_WARN_UNUSED_RESULT static LLBC_ObjPool *GetSafeObjPool()
     {
         return reinterpret_cast<LLBC_ObjPool *>(__LLBC_GetLibTls()->coreTls.safeObjPool);
     }
@@ -53,7 +53,7 @@ public:
      * Get current thread thread-unsafe object pool.
      * @return LLBC_ObjPool * - the current thread thread-unsafe object pool.
      */
-    static LLBC_ObjPool *GetUnsafeObjPool()
+    LLBC_WARN_UNUSED_RESULT static LLBC_ObjPool *GetUnsafeObjPool()
     {
         return reinterpret_cast<LLBC_ObjPool *>(__LLBC_GetLibTls()->coreTls.unsafeObjPool);
     }
@@ -64,7 +64,7 @@ public:
      * @return Obj * - the object.
      */
     template <typename Obj>
-    static Obj *SafeAcquire() { return GetSafeObjPool()->Acquire<Obj>(); }
+    LLBC_WARN_UNUSED_RESULT static Obj *SafeAcquire() { return GetSafeObjPool()->Acquire<Obj>(); }
 
     /**
      * Acquire object in thread-unsafe object pool.
@@ -72,7 +72,7 @@ public:
      * @return Obj * - the object.
      */
     template <typename Obj>
-    static Obj *UnsafeAcquire() { return GetUnsafeObjPool()->Acquire<Obj>(); }
+    LLBC_WARN_UNUSED_RESULT static Obj *UnsafeAcquire() { return GetUnsafeObjPool()->Acquire<Obj>(); }
 
     /**
      * Release object to thread-unsafe object pool.
@@ -95,13 +95,13 @@ public:
      * @return LLBC_GuardedPoolObj<T> - the guarded object.
      */
     template<typename T>
-    static LLBC_GuardedPoolObj<T> GuardedSafeAcquire() { return GetSafeObjPool()->AcquireGuarded<T>(); }
+    LLBC_WARN_UNUSED_RESULT static LLBC_GuardedPoolObj<T> GuardedSafeAcquire() { return GetSafeObjPool()->AcquireGuarded<T>(); }
 
     /**
      * Acquire guarded object in thread-unsafe object pool.
      * @return LLBC_GuardedPoolObj<T> - the guarded object.
      */
     template<typename T>
-    static LLBC_GuardedPoolObj<T> GuardedUnsafeAcquire() { return GetUnsafeObjPool()->AcquireGuarded<T>(); }
+    LLBC_WARN_UNUSED_RESULT static LLBC_GuardedPoolObj<T> GuardedUnsafeAcquire() { return GetUnsafeObjPool()->AcquireGuarded<T>(); }
 };
 __LLBC_NS_END

--- a/llbc/include/llbc/core/objpool/ThreadSpecObjPool.h
+++ b/llbc/include/llbc/core/objpool/ThreadSpecObjPool.h
@@ -32,7 +32,7 @@ public:
      * Initialize thread-spec object pool.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int Initialize();
+    LLBC_NO_DISCARD static int Initialize();
 
     /**
      * Finalize thread-spec object pool.
@@ -44,7 +44,7 @@ public:
      * Get current thread thread-safe object pool.
      * @return LLBC_ObjPool * - the current thread thread-safe object pool.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_ObjPool *GetSafeObjPool()
+    LLBC_NO_DISCARD static LLBC_ObjPool *GetSafeObjPool()
     {
         return reinterpret_cast<LLBC_ObjPool *>(__LLBC_GetLibTls()->coreTls.safeObjPool);
     }
@@ -53,7 +53,7 @@ public:
      * Get current thread thread-unsafe object pool.
      * @return LLBC_ObjPool * - the current thread thread-unsafe object pool.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_ObjPool *GetUnsafeObjPool()
+    LLBC_NO_DISCARD static LLBC_ObjPool *GetUnsafeObjPool()
     {
         return reinterpret_cast<LLBC_ObjPool *>(__LLBC_GetLibTls()->coreTls.unsafeObjPool);
     }
@@ -64,7 +64,7 @@ public:
      * @return Obj * - the object.
      */
     template <typename Obj>
-    LLBC_WARN_UNUSED_RESULT static Obj *SafeAcquire() { return GetSafeObjPool()->Acquire<Obj>(); }
+    LLBC_NO_DISCARD static Obj *SafeAcquire() { return GetSafeObjPool()->Acquire<Obj>(); }
 
     /**
      * Acquire object in thread-unsafe object pool.
@@ -72,7 +72,7 @@ public:
      * @return Obj * - the object.
      */
     template <typename Obj>
-    LLBC_WARN_UNUSED_RESULT static Obj *UnsafeAcquire() { return GetUnsafeObjPool()->Acquire<Obj>(); }
+    LLBC_NO_DISCARD static Obj *UnsafeAcquire() { return GetUnsafeObjPool()->Acquire<Obj>(); }
 
     /**
      * Release object to thread-unsafe object pool.
@@ -95,7 +95,7 @@ public:
      * @return LLBC_GuardedPoolObj<T> - the guarded object.
      */
     template<typename T>
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_GuardedPoolObj<T> GuardedSafeAcquire() { return GetSafeObjPool()->AcquireGuarded<T>(); }
 
     /**
@@ -103,7 +103,7 @@ public:
      * @return LLBC_GuardedPoolObj<T> - the guarded object.
      */
     template<typename T>
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_GuardedPoolObj<T> GuardedUnsafeAcquire() { return GetUnsafeObjPool()->AcquireGuarded<T>(); }
 };
 __LLBC_NS_END

--- a/llbc/include/llbc/core/os/OS_Thread.h
+++ b/llbc/include/llbc/core/os/OS_Thread.h
@@ -69,7 +69,7 @@ public:
      * @param[in] threadPriority - the thread priority.
      * @return bool - the valid flag.
      */
-    LLBC_WARN_UNUSED_RESULT static bool IsValid(int threadPriority);
+    LLBC_NO_DISCARD static bool IsValid(int threadPriority);
 };
 
 /**

--- a/llbc/include/llbc/core/os/OS_Thread.h
+++ b/llbc/include/llbc/core/os/OS_Thread.h
@@ -69,7 +69,7 @@ public:
      * @param[in] threadPriority - the thread priority.
      * @return bool - the valid flag.
      */
-    static bool IsValid(int threadPriority);
+    LLBC_WARN_UNUSED_RESULT static bool IsValid(int threadPriority);
 };
 
 /**

--- a/llbc/include/llbc/core/rapidjson/document.h
+++ b/llbc/include/llbc/core/rapidjson/document.h
@@ -431,129 +431,184 @@ struct TypeHelper {};
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, bool> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsBool(); }
-    LLBC_WARN_UNUSED_RESULT static bool Get(const ValueType& v) { return v.GetBool(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, bool data) { return v.SetBool(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, bool data, typename ValueType::AllocatorType&) { return v.SetBool(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsBool(); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Get(const ValueType& v) { return v.GetBool(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, bool data) { return v.SetBool(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, bool data, typename ValueType::AllocatorType&) { return v.SetBool(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, int> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsInt(); }
-    LLBC_WARN_UNUSED_RESULT static int Get(const ValueType& v) { return v.GetInt(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int data) { return v.SetInt(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsInt(); }
+    LLBC_WARN_UNUSED_RESULT static
+    int Get(const ValueType& v) { return v.GetInt(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, int data) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, int data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, unsigned> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsUint(); }
-    LLBC_WARN_UNUSED_RESULT static unsigned Get(const ValueType& v) { return v.GetUint(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned data) { return v.SetUint(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsUint(); }
+    LLBC_WARN_UNUSED_RESULT static
+    unsigned Get(const ValueType& v) { return v.GetUint(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, unsigned data) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, unsigned data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 
 #ifdef _MSC_VER
 LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(long) == sizeof(int));
 template<typename ValueType>
 struct TypeHelper<ValueType, long> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsInt(); }
-    LLBC_WARN_UNUSED_RESULT static long Get(const ValueType& v) { return v.GetInt(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, long data) { return v.SetInt(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, long data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsInt(); }
+    LLBC_WARN_UNUSED_RESULT static
+    long Get(const ValueType& v) { return v.GetInt(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, long data) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, long data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
 };
 
 LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(unsigned long) == sizeof(unsigned));
 template<typename ValueType>
 struct TypeHelper<ValueType, unsigned long> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsUint(); }
-    LLBC_WARN_UNUSED_RESULT static unsigned long Get(const ValueType& v) { return v.GetUint(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned long data) { return v.SetUint(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned long data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsUint(); }
+    LLBC_WARN_UNUSED_RESULT static
+    unsigned long Get(const ValueType& v) { return v.GetUint(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, unsigned long data) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, unsigned long data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 #endif
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, int64_t> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsInt64(); }
-    LLBC_WARN_UNUSED_RESULT static int64_t Get(const ValueType& v) { return v.GetInt64(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int64_t data) { return v.SetInt64(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int64_t data, typename ValueType::AllocatorType&) { return v.SetInt64(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsInt64(); }
+    LLBC_WARN_UNUSED_RESULT static
+    int64_t Get(const ValueType& v) { return v.GetInt64(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, int64_t data) { return v.SetInt64(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, int64_t data, typename ValueType::AllocatorType&) { return v.SetInt64(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, uint64_t> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsUint64(); }
-    LLBC_WARN_UNUSED_RESULT static uint64_t Get(const ValueType& v) { return v.GetUint64(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, uint64_t data) { return v.SetUint64(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, uint64_t data, typename ValueType::AllocatorType&) { return v.SetUint64(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsUint64(); }
+    LLBC_WARN_UNUSED_RESULT static
+    uint64_t Get(const ValueType& v) { return v.GetUint64(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, uint64_t data) { return v.SetUint64(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, uint64_t data, typename ValueType::AllocatorType&) { return v.SetUint64(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, double> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsDouble(); }
-    LLBC_WARN_UNUSED_RESULT static double Get(const ValueType& v) { return v.GetDouble(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, double data) { return v.SetDouble(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, double data, typename ValueType::AllocatorType&) { return v.SetDouble(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsDouble(); }
+    LLBC_WARN_UNUSED_RESULT static
+    double Get(const ValueType& v) { return v.GetDouble(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, double data) { return v.SetDouble(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, double data, typename ValueType::AllocatorType&) { return v.SetDouble(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, float> {
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsFloat(); }
-    LLBC_WARN_UNUSED_RESULT static float Get(const ValueType& v) { return v.GetFloat(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, float data) { return v.SetFloat(data); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, float data, typename ValueType::AllocatorType&) { return v.SetFloat(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsFloat(); }
+    LLBC_WARN_UNUSED_RESULT static
+    float Get(const ValueType& v) { return v.GetFloat(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, float data) { return v.SetFloat(data); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, float data, typename ValueType::AllocatorType&) { return v.SetFloat(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, const typename ValueType::Ch*> {
     typedef const typename ValueType::Ch* StringType;
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsString(); }
-    LLBC_WARN_UNUSED_RESULT static StringType Get(const ValueType& v) { return v.GetString(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, const StringType data) { return v.SetString(typename ValueType::StringRefType(data)); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, const StringType data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsString(); }
+    LLBC_WARN_UNUSED_RESULT static
+    StringType Get(const ValueType& v) { return v.GetString(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, const StringType data) { return v.SetString(typename ValueType::StringRefType(data)); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, const StringType data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
 };
 
 #if LLBC_RAPIDJSON_HAS_STDSTRING
 template<typename ValueType> 
 struct TypeHelper<ValueType, std::basic_string<typename ValueType::Ch> > {
     typedef std::basic_string<typename ValueType::Ch> StringType;
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsString(); }
-    LLBC_WARN_UNUSED_RESULT static StringType Get(const ValueType& v) { return StringType(v.GetString(), v.GetStringLength()); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, const StringType& data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsString(); }
+    LLBC_WARN_UNUSED_RESULT static
+    StringType Get(const ValueType& v) { return StringType(v.GetString(), v.GetStringLength()); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, const StringType& data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
 };
 #endif
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::Array> {
     typedef typename ValueType::Array ArrayType;
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsArray(); }
-    LLBC_WARN_UNUSED_RESULT static ArrayType Get(ValueType& v) { return v.GetArray(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ArrayType data) { return v = data; }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ArrayType data, typename ValueType::AllocatorType&) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsArray(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ArrayType Get(ValueType& v) { return v.GetArray(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, ArrayType data) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, ArrayType data, typename ValueType::AllocatorType&) { return v = data; }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::ConstArray> {
     typedef typename ValueType::ConstArray ArrayType;
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsArray(); }
-    LLBC_WARN_UNUSED_RESULT static ArrayType Get(const ValueType& v) { return v.GetArray(); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsArray(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ArrayType Get(const ValueType& v) { return v.GetArray(); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::Object> {
     typedef typename ValueType::Object ObjectType;
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsObject(); }
-    LLBC_WARN_UNUSED_RESULT static ObjectType Get(ValueType& v) { return v.GetObject(); }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ObjectType data) { return v = data; }
-    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ObjectType data, typename ValueType::AllocatorType&) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsObject(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ObjectType Get(ValueType& v) { return v.GetObject(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, ObjectType data) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static
+    ValueType& Set(ValueType& v, ObjectType data, typename ValueType::AllocatorType&) { return v = data; }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::ConstObject> {
     typedef typename ValueType::ConstObject ObjectType;
-    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsObject(); }
-    LLBC_WARN_UNUSED_RESULT static ObjectType Get(const ValueType& v) { return v.GetObject(); }
+    LLBC_WARN_UNUSED_RESULT static
+    bool Is(const ValueType& v) { return v.IsObject(); }
+    LLBC_WARN_UNUSED_RESULT static
+    ObjectType Get(const ValueType& v) { return v.GetObject(); }
 };
 
 } // namespace internal

--- a/llbc/include/llbc/core/rapidjson/document.h
+++ b/llbc/include/llbc/core/rapidjson/document.h
@@ -431,129 +431,129 @@ struct TypeHelper {};
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, bool> {
-    static bool Is(const ValueType& v) { return v.IsBool(); }
-    static bool Get(const ValueType& v) { return v.GetBool(); }
-    static ValueType& Set(ValueType& v, bool data) { return v.SetBool(data); }
-    static ValueType& Set(ValueType& v, bool data, typename ValueType::AllocatorType&) { return v.SetBool(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsBool(); }
+    LLBC_WARN_UNUSED_RESULT static bool Get(const ValueType& v) { return v.GetBool(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, bool data) { return v.SetBool(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, bool data, typename ValueType::AllocatorType&) { return v.SetBool(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, int> {
-    static bool Is(const ValueType& v) { return v.IsInt(); }
-    static int Get(const ValueType& v) { return v.GetInt(); }
-    static ValueType& Set(ValueType& v, int data) { return v.SetInt(data); }
-    static ValueType& Set(ValueType& v, int data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsInt(); }
+    LLBC_WARN_UNUSED_RESULT static int Get(const ValueType& v) { return v.GetInt(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int data) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, unsigned> {
-    static bool Is(const ValueType& v) { return v.IsUint(); }
-    static unsigned Get(const ValueType& v) { return v.GetUint(); }
-    static ValueType& Set(ValueType& v, unsigned data) { return v.SetUint(data); }
-    static ValueType& Set(ValueType& v, unsigned data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsUint(); }
+    LLBC_WARN_UNUSED_RESULT static unsigned Get(const ValueType& v) { return v.GetUint(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned data) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 
 #ifdef _MSC_VER
 LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(long) == sizeof(int));
 template<typename ValueType>
 struct TypeHelper<ValueType, long> {
-    static bool Is(const ValueType& v) { return v.IsInt(); }
-    static long Get(const ValueType& v) { return v.GetInt(); }
-    static ValueType& Set(ValueType& v, long data) { return v.SetInt(data); }
-    static ValueType& Set(ValueType& v, long data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsInt(); }
+    LLBC_WARN_UNUSED_RESULT static long Get(const ValueType& v) { return v.GetInt(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, long data) { return v.SetInt(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, long data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
 };
 
 LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(unsigned long) == sizeof(unsigned));
 template<typename ValueType>
 struct TypeHelper<ValueType, unsigned long> {
-    static bool Is(const ValueType& v) { return v.IsUint(); }
-    static unsigned long Get(const ValueType& v) { return v.GetUint(); }
-    static ValueType& Set(ValueType& v, unsigned long data) { return v.SetUint(data); }
-    static ValueType& Set(ValueType& v, unsigned long data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsUint(); }
+    LLBC_WARN_UNUSED_RESULT static unsigned long Get(const ValueType& v) { return v.GetUint(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned long data) { return v.SetUint(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, unsigned long data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 #endif
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, int64_t> {
-    static bool Is(const ValueType& v) { return v.IsInt64(); }
-    static int64_t Get(const ValueType& v) { return v.GetInt64(); }
-    static ValueType& Set(ValueType& v, int64_t data) { return v.SetInt64(data); }
-    static ValueType& Set(ValueType& v, int64_t data, typename ValueType::AllocatorType&) { return v.SetInt64(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsInt64(); }
+    LLBC_WARN_UNUSED_RESULT static int64_t Get(const ValueType& v) { return v.GetInt64(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int64_t data) { return v.SetInt64(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, int64_t data, typename ValueType::AllocatorType&) { return v.SetInt64(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, uint64_t> {
-    static bool Is(const ValueType& v) { return v.IsUint64(); }
-    static uint64_t Get(const ValueType& v) { return v.GetUint64(); }
-    static ValueType& Set(ValueType& v, uint64_t data) { return v.SetUint64(data); }
-    static ValueType& Set(ValueType& v, uint64_t data, typename ValueType::AllocatorType&) { return v.SetUint64(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsUint64(); }
+    LLBC_WARN_UNUSED_RESULT static uint64_t Get(const ValueType& v) { return v.GetUint64(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, uint64_t data) { return v.SetUint64(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, uint64_t data, typename ValueType::AllocatorType&) { return v.SetUint64(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, double> {
-    static bool Is(const ValueType& v) { return v.IsDouble(); }
-    static double Get(const ValueType& v) { return v.GetDouble(); }
-    static ValueType& Set(ValueType& v, double data) { return v.SetDouble(data); }
-    static ValueType& Set(ValueType& v, double data, typename ValueType::AllocatorType&) { return v.SetDouble(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsDouble(); }
+    LLBC_WARN_UNUSED_RESULT static double Get(const ValueType& v) { return v.GetDouble(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, double data) { return v.SetDouble(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, double data, typename ValueType::AllocatorType&) { return v.SetDouble(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, float> {
-    static bool Is(const ValueType& v) { return v.IsFloat(); }
-    static float Get(const ValueType& v) { return v.GetFloat(); }
-    static ValueType& Set(ValueType& v, float data) { return v.SetFloat(data); }
-    static ValueType& Set(ValueType& v, float data, typename ValueType::AllocatorType&) { return v.SetFloat(data); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsFloat(); }
+    LLBC_WARN_UNUSED_RESULT static float Get(const ValueType& v) { return v.GetFloat(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, float data) { return v.SetFloat(data); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, float data, typename ValueType::AllocatorType&) { return v.SetFloat(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, const typename ValueType::Ch*> {
     typedef const typename ValueType::Ch* StringType;
-    static bool Is(const ValueType& v) { return v.IsString(); }
-    static StringType Get(const ValueType& v) { return v.GetString(); }
-    static ValueType& Set(ValueType& v, const StringType data) { return v.SetString(typename ValueType::StringRefType(data)); }
-    static ValueType& Set(ValueType& v, const StringType data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsString(); }
+    LLBC_WARN_UNUSED_RESULT static StringType Get(const ValueType& v) { return v.GetString(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, const StringType data) { return v.SetString(typename ValueType::StringRefType(data)); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, const StringType data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
 };
 
 #if LLBC_RAPIDJSON_HAS_STDSTRING
 template<typename ValueType> 
 struct TypeHelper<ValueType, std::basic_string<typename ValueType::Ch> > {
     typedef std::basic_string<typename ValueType::Ch> StringType;
-    static bool Is(const ValueType& v) { return v.IsString(); }
-    static StringType Get(const ValueType& v) { return StringType(v.GetString(), v.GetStringLength()); }
-    static ValueType& Set(ValueType& v, const StringType& data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsString(); }
+    LLBC_WARN_UNUSED_RESULT static StringType Get(const ValueType& v) { return StringType(v.GetString(), v.GetStringLength()); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, const StringType& data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
 };
 #endif
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::Array> {
     typedef typename ValueType::Array ArrayType;
-    static bool Is(const ValueType& v) { return v.IsArray(); }
-    static ArrayType Get(ValueType& v) { return v.GetArray(); }
-    static ValueType& Set(ValueType& v, ArrayType data) { return v = data; }
-    static ValueType& Set(ValueType& v, ArrayType data, typename ValueType::AllocatorType&) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsArray(); }
+    LLBC_WARN_UNUSED_RESULT static ArrayType Get(ValueType& v) { return v.GetArray(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ArrayType data) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ArrayType data, typename ValueType::AllocatorType&) { return v = data; }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::ConstArray> {
     typedef typename ValueType::ConstArray ArrayType;
-    static bool Is(const ValueType& v) { return v.IsArray(); }
-    static ArrayType Get(const ValueType& v) { return v.GetArray(); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsArray(); }
+    LLBC_WARN_UNUSED_RESULT static ArrayType Get(const ValueType& v) { return v.GetArray(); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::Object> {
     typedef typename ValueType::Object ObjectType;
-    static bool Is(const ValueType& v) { return v.IsObject(); }
-    static ObjectType Get(ValueType& v) { return v.GetObject(); }
-    static ValueType& Set(ValueType& v, ObjectType data) { return v = data; }
-    static ValueType& Set(ValueType& v, ObjectType data, typename ValueType::AllocatorType&) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsObject(); }
+    LLBC_WARN_UNUSED_RESULT static ObjectType Get(ValueType& v) { return v.GetObject(); }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ObjectType data) { return v = data; }
+    LLBC_WARN_UNUSED_RESULT static ValueType& Set(ValueType& v, ObjectType data, typename ValueType::AllocatorType&) { return v = data; }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::ConstObject> {
     typedef typename ValueType::ConstObject ObjectType;
-    static bool Is(const ValueType& v) { return v.IsObject(); }
-    static ObjectType Get(const ValueType& v) { return v.GetObject(); }
+    LLBC_WARN_UNUSED_RESULT static bool Is(const ValueType& v) { return v.IsObject(); }
+    LLBC_WARN_UNUSED_RESULT static ObjectType Get(const ValueType& v) { return v.GetObject(); }
 };
 
 } // namespace internal

--- a/llbc/include/llbc/core/rapidjson/document.h
+++ b/llbc/include/llbc/core/rapidjson/document.h
@@ -431,37 +431,37 @@ struct TypeHelper {};
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, bool> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsBool(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Get(const ValueType& v) { return v.GetBool(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, bool data) { return v.SetBool(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, bool data, typename ValueType::AllocatorType&) { return v.SetBool(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, int> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsInt(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     int Get(const ValueType& v) { return v.GetInt(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, int data) { return v.SetInt(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, int data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, unsigned> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsUint(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     unsigned Get(const ValueType& v) { return v.GetUint(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, unsigned data) { return v.SetUint(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, unsigned data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 
@@ -469,88 +469,88 @@ struct TypeHelper<ValueType, unsigned> {
 LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(long) == sizeof(int));
 template<typename ValueType>
 struct TypeHelper<ValueType, long> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsInt(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     long Get(const ValueType& v) { return v.GetInt(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, long data) { return v.SetInt(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, long data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
 };
 
 LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(unsigned long) == sizeof(unsigned));
 template<typename ValueType>
 struct TypeHelper<ValueType, unsigned long> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsUint(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     unsigned long Get(const ValueType& v) { return v.GetUint(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, unsigned long data) { return v.SetUint(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, unsigned long data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 #endif
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, int64_t> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsInt64(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     int64_t Get(const ValueType& v) { return v.GetInt64(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, int64_t data) { return v.SetInt64(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, int64_t data, typename ValueType::AllocatorType&) { return v.SetInt64(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, uint64_t> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsUint64(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     uint64_t Get(const ValueType& v) { return v.GetUint64(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, uint64_t data) { return v.SetUint64(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, uint64_t data, typename ValueType::AllocatorType&) { return v.SetUint64(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, double> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsDouble(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     double Get(const ValueType& v) { return v.GetDouble(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, double data) { return v.SetDouble(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, double data, typename ValueType::AllocatorType&) { return v.SetDouble(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, float> {
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsFloat(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     float Get(const ValueType& v) { return v.GetFloat(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, float data) { return v.SetFloat(data); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, float data, typename ValueType::AllocatorType&) { return v.SetFloat(data); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, const typename ValueType::Ch*> {
     typedef const typename ValueType::Ch* StringType;
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsString(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     StringType Get(const ValueType& v) { return v.GetString(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, const StringType data) { return v.SetString(typename ValueType::StringRefType(data)); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, const StringType data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
 };
 
@@ -558,11 +558,11 @@ struct TypeHelper<ValueType, const typename ValueType::Ch*> {
 template<typename ValueType> 
 struct TypeHelper<ValueType, std::basic_string<typename ValueType::Ch> > {
     typedef std::basic_string<typename ValueType::Ch> StringType;
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsString(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     StringType Get(const ValueType& v) { return StringType(v.GetString(), v.GetStringLength()); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, const StringType& data, typename ValueType::AllocatorType& a) { return v.SetString(data, a); }
 };
 #endif
@@ -570,44 +570,44 @@ struct TypeHelper<ValueType, std::basic_string<typename ValueType::Ch> > {
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::Array> {
     typedef typename ValueType::Array ArrayType;
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsArray(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ArrayType Get(ValueType& v) { return v.GetArray(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, ArrayType data) { return v = data; }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, ArrayType data, typename ValueType::AllocatorType&) { return v = data; }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::ConstArray> {
     typedef typename ValueType::ConstArray ArrayType;
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsArray(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ArrayType Get(const ValueType& v) { return v.GetArray(); }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::Object> {
     typedef typename ValueType::Object ObjectType;
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsObject(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ObjectType Get(ValueType& v) { return v.GetObject(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, ObjectType data) { return v = data; }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ValueType& Set(ValueType& v, ObjectType data, typename ValueType::AllocatorType&) { return v = data; }
 };
 
 template<typename ValueType> 
 struct TypeHelper<ValueType, typename ValueType::ConstObject> {
     typedef typename ValueType::ConstObject ObjectType;
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     bool Is(const ValueType& v) { return v.IsObject(); }
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     ObjectType Get(const ValueType& v) { return v.GetObject(); }
 };
 

--- a/llbc/include/llbc/core/rapidjson/encodings.h
+++ b/llbc/include/llbc/core/rapidjson/encodings.h
@@ -52,7 +52,7 @@ concept Encoding {
     //! \param codepoint Output of the unicode codepoint.
     //! \return true if a valid codepoint can be decoded from the stream.
     template <typename InputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint);
+    LLBC_NO_DISCARD static bool Decode(InputStream& is, unsigned* codepoint);
 
     //! \brief Validate one Unicode codepoint from an encoded stream.
     //! \param is Input stream to obtain codepoint.
@@ -60,17 +60,17 @@ concept Encoding {
     //! \return true if it is valid.
     //! \note This function just validating and copying the codepoint without actually decode it.
     template <typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os);
+    LLBC_NO_DISCARD static bool Validate(InputStream& is, OutputStream& os);
 
     // The following functions are deal with byte streams.
 
     //! Take a character from input byte stream, skip BOM if exist.
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is);
+    LLBC_NO_DISCARD static CharType TakeBOM(InputByteStream& is);
 
     //! Take a character from input byte stream.
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static Ch Take(InputByteStream& is);
+    LLBC_NO_DISCARD static Ch Take(InputByteStream& is);
 
     //! Put BOM to output byte stream.
     template <typename OutputByteStream>
@@ -143,7 +143,7 @@ struct UTF8 {
     }
 
     template <typename InputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_NO_DISCARD static bool Decode(InputStream& is, unsigned* codepoint) {
 #define LLBC_RAPIDJSON_COPY() c = is.Take(); *codepoint = (*codepoint << 6) | (static_cast<unsigned char>(c) & 0x3Fu)
 #define LLBC_RAPIDJSON_TRANS(mask) result &= ((GetRange(static_cast<unsigned char>(c)) & mask) != 0)
 #define LLBC_RAPIDJSON_TAIL() LLBC_RAPIDJSON_COPY(); LLBC_RAPIDJSON_TRANS(0x70)
@@ -176,7 +176,7 @@ struct UTF8 {
     }
 
     template <typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static bool Validate(InputStream& is, OutputStream& os) {
 #define LLBC_RAPIDJSON_COPY() os.Put(c = is.Take())
 #define LLBC_RAPIDJSON_TRANS(mask) result &= ((GetRange(static_cast<unsigned char>(c)) & mask) != 0)
 #define LLBC_RAPIDJSON_TAIL() LLBC_RAPIDJSON_COPY(); LLBC_RAPIDJSON_TRANS(0x70)
@@ -201,7 +201,7 @@ struct UTF8 {
 #undef LLBC_RAPIDJSON_TAIL
     }
 
-    LLBC_WARN_UNUSED_RESULT static unsigned char GetRange(unsigned char c) {
+    LLBC_NO_DISCARD static unsigned char GetRange(unsigned char c) {
         // Referring to DFA of http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
         // With new mapping 1 -> 0x10, 7 -> 0x20, 9 -> 0x40, such that AND operation can test multiple types.
         static const unsigned char type[] = {
@@ -220,7 +220,7 @@ struct UTF8 {
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         typename InputByteStream::Ch c = Take(is);
         if (static_cast<unsigned char>(c) != 0xEFu) return c;
@@ -233,7 +233,7 @@ struct UTF8 {
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static Ch Take(InputByteStream& is) {
+    LLBC_NO_DISCARD static Ch Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         return static_cast<Ch>(is.Take());
     }
@@ -304,7 +304,7 @@ struct UTF16 {
     }
 
     template <typename InputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_NO_DISCARD static bool Decode(InputStream& is, unsigned* codepoint) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 2);
         typename InputStream::Ch c = is.Take();
         if (c < 0xD800 || c > 0xDFFF) {
@@ -322,7 +322,7 @@ struct UTF16 {
     }
 
     template <typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static bool Validate(InputStream& is, OutputStream& os) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 2);
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename OutputStream::Ch) >= 2);
         typename InputStream::Ch c;
@@ -341,14 +341,14 @@ struct UTF16 {
 template<typename CharType = wchar_t>
 struct UTF16LE : UTF16<CharType> {
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint16_t>(c) == 0xFEFFu ? Take(is) : c;
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<uint8_t>(is.Take());
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 8;
@@ -374,14 +374,14 @@ struct UTF16LE : UTF16<CharType> {
 template<typename CharType = wchar_t>
 struct UTF16BE : UTF16<CharType> {
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint16_t>(c) == 0xFEFFu ? Take(is) : c;
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 8;
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take()));
@@ -436,7 +436,7 @@ struct UTF32 {
     }
 
     template <typename InputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_NO_DISCARD static bool Decode(InputStream& is, unsigned* codepoint) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 4);
         Ch c = is.Take();
         *codepoint = c;
@@ -444,7 +444,7 @@ struct UTF32 {
     }
 
     template <typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static bool Validate(InputStream& is, OutputStream& os) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 4);
         Ch c;
         os.Put(c = is.Take());
@@ -456,14 +456,14 @@ struct UTF32 {
 template<typename CharType = unsigned>
 struct UTF32LE : UTF32<CharType> {
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint32_t>(c) == 0x0000FEFFu ? Take(is) : c;
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<uint8_t>(is.Take());
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 8;
@@ -495,14 +495,14 @@ struct UTF32LE : UTF32<CharType> {
 template<typename CharType = unsigned>
 struct UTF32BE : UTF32<CharType> {
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint32_t>(c) == 0x0000FEFFu ? Take(is) : c; 
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 24;
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 16;
@@ -557,28 +557,28 @@ struct ASCII {
     }
 
     template <typename InputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_NO_DISCARD static bool Decode(InputStream& is, unsigned* codepoint) {
         uint8_t c = static_cast<uint8_t>(is.Take());
         *codepoint = c;
         return c <= 0X7F;
     }
 
     template <typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static bool Validate(InputStream& is, OutputStream& os) {
         uint8_t c = static_cast<uint8_t>(is.Take());
         os.Put(static_cast<typename OutputStream::Ch>(c));
         return c <= 0x7F;
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
+    LLBC_NO_DISCARD static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         uint8_t c = static_cast<uint8_t>(Take(is));
         return static_cast<Ch>(c);
     }
 
     template <typename InputByteStream>
-    LLBC_WARN_UNUSED_RESULT static Ch Take(InputByteStream& is) {
+    LLBC_NO_DISCARD static Ch Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         return static_cast<Ch>(is.Take());
     }
@@ -634,14 +634,14 @@ struct AutoUTF {
     }
 
     template <typename InputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool Decode(InputStream& is, unsigned* codepoint) {
         typedef bool (*DecodeFunc)(InputStream&, unsigned*);
         static const DecodeFunc f[] = { LLBC_RAPIDJSON_ENCODINGS_FUNC(Decode) };
         return (*f[is.GetType()])(is, codepoint);
     }
 
     template <typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
         typedef bool (*ValidateFunc)(InputStream&, OutputStream&);
         static const ValidateFunc f[] = { LLBC_RAPIDJSON_ENCODINGS_FUNC(Validate) };
         return (*f[is.GetType()])(is, os);
@@ -658,7 +658,7 @@ template<typename SourceEncoding, typename TargetEncoding>
 struct Transcoder {
     //! Take one Unicode codepoint from source encoding, convert it to target encoding and put it to the output stream.
     template<typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
         unsigned codepoint;
         if (!SourceEncoding::Decode(is, &codepoint))
             return false;
@@ -667,7 +667,7 @@ struct Transcoder {
     }
 
     template<typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
         unsigned codepoint;
         if (!SourceEncoding::Decode(is, &codepoint))
             return false;
@@ -677,7 +677,7 @@ struct Transcoder {
 
     //! Validate one Unicode codepoint from an encoded stream.
     template<typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
         return Transcode(is, os);   // Since source/target encoding is different, must transcode.
     }
 };
@@ -690,19 +690,19 @@ inline void PutUnsafe(Stream& stream, typename Stream::Ch c);
 template<typename Encoding>
 struct Transcoder<Encoding, Encoding> {
     template<typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
         os.Put(is.Take());  // Just copy one code unit. This semantic is different from primary template class.
         return true;
     }
     
     template<typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
         PutUnsafe(os, is.Take());  // Just copy one code unit. This semantic is different from primary template class.
         return true;
     }
     
     template<typename InputStream, typename OutputStream>
-    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_NO_DISCARD static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
         return Encoding::Validate(is, os);  // source/target encoding are the same
     }
 };

--- a/llbc/include/llbc/core/rapidjson/encodings.h
+++ b/llbc/include/llbc/core/rapidjson/encodings.h
@@ -52,7 +52,7 @@ concept Encoding {
     //! \param codepoint Output of the unicode codepoint.
     //! \return true if a valid codepoint can be decoded from the stream.
     template <typename InputStream>
-    static bool Decode(InputStream& is, unsigned* codepoint);
+    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint);
 
     //! \brief Validate one Unicode codepoint from an encoded stream.
     //! \param is Input stream to obtain codepoint.
@@ -60,17 +60,17 @@ concept Encoding {
     //! \return true if it is valid.
     //! \note This function just validating and copying the codepoint without actually decode it.
     template <typename InputStream, typename OutputStream>
-    static bool Validate(InputStream& is, OutputStream& os);
+    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os);
 
     // The following functions are deal with byte streams.
 
     //! Take a character from input byte stream, skip BOM if exist.
     template <typename InputByteStream>
-    static CharType TakeBOM(InputByteStream& is);
+    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is);
 
     //! Take a character from input byte stream.
     template <typename InputByteStream>
-    static Ch Take(InputByteStream& is);
+    LLBC_WARN_UNUSED_RESULT static Ch Take(InputByteStream& is);
 
     //! Put BOM to output byte stream.
     template <typename OutputByteStream>
@@ -143,7 +143,7 @@ struct UTF8 {
     }
 
     template <typename InputStream>
-    static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
 #define LLBC_RAPIDJSON_COPY() c = is.Take(); *codepoint = (*codepoint << 6) | (static_cast<unsigned char>(c) & 0x3Fu)
 #define LLBC_RAPIDJSON_TRANS(mask) result &= ((GetRange(static_cast<unsigned char>(c)) & mask) != 0)
 #define LLBC_RAPIDJSON_TAIL() LLBC_RAPIDJSON_COPY(); LLBC_RAPIDJSON_TRANS(0x70)
@@ -176,7 +176,7 @@ struct UTF8 {
     }
 
     template <typename InputStream, typename OutputStream>
-    static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
 #define LLBC_RAPIDJSON_COPY() os.Put(c = is.Take())
 #define LLBC_RAPIDJSON_TRANS(mask) result &= ((GetRange(static_cast<unsigned char>(c)) & mask) != 0)
 #define LLBC_RAPIDJSON_TAIL() LLBC_RAPIDJSON_COPY(); LLBC_RAPIDJSON_TRANS(0x70)
@@ -201,7 +201,7 @@ struct UTF8 {
 #undef LLBC_RAPIDJSON_TAIL
     }
 
-    static unsigned char GetRange(unsigned char c) {
+    LLBC_WARN_UNUSED_RESULT static unsigned char GetRange(unsigned char c) {
         // Referring to DFA of http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
         // With new mapping 1 -> 0x10, 7 -> 0x20, 9 -> 0x40, such that AND operation can test multiple types.
         static const unsigned char type[] = {
@@ -220,7 +220,7 @@ struct UTF8 {
     }
 
     template <typename InputByteStream>
-    static CharType TakeBOM(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         typename InputByteStream::Ch c = Take(is);
         if (static_cast<unsigned char>(c) != 0xEFu) return c;
@@ -233,7 +233,7 @@ struct UTF8 {
     }
 
     template <typename InputByteStream>
-    static Ch Take(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static Ch Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         return static_cast<Ch>(is.Take());
     }
@@ -304,7 +304,7 @@ struct UTF16 {
     }
 
     template <typename InputStream>
-    static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 2);
         typename InputStream::Ch c = is.Take();
         if (c < 0xD800 || c > 0xDFFF) {
@@ -322,7 +322,7 @@ struct UTF16 {
     }
 
     template <typename InputStream, typename OutputStream>
-    static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 2);
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename OutputStream::Ch) >= 2);
         typename InputStream::Ch c;
@@ -341,14 +341,14 @@ struct UTF16 {
 template<typename CharType = wchar_t>
 struct UTF16LE : UTF16<CharType> {
     template <typename InputByteStream>
-    static CharType TakeBOM(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint16_t>(c) == 0xFEFFu ? Take(is) : c;
     }
 
     template <typename InputByteStream>
-    static CharType Take(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<uint8_t>(is.Take());
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 8;
@@ -374,14 +374,14 @@ struct UTF16LE : UTF16<CharType> {
 template<typename CharType = wchar_t>
 struct UTF16BE : UTF16<CharType> {
     template <typename InputByteStream>
-    static CharType TakeBOM(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint16_t>(c) == 0xFEFFu ? Take(is) : c;
     }
 
     template <typename InputByteStream>
-    static CharType Take(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 8;
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take()));
@@ -436,7 +436,7 @@ struct UTF32 {
     }
 
     template <typename InputStream>
-    static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 4);
         Ch c = is.Take();
         *codepoint = c;
@@ -444,7 +444,7 @@ struct UTF32 {
     }
 
     template <typename InputStream, typename OutputStream>
-    static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputStream::Ch) >= 4);
         Ch c;
         os.Put(c = is.Take());
@@ -456,14 +456,14 @@ struct UTF32 {
 template<typename CharType = unsigned>
 struct UTF32LE : UTF32<CharType> {
     template <typename InputByteStream>
-    static CharType TakeBOM(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint32_t>(c) == 0x0000FEFFu ? Take(is) : c;
     }
 
     template <typename InputByteStream>
-    static CharType Take(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<uint8_t>(is.Take());
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 8;
@@ -495,14 +495,14 @@ struct UTF32LE : UTF32<CharType> {
 template<typename CharType = unsigned>
 struct UTF32BE : UTF32<CharType> {
     template <typename InputByteStream>
-    static CharType TakeBOM(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         CharType c = Take(is);
         return static_cast<uint32_t>(c) == 0x0000FEFFu ? Take(is) : c; 
     }
 
     template <typename InputByteStream>
-    static CharType Take(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         unsigned c = static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 24;
         c |= static_cast<unsigned>(static_cast<uint8_t>(is.Take())) << 16;
@@ -557,28 +557,28 @@ struct ASCII {
     }
 
     template <typename InputStream>
-    static bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_WARN_UNUSED_RESULT static bool Decode(InputStream& is, unsigned* codepoint) {
         uint8_t c = static_cast<uint8_t>(is.Take());
         *codepoint = c;
         return c <= 0X7F;
     }
 
     template <typename InputStream, typename OutputStream>
-    static bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static bool Validate(InputStream& is, OutputStream& os) {
         uint8_t c = static_cast<uint8_t>(is.Take());
         os.Put(static_cast<typename OutputStream::Ch>(c));
         return c <= 0x7F;
     }
 
     template <typename InputByteStream>
-    static CharType TakeBOM(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static CharType TakeBOM(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         uint8_t c = static_cast<uint8_t>(Take(is));
         return static_cast<Ch>(c);
     }
 
     template <typename InputByteStream>
-    static Ch Take(InputByteStream& is) {
+    LLBC_WARN_UNUSED_RESULT static Ch Take(InputByteStream& is) {
         LLBC_RAPIDJSON_STATIC_ASSERT(sizeof(typename InputByteStream::Ch) == 1);
         return static_cast<Ch>(is.Take());
     }
@@ -634,14 +634,14 @@ struct AutoUTF {
     }
 
     template <typename InputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool Decode(InputStream& is, unsigned* codepoint) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Decode(InputStream& is, unsigned* codepoint) {
         typedef bool (*DecodeFunc)(InputStream&, unsigned*);
         static const DecodeFunc f[] = { LLBC_RAPIDJSON_ENCODINGS_FUNC(Decode) };
         return (*f[is.GetType()])(is, codepoint);
     }
 
     template <typename InputStream, typename OutputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
         typedef bool (*ValidateFunc)(InputStream&, OutputStream&);
         static const ValidateFunc f[] = { LLBC_RAPIDJSON_ENCODINGS_FUNC(Validate) };
         return (*f[is.GetType()])(is, os);
@@ -658,7 +658,7 @@ template<typename SourceEncoding, typename TargetEncoding>
 struct Transcoder {
     //! Take one Unicode codepoint from source encoding, convert it to target encoding and put it to the output stream.
     template<typename InputStream, typename OutputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
         unsigned codepoint;
         if (!SourceEncoding::Decode(is, &codepoint))
             return false;
@@ -667,7 +667,7 @@ struct Transcoder {
     }
 
     template<typename InputStream, typename OutputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
         unsigned codepoint;
         if (!SourceEncoding::Decode(is, &codepoint))
             return false;
@@ -677,7 +677,7 @@ struct Transcoder {
 
     //! Validate one Unicode codepoint from an encoded stream.
     template<typename InputStream, typename OutputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
         return Transcode(is, os);   // Since source/target encoding is different, must transcode.
     }
 };
@@ -690,19 +690,19 @@ inline void PutUnsafe(Stream& stream, typename Stream::Ch c);
 template<typename Encoding>
 struct Transcoder<Encoding, Encoding> {
     template<typename InputStream, typename OutputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Transcode(InputStream& is, OutputStream& os) {
         os.Put(is.Take());  // Just copy one code unit. This semantic is different from primary template class.
         return true;
     }
     
     template<typename InputStream, typename OutputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool TranscodeUnsafe(InputStream& is, OutputStream& os) {
         PutUnsafe(os, is.Take());  // Just copy one code unit. This semantic is different from primary template class.
         return true;
     }
     
     template<typename InputStream, typename OutputStream>
-    static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
+    LLBC_WARN_UNUSED_RESULT static LLBC_RAPIDJSON_FORCEINLINE bool Validate(InputStream& is, OutputStream& os) {
         return Encoding::Validate(is, os);  // source/target encoding are the same
     }
 };

--- a/llbc/include/llbc/core/rapidjson/internal/biginteger.h
+++ b/llbc/include/llbc/core/rapidjson/internal/biginteger.h
@@ -236,7 +236,7 @@ private:
         digits_[count_++] = digit;
     }
 
-    static uint64_t ParseUint64(const char* begin, const char* end) {
+    LLBC_WARN_UNUSED_RESULT static uint64_t ParseUint64(const char* begin, const char* end) {
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
             LLBC_RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
@@ -246,7 +246,7 @@ private:
     }
 
     // Assume a * b + k < 2^128
-    static uint64_t MulAdd64(uint64_t a, uint64_t b, uint64_t k, uint64_t* outHigh) {
+    LLBC_WARN_UNUSED_RESULT static uint64_t MulAdd64(uint64_t a, uint64_t b, uint64_t k, uint64_t* outHigh) {
 #if defined(_MSC_VER) && defined(_M_AMD64)
         uint64_t low = _umul128(a, b, outHigh) + k;
         if (low < k)

--- a/llbc/include/llbc/core/rapidjson/internal/biginteger.h
+++ b/llbc/include/llbc/core/rapidjson/internal/biginteger.h
@@ -236,7 +236,7 @@ private:
         digits_[count_++] = digit;
     }
 
-    LLBC_WARN_UNUSED_RESULT static uint64_t ParseUint64(const char* begin, const char* end) {
+    static uint64_t ParseUint64(const char* begin, const char* end) {
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
             LLBC_RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
@@ -246,7 +246,7 @@ private:
     }
 
     // Assume a * b + k < 2^128
-    LLBC_WARN_UNUSED_RESULT static uint64_t MulAdd64(uint64_t a, uint64_t b, uint64_t k, uint64_t* outHigh) {
+    static uint64_t MulAdd64(uint64_t a, uint64_t b, uint64_t k, uint64_t* outHigh) {
 #if defined(_MSC_VER) && defined(_M_AMD64)
         uint64_t low = _umul128(a, b, outHigh) + k;
         if (low < k)

--- a/llbc/include/llbc/core/rapidjson/internal/ieee754.h
+++ b/llbc/include/llbc/core/rapidjson/internal/ieee754.h
@@ -48,7 +48,7 @@ public:
     int IntegerExponent() const { return (IsNormal() ? Exponent() : kDenormalExponent) - kSignificandSize; }
     uint64_t ToBias() const { return (u_ & kSignMask) ? ~u_ + 1 : u_ | kSignMask; }
 
-    LLBC_WARN_UNUSED_RESULT static int EffectiveSignificandSize(int order) {
+    LLBC_NO_DISCARD static int EffectiveSignificandSize(int order) {
         if (order >= -1021)
             return 53;
         else if (order <= -1074)

--- a/llbc/include/llbc/core/rapidjson/internal/ieee754.h
+++ b/llbc/include/llbc/core/rapidjson/internal/ieee754.h
@@ -48,7 +48,7 @@ public:
     int IntegerExponent() const { return (IsNormal() ? Exponent() : kDenormalExponent) - kSignificandSize; }
     uint64_t ToBias() const { return (u_ & kSignMask) ? ~u_ + 1 : u_ | kSignMask; }
 
-    static int EffectiveSignificandSize(int order) {
+    LLBC_WARN_UNUSED_RESULT static int EffectiveSignificandSize(int order) {
         if (order >= -1021)
             return 53;
         else if (order <= -1074)

--- a/llbc/include/llbc/core/rapidjson/internal/meta.h
+++ b/llbc/include/llbc/core/rapidjson/internal/meta.h
@@ -112,8 +112,8 @@ template<typename B, typename D> struct IsBaseOfImpl {
     typedef char (&No) [2];
 
     template <typename T>
-    LLBC_WARN_UNUSED_RESULT static Yes Check(const D*, T);
-    LLBC_WARN_UNUSED_RESULT static No  Check(const B*, int);
+    LLBC_NO_DISCARD static Yes Check(const D*, T);
+    LLBC_NO_DISCARD static No  Check(const B*, int);
 
     struct Host {
         operator const B*() const;

--- a/llbc/include/llbc/core/rapidjson/internal/meta.h
+++ b/llbc/include/llbc/core/rapidjson/internal/meta.h
@@ -112,8 +112,8 @@ template<typename B, typename D> struct IsBaseOfImpl {
     typedef char (&No) [2];
 
     template <typename T>
-    static Yes Check(const D*, T);
-    static No  Check(const B*, int);
+    LLBC_WARN_UNUSED_RESULT static Yes Check(const D*, T);
+    LLBC_WARN_UNUSED_RESULT static No  Check(const B*, int);
 
     struct Host {
         operator const B*() const;

--- a/llbc/include/llbc/core/rapidjson/reader.h
+++ b/llbc/include/llbc/core/rapidjson/reader.h
@@ -1681,7 +1681,7 @@ private:
                 StringStream srcStream(s.Pop());
                 StackStream<typename TargetEncoding::Ch> dstStream(stack_);
                 while (numCharsToCopy--) {
-                    Transcoder<UTF8<>, TargetEncoding>::Transcode(srcStream, dstStream);
+                    if (Transcoder<UTF8<>, TargetEncoding>::Transcode(srcStream, dstStream));
                 }
                 dstStream.Put('\0');
                 const typename TargetEncoding::Ch* str = dstStream.Pop();

--- a/llbc/include/llbc/core/rapidjson/reader.h
+++ b/llbc/include/llbc/core/rapidjson/reader.h
@@ -1681,7 +1681,7 @@ private:
                 StringStream srcStream(s.Pop());
                 StackStream<typename TargetEncoding::Ch> dstStream(stack_);
                 while (numCharsToCopy--) {
-                    if (Transcoder<UTF8<>, TargetEncoding>::Transcode(srcStream, dstStream));
+                    if (Transcoder<UTF8<>, TargetEncoding>::Transcode(srcStream, dstStream)) { }
                 }
                 dstStream.Put('\0');
                 const typename TargetEncoding::Ch* str = dstStream.Pop();

--- a/llbc/include/llbc/core/singleton/Singleton.h
+++ b/llbc/include/llbc/core/singleton/Singleton.h
@@ -46,7 +46,7 @@ public:
      * Get the instance of singleton.
      * @return T * - singleton instance.
      */
-    LLBC_WARN_UNUSED_RESULT static T *Instance();
+    LLBC_NO_DISCARD static T *Instance();
 
     /**
      *  Release instance object.

--- a/llbc/include/llbc/core/singleton/Singleton.h
+++ b/llbc/include/llbc/core/singleton/Singleton.h
@@ -46,7 +46,7 @@ public:
      * Get the instance of singleton.
      * @return T * - singleton instance.
      */
-    static T *Instance();
+    LLBC_WARN_UNUSED_RESULT static T *Instance();
 
     /**
      *  Release instance object.

--- a/llbc/include/llbc/core/thread/Task.h
+++ b/llbc/include/llbc/core/thread/Task.h
@@ -57,7 +57,7 @@ public:
      * @param[in] taskState - the task state.
      * @return const char * - the task state describe.
      */
-    LLBC_WARN_UNUSED_RESULT static const char *GetDesc(int taskState);
+    LLBC_NO_DISCARD static const char *GetDesc(int taskState);
 };
 
 /**

--- a/llbc/include/llbc/core/thread/Task.h
+++ b/llbc/include/llbc/core/thread/Task.h
@@ -57,7 +57,7 @@ public:
      * @param[in] taskState - the task state.
      * @return const char * - the task state describe.
      */
-    static const char *GetDesc(int taskState);
+    LLBC_WARN_UNUSED_RESULT static const char *GetDesc(int taskState);
 };
 
 /**

--- a/llbc/include/llbc/core/thread/ThreadMgr.h
+++ b/llbc/include/llbc/core/thread/ThreadMgr.h
@@ -81,38 +81,38 @@ public:
      * Check in llbc thread or not.
      * @reutrn bool - return llbc thread flag.
      */
-    LLBC_WARN_UNUSED_RESULT static bool InLLBCThread();
+    LLBC_NO_DISCARD static bool InLLBCThread();
 
     /**
      * Check in llbc entry thread or not.
      * @return bool - return llbc entry thread flag.
      */
-    LLBC_WARN_UNUSED_RESULT static bool InLLBCEntryThread();
+    LLBC_NO_DISCARD static bool InLLBCEntryThread();
 
     /**
      * Get current threadId.
      * @return LLBC_ThreadId - current thread id.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_ThreadId CurThreadId();
+    LLBC_NO_DISCARD static LLBC_ThreadId CurThreadId();
 
     /**
      * Get current thread handle.
      * @return LLBC_Handle - current thread handle.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Handle CurThreadHandle();
+    LLBC_NO_DISCARD static LLBC_Handle CurThreadHandle();
 
     /**
      * Get current native thread handle.
      * @return LLBC_NativeThreadHandle - native thread handle.
      *                                   Note: In win32 platform, don't need call CloseHandle().
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_NativeThreadHandle CurNativeThreadHandle();
+    LLBC_NO_DISCARD static LLBC_NativeThreadHandle CurNativeThreadHandle();
 
     /**
      * Get current thread group handle.
      * @return LLBC_Handle - current thread group handle.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Handle CurGroupHandle();
+    LLBC_NO_DISCARD static LLBC_Handle CurGroupHandle();
 
 public:
     /**

--- a/llbc/include/llbc/core/thread/ThreadMgr.h
+++ b/llbc/include/llbc/core/thread/ThreadMgr.h
@@ -81,38 +81,38 @@ public:
      * Check in llbc thread or not.
      * @reutrn bool - return llbc thread flag.
      */
-    static bool InLLBCThread();
+    LLBC_WARN_UNUSED_RESULT static bool InLLBCThread();
 
     /**
      * Check in llbc entry thread or not.
      * @return bool - return llbc entry thread flag.
      */
-    static bool InLLBCEntryThread();
+    LLBC_WARN_UNUSED_RESULT static bool InLLBCEntryThread();
 
     /**
      * Get current threadId.
      * @return LLBC_ThreadId - current thread id.
      */
-    static LLBC_ThreadId CurThreadId();
+    LLBC_WARN_UNUSED_RESULT static LLBC_ThreadId CurThreadId();
 
     /**
      * Get current thread handle.
      * @return LLBC_Handle - current thread handle.
      */
-    static LLBC_Handle CurThreadHandle();
+    LLBC_WARN_UNUSED_RESULT static LLBC_Handle CurThreadHandle();
 
     /**
      * Get current native thread handle.
      * @return LLBC_NativeThreadHandle - native thread handle.
      *                                   Note: In win32 platform, don't need call CloseHandle().
      */
-    static LLBC_NativeThreadHandle CurNativeThreadHandle();
+    LLBC_WARN_UNUSED_RESULT static LLBC_NativeThreadHandle CurNativeThreadHandle();
 
     /**
      * Get current thread group handle.
      * @return LLBC_Handle - current thread group handle.
      */
-    static LLBC_Handle CurGroupHandle();
+    LLBC_WARN_UNUSED_RESULT static LLBC_Handle CurGroupHandle();
 
 public:
     /**

--- a/llbc/include/llbc/core/time/Time.h
+++ b/llbc/include/llbc/core/time/Time.h
@@ -60,25 +60,25 @@ public:
     /**
      * Get current time.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time Now();
+    LLBC_NO_DISCARD static LLBC_Time Now();
 
     /**
      * Get now timestamp, in seconds.
      * @return time_t - now timestamp, in seconds.
      */
-    LLBC_WARN_UNUSED_RESULT static time_t NowTimestampInSecs();
+    LLBC_NO_DISCARD static time_t NowTimestampInSecs();
 
     /**
      * Get now timestamp, in milli-seconds.
      * @return time_t - now timestamp, in milli-seconds.
      */
-    LLBC_WARN_UNUSED_RESULT static sint64 NowTimestampInMillis();
+    LLBC_NO_DISCARD static sint64 NowTimestampInMillis();
 
     /**
      * Get now timestamp, in micro-seconds.
      * @return time_t - now timestamp, in micro-seconds.
      */
-    LLBC_WARN_UNUSED_RESULT static sint64 NowTimestampInMicros();
+    LLBC_NO_DISCARD static sint64 NowTimestampInMicros();
 
 public:
     /**
@@ -90,30 +90,30 @@ public:
      * @param[in] <time parts>     - the all time parts(year, month, day, ...). 
      * @return LLBC_Time - Time object.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromSeconds(time_t clanderTimeInSeconds);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromMillis(sint64 clanderTimeInMillis);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromMicros(sint64 clanderTimeInMicros);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeVal(const timeval &timeVal);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeSpec(const timespec &timeSpec);
+    LLBC_NO_DISCARD static LLBC_Time FromSeconds(time_t clanderTimeInSeconds);
+    LLBC_NO_DISCARD static LLBC_Time FromMillis(sint64 clanderTimeInMillis);
+    LLBC_NO_DISCARD static LLBC_Time FromMicros(sint64 clanderTimeInMicros);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeVal(const timeval &timeVal);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeSpec(const timespec &timeSpec);
     template <size_t _StrArrLen>
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char (&timeStr)[_StrArrLen]);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char *timeStr);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeStr(const char (&timeStr)[_StrArrLen]);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeStr(const char *timeStr);
     template <typename _StrType>
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_Time>::type
     FromTimeStr(const _StrType &timeStr);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const LLBC_String &timeStr);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStruct(const tm &timeStruct,
-                                                            int milliSec = 0,
-                                                            int microSec = 0);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeParts(int year,
-                                                           int month,
-                                                           int day,
-                                                           int hour,
-                                                           int minute,
-                                                           int second,
-                                                           int milliSec = 0,
-                                                           int microSec = 0);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeStr(const LLBC_String &timeStr);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeStruct(const tm &timeStruct,
+                                                    int milliSec = 0,
+                                                    int microSec = 0);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeParts(int year,
+                                                   int month,
+                                                   int day,
+                                                   int hour,
+                                                   int minute,
+                                                   int second,
+                                                   int milliSec = 0,
+                                                   int microSec = 0);
 
 public:
     /**
@@ -256,13 +256,13 @@ public:
      * Format local time, see strftime() api.
      */
     LLBC_String Format(const char *format = nullptr) const;
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Format(const time_t &clanderTimeInSeconds, const char *format);
+    LLBC_NO_DISCARD static LLBC_String Format(const time_t &clanderTimeInSeconds, const char *format);
 
     /**
      * Format gmt time, see strftime() api.
      */
     LLBC_String FormatAsGmt(const char *format = nullptr) const;
-    LLBC_WARN_UNUSED_RESULT static LLBC_String FormatAsGmt(const time_t &clanderTimeInSeconds, const char *format);
+    LLBC_NO_DISCARD static LLBC_String FormatAsGmt(const time_t &clanderTimeInSeconds, const char *format);
 
 public:
     /**
@@ -286,7 +286,7 @@ public:
      * @param[in] year - the given year.
       *@return bool - return true it means given year is leap year, otherwise not.
      */
-    LLBC_WARN_UNUSED_RESULT static bool IsLeapYear(int year);
+    LLBC_NO_DISCARD static bool IsLeapYear(int year);
 
     /**
      * Get specific month max days.
@@ -294,7 +294,7 @@ public:
      * @param[in] month - the month.
      * @return int - the specific month max days, if failed, return 0.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetMonthMaxDays(int year, int month);
+    LLBC_NO_DISCARD static int GetMonthMaxDays(int year, int month);
 
     /**
      * Get specific month span days.
@@ -302,7 +302,7 @@ public:
      * @param[in] month - the month - [1, 12].
      * @return int - the month span days(not included giving month).
      */
-    LLBC_WARN_UNUSED_RESULT static int GetMonthSpanDays(int year, int month);
+    LLBC_NO_DISCARD static int GetMonthSpanDays(int year, int month);
 
 public:
     /**
@@ -335,9 +335,9 @@ public:
      * @param[in] timeOfHour - cross time of hour point.
      * @return int - crossed hours.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetCrossedHours(const LLBC_Time &from,
-                                                       const LLBC_Time &to,
-                                                       const LLBC_TimeSpan &timeOfHour = LLBC_TimeSpan::zero);
+    LLBC_NO_DISCARD static int GetCrossedHours(const LLBC_Time &from,
+                                               const LLBC_Time &to,
+                                               const LLBC_TimeSpan &timeOfHour = LLBC_TimeSpan::zero);
 
     /**
      * Get crossed days between from and to time.
@@ -346,9 +346,9 @@ public:
      * @param[in] diffHours - diff time from daily zero time.
      * @return int - crossed days.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetCrossedDays(const LLBC_Time &from,
-                                                      const LLBC_Time &to,
-                                                      const LLBC_TimeSpan &timeOfDay = LLBC_TimeSpan::zero);
+    LLBC_NO_DISCARD static int GetCrossedDays(const LLBC_Time &from,
+                                              const LLBC_Time &to,
+                                              const LLBC_TimeSpan &timeOfDay = LLBC_TimeSpan::zero);
 
     /**
      * Get crossed weeks between from and to time.
@@ -357,9 +357,9 @@ public:
      * @param[in] timeOfWeek - cross time of week point.
      * @return int - crossed weeks.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetCrossedWeeks(const LLBC_Time &from,
-                                                       const LLBC_Time &to,
-                                                       const LLBC_TimeSpan &timeOfWeek = LLBC_TimeSpan::zero);
+    LLBC_NO_DISCARD static int GetCrossedWeeks(const LLBC_Time &from,
+                                               const LLBC_Time &to,
+                                               const LLBC_TimeSpan &timeOfWeek = LLBC_TimeSpan::zero);
 
     /**
      * Get crossed months between from and to time.
@@ -370,9 +370,9 @@ public:
      * @note: timeOfMonth must be less than 31 days old, otherwise will return 0.
      *        if timeOfMonth=oneDay, it means it's the second day of month.
      */
-    LLBC_WARN_UNUSED_RESULT static int GetCrossedMonths(const LLBC_Time &from,
-                                                        const LLBC_Time &to,
-                                                        const LLBC_TimeSpan &timeOfMonth = LLBC_TimeSpan::zero);
+    LLBC_NO_DISCARD static int GetCrossedMonths(const LLBC_Time &from,
+                                                const LLBC_Time &to,
+                                                const LLBC_TimeSpan &timeOfMonth = LLBC_TimeSpan::zero);
      
 
 public:
@@ -416,7 +416,7 @@ private:
      * @param[in] timeStrLen - the time string length, not included '\0'.
      * @return LLBC_Time - time obuect.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char *timeStr, size_t timeStrLen);
+    LLBC_NO_DISCARD static LLBC_Time FromTimeStr(const char *timeStr, size_t timeStrLen);
 
     /**
      * Internal constructor.
@@ -439,10 +439,10 @@ private:
     /**
      * Crossed time-cycle internal implement. 
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan GetCrossedCycles(const LLBC_Time &from,
-                                                                  const LLBC_Time &to,
-                                                                  const LLBC_TimeSpan &timeCycle,
-                                                                  LLBC_TimeSpan timeOfTimeCycle);
+    LLBC_NO_DISCARD static LLBC_TimeSpan GetCrossedCycles(const LLBC_Time &from,
+                                                          const LLBC_Time &to,
+                                                          const LLBC_TimeSpan &timeCycle,
+                                                          LLBC_TimeSpan timeOfTimeCycle);
 
 private:
     sint64 _time;

--- a/llbc/include/llbc/core/time/Time.h
+++ b/llbc/include/llbc/core/time/Time.h
@@ -99,7 +99,8 @@ public:
     LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char (&timeStr)[_StrArrLen]);
     LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char *timeStr);
     template <typename _StrType>
-    LLBC_WARN_UNUSED_RESULT static typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_Time>::type
+    LLBC_WARN_UNUSED_RESULT static
+    typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_Time>::type
     FromTimeStr(const _StrType &timeStr);
     LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const LLBC_String &timeStr);
     LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStruct(const tm &timeStruct,

--- a/llbc/include/llbc/core/time/Time.h
+++ b/llbc/include/llbc/core/time/Time.h
@@ -60,25 +60,25 @@ public:
     /**
      * Get current time.
      */
-    static LLBC_Time Now();
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time Now();
 
     /**
      * Get now timestamp, in seconds.
      * @return time_t - now timestamp, in seconds.
      */
-    static time_t NowTimestampInSecs();
+    LLBC_WARN_UNUSED_RESULT static time_t NowTimestampInSecs();
 
     /**
      * Get now timestamp, in milli-seconds.
      * @return time_t - now timestamp, in milli-seconds.
      */
-    static sint64 NowTimestampInMillis();
+    LLBC_WARN_UNUSED_RESULT static sint64 NowTimestampInMillis();
 
     /**
      * Get now timestamp, in micro-seconds.
      * @return time_t - now timestamp, in micro-seconds.
      */
-    static sint64 NowTimestampInMicros();
+    LLBC_WARN_UNUSED_RESULT static sint64 NowTimestampInMicros();
 
 public:
     /**
@@ -90,29 +90,29 @@ public:
      * @param[in] <time parts>     - the all time parts(year, month, day, ...). 
      * @return LLBC_Time - Time object.
      */
-    static LLBC_Time FromSeconds(time_t clanderTimeInSeconds);
-    static LLBC_Time FromMillis(sint64 clanderTimeInMillis);
-    static LLBC_Time FromMicros(sint64 clanderTimeInMicros);
-    static LLBC_Time FromTimeVal(const timeval &timeVal);
-    static LLBC_Time FromTimeSpec(const timespec &timeSpec);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromSeconds(time_t clanderTimeInSeconds);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromMillis(sint64 clanderTimeInMillis);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromMicros(sint64 clanderTimeInMicros);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeVal(const timeval &timeVal);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeSpec(const timespec &timeSpec);
     template <size_t _StrArrLen>
-    static LLBC_Time FromTimeStr(const char (&timeStr)[_StrArrLen]);
-    static LLBC_Time FromTimeStr(const char *timeStr);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char (&timeStr)[_StrArrLen]);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char *timeStr);
     template <typename _StrType>
-    static typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_Time>::type
+    LLBC_WARN_UNUSED_RESULT static typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_Time>::type
     FromTimeStr(const _StrType &timeStr);
-    static LLBC_Time FromTimeStr(const LLBC_String &timeStr);
-    static LLBC_Time FromTimeStruct(const tm &timeStruct,
-                                    int milliSec = 0,
-                                    int microSec = 0);
-    static LLBC_Time FromTimeParts(int year,
-                                   int month,
-                                   int day,
-                                   int hour,
-                                   int minute,
-                                   int second,
-                                   int milliSec = 0,
-                                   int microSec = 0);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const LLBC_String &timeStr);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStruct(const tm &timeStruct,
+                                                            int milliSec = 0,
+                                                            int microSec = 0);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeParts(int year,
+                                                           int month,
+                                                           int day,
+                                                           int hour,
+                                                           int minute,
+                                                           int second,
+                                                           int milliSec = 0,
+                                                           int microSec = 0);
 
 public:
     /**
@@ -255,13 +255,13 @@ public:
      * Format local time, see strftime() api.
      */
     LLBC_String Format(const char *format = nullptr) const;
-    static LLBC_String Format(const time_t &clanderTimeInSeconds, const char *format);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Format(const time_t &clanderTimeInSeconds, const char *format);
 
     /**
      * Format gmt time, see strftime() api.
      */
     LLBC_String FormatAsGmt(const char *format = nullptr) const;
-    static LLBC_String FormatAsGmt(const time_t &clanderTimeInSeconds, const char *format);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String FormatAsGmt(const time_t &clanderTimeInSeconds, const char *format);
 
 public:
     /**
@@ -285,7 +285,7 @@ public:
      * @param[in] year - the given year.
       *@return bool - return true it means given year is leap year, otherwise not.
      */
-    static bool IsLeapYear(int year);
+    LLBC_WARN_UNUSED_RESULT static bool IsLeapYear(int year);
 
     /**
      * Get specific month max days.
@@ -293,7 +293,7 @@ public:
      * @param[in] month - the month.
      * @return int - the specific month max days, if failed, return 0.
      */
-    static int GetMonthMaxDays(int year, int month);
+    LLBC_WARN_UNUSED_RESULT static int GetMonthMaxDays(int year, int month);
 
     /**
      * Get specific month span days.
@@ -301,7 +301,7 @@ public:
      * @param[in] month - the month - [1, 12].
      * @return int - the month span days(not included giving month).
      */
-    static int GetMonthSpanDays(int year, int month);
+    LLBC_WARN_UNUSED_RESULT static int GetMonthSpanDays(int year, int month);
 
 public:
     /**
@@ -334,9 +334,9 @@ public:
      * @param[in] timeOfHour - cross time of hour point.
      * @return int - crossed hours.
      */
-    static int GetCrossedHours(const LLBC_Time &from,
-                               const LLBC_Time &to,
-                               const LLBC_TimeSpan &timeOfHour = LLBC_TimeSpan::zero);
+    LLBC_WARN_UNUSED_RESULT static int GetCrossedHours(const LLBC_Time &from,
+                                                       const LLBC_Time &to,
+                                                       const LLBC_TimeSpan &timeOfHour = LLBC_TimeSpan::zero);
 
     /**
      * Get crossed days between from and to time.
@@ -345,9 +345,9 @@ public:
      * @param[in] diffHours - diff time from daily zero time.
      * @return int - crossed days.
      */
-    static int GetCrossedDays(const LLBC_Time &from, 
-                              const LLBC_Time &to,
-                              const LLBC_TimeSpan &timeOfDay = LLBC_TimeSpan::zero);
+    LLBC_WARN_UNUSED_RESULT static int GetCrossedDays(const LLBC_Time &from,
+                                                      const LLBC_Time &to,
+                                                      const LLBC_TimeSpan &timeOfDay = LLBC_TimeSpan::zero);
 
     /**
      * Get crossed weeks between from and to time.
@@ -356,9 +356,9 @@ public:
      * @param[in] timeOfWeek - cross time of week point.
      * @return int - crossed weeks.
      */
-    static int GetCrossedWeeks(const LLBC_Time &from,
-                               const LLBC_Time &to,
-                               const LLBC_TimeSpan &timeOfWeek = LLBC_TimeSpan::zero);
+    LLBC_WARN_UNUSED_RESULT static int GetCrossedWeeks(const LLBC_Time &from,
+                                                       const LLBC_Time &to,
+                                                       const LLBC_TimeSpan &timeOfWeek = LLBC_TimeSpan::zero);
 
     /**
      * Get crossed months between from and to time.
@@ -369,9 +369,9 @@ public:
      * @note: timeOfMonth must be less than 31 days old, otherwise will return 0.
      *        if timeOfMonth=oneDay, it means it's the second day of month.
      */
-    static int GetCrossedMonths(const LLBC_Time &from,
-                                const LLBC_Time &to,
-                                const LLBC_TimeSpan &timeOfMonth = LLBC_TimeSpan::zero);
+    LLBC_WARN_UNUSED_RESULT static int GetCrossedMonths(const LLBC_Time &from,
+                                                        const LLBC_Time &to,
+                                                        const LLBC_TimeSpan &timeOfMonth = LLBC_TimeSpan::zero);
      
 
 public:
@@ -415,7 +415,7 @@ private:
      * @param[in] timeStrLen - the time string length, not included '\0'.
      * @return LLBC_Time - time obuect.
      */
-    static LLBC_Time FromTimeStr(const char *timeStr, size_t timeStrLen);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Time FromTimeStr(const char *timeStr, size_t timeStrLen);
 
     /**
      * Internal constructor.
@@ -438,10 +438,10 @@ private:
     /**
      * Crossed time-cycle internal implement. 
      */
-    static LLBC_TimeSpan GetCrossedCycles(const LLBC_Time &from,
-                                         const LLBC_Time &to,
-                                         const LLBC_TimeSpan &timeCycle,
-                                         LLBC_TimeSpan timeOfTimeCycle);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan GetCrossedCycles(const LLBC_Time &from,
+                                                                  const LLBC_Time &to,
+                                                                  const LLBC_TimeSpan &timeCycle,
+                                                                  LLBC_TimeSpan timeOfTimeCycle);
 
 private:
     sint64 _time;

--- a/llbc/include/llbc/core/time/TimeConst.h
+++ b/llbc/include/llbc/core/time/TimeConst.h
@@ -84,7 +84,7 @@ public:
      * @param[in] dayOfWeek - day of week.
      * @return const char * - the day of week describe.
      */
-    static const char *GetDayOfWeekDesc(int dayOfWeek, bool brief = false);
+    LLBC_WARN_UNUSED_RESULT static const char *GetDayOfWeekDesc(int dayOfWeek, bool brief = false);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/time/TimeConst.h
+++ b/llbc/include/llbc/core/time/TimeConst.h
@@ -84,7 +84,7 @@ public:
      * @param[in] dayOfWeek - day of week.
      * @return const char * - the day of week describe.
      */
-    LLBC_WARN_UNUSED_RESULT static const char *GetDayOfWeekDesc(int dayOfWeek, bool brief = false);
+    LLBC_NO_DISCARD static const char *GetDayOfWeekDesc(int dayOfWeek, bool brief = false);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/time/TimeSpan.h
+++ b/llbc/include/llbc/core/time/TimeSpan.h
@@ -49,19 +49,29 @@ public:
     /**
      * Convenience span construct methods.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromDays(int days, int hours = 0, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromHours(int hours, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromMinutes(int minutes, int seconds = 0, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSeconds(int seconds, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromMillis(sint64 millis, sint64 micros = 0);
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromMicros(sint64 micros);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromDays(int days, int hours = 0, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromHours(int hours, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromMinutes(int minutes, int seconds = 0, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromSeconds(int seconds, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromMillis(sint64 millis, sint64 micros = 0);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromMicros(sint64 micros);
     template <size_t _StrArrLen>
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSpanStr(const char (&spanStr)[_StrArrLen]);
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSpanStr(const char *spanStr);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromSpanStr(const char (&spanStr)[_StrArrLen]);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromSpanStr(const char *spanStr);
     template <typename _StrType>
-    LLBC_WARN_UNUSED_RESULT static typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_TimeSpan>::type
+    LLBC_WARN_UNUSED_RESULT static
+    typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_TimeSpan>::type
     FromSpanStr(const _StrType &spanStr);
-    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSpanStr(const LLBC_String &spanStr);
+    LLBC_WARN_UNUSED_RESULT static
+    LLBC_TimeSpan FromSpanStr(const LLBC_String &spanStr);
 
 public:
     /**

--- a/llbc/include/llbc/core/time/TimeSpan.h
+++ b/llbc/include/llbc/core/time/TimeSpan.h
@@ -49,19 +49,19 @@ public:
     /**
      * Convenience span construct methods.
      */
-    static LLBC_TimeSpan FromDays(int days, int hours = 0, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
-    static LLBC_TimeSpan FromHours(int hours, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
-    static LLBC_TimeSpan FromMinutes(int minutes, int seconds = 0, int millis = 0, int micros = 0);
-    static LLBC_TimeSpan FromSeconds(int seconds, int millis = 0, int micros = 0);
-    static LLBC_TimeSpan FromMillis(sint64 millis, sint64 micros = 0);
-    static LLBC_TimeSpan FromMicros(sint64 micros);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromDays(int days, int hours = 0, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromHours(int hours, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromMinutes(int minutes, int seconds = 0, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSeconds(int seconds, int millis = 0, int micros = 0);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromMillis(sint64 millis, sint64 micros = 0);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromMicros(sint64 micros);
     template <size_t _StrArrLen>
-    static LLBC_TimeSpan FromSpanStr(const char (&spanStr)[_StrArrLen]);
-    static LLBC_TimeSpan FromSpanStr(const char *spanStr);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSpanStr(const char (&spanStr)[_StrArrLen]);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSpanStr(const char *spanStr);
     template <typename _StrType>
-    static typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_TimeSpan>::type
+    LLBC_WARN_UNUSED_RESULT static typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_TimeSpan>::type
     FromSpanStr(const _StrType &spanStr);
-    static LLBC_TimeSpan FromSpanStr(const LLBC_String &spanStr);
+    LLBC_WARN_UNUSED_RESULT static LLBC_TimeSpan FromSpanStr(const LLBC_String &spanStr);
 
 public:
     /**

--- a/llbc/include/llbc/core/time/TimeSpan.h
+++ b/llbc/include/llbc/core/time/TimeSpan.h
@@ -49,28 +49,28 @@ public:
     /**
      * Convenience span construct methods.
      */
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromDays(int days, int hours = 0, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromHours(int hours, int minutes = 0, int seconds = 0, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromMinutes(int minutes, int seconds = 0, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromSeconds(int seconds, int millis = 0, int micros = 0);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromMillis(sint64 millis, sint64 micros = 0);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromMicros(sint64 micros);
     template <size_t _StrArrLen>
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromSpanStr(const char (&spanStr)[_StrArrLen]);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromSpanStr(const char *spanStr);
     template <typename _StrType>
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     typename std::enable_if<LLBC_IsTemplSpec<_StrType, std::basic_string>::value, LLBC_TimeSpan>::type
     FromSpanStr(const _StrType &spanStr);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     LLBC_TimeSpan FromSpanStr(const LLBC_String &spanStr);
 
 public:

--- a/llbc/include/llbc/core/timer/TimerScheduler.h
+++ b/llbc/include/llbc/core/timer/TimerScheduler.h
@@ -52,7 +52,7 @@ public:
      * Get current thread timer scheduler, thread must be LLBC style thread.
      * @return _This * - timer scheduler pointer.
      */
-    LLBC_WARN_UNUSED_RESULT static _This *GetCurrentThreadScheduler();
+    LLBC_NO_DISCARD static _This *GetCurrentThreadScheduler();
 
 public:
     /**

--- a/llbc/include/llbc/core/timer/TimerScheduler.h
+++ b/llbc/include/llbc/core/timer/TimerScheduler.h
@@ -52,7 +52,7 @@ public:
      * Get current thread timer scheduler, thread must be LLBC style thread.
      * @return _This * - timer scheduler pointer.
      */
-    static _This *GetCurrentThreadScheduler();
+    LLBC_WARN_UNUSED_RESULT static _This *GetCurrentThreadScheduler();
 
 public:
     /**

--- a/llbc/include/llbc/core/tinyxml2/tinyxml2.h
+++ b/llbc/include/llbc/core/tinyxml2/tinyxml2.h
@@ -552,7 +552,7 @@ enum XMLError {
 class LLBC_TINYXML2_LIB XMLUtil
 {
 public:
-    static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
+    LLBC_WARN_UNUSED_RESULT static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
         TIXMLASSERT( p );
 
         while( IsWhiteSpace(*p) ) {
@@ -564,13 +564,13 @@ public:
         TIXMLASSERT( p );
         return p;
     }
-    static char* SkipWhiteSpace( char* const p, int* curLineNumPtr ) {
+    LLBC_WARN_UNUSED_RESULT static char* SkipWhiteSpace( char* const p, int* curLineNumPtr ) {
         return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
     }
 
     // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
     // correct, but simple, and usually works.
-    static bool IsWhiteSpace( char p )					{
+    LLBC_WARN_UNUSED_RESULT static bool IsWhiteSpace( char p )					{
         return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
     }
 
@@ -611,10 +611,10 @@ public:
         return ( p & 0x80 ) != 0;
     }
 
-    static const char* ReadBOM( const char* p, bool* hasBOM );
+    LLBC_WARN_UNUSED_RESULT static const char* ReadBOM( const char* p, bool* hasBOM );
     // p is the starting location,
     // the UTF-8 value of the entity will be placed in value, and length filled in.
-    static const char* GetCharacterRef( const char* p, char* value, int* length );
+    LLBC_WARN_UNUSED_RESULT static const char* GetCharacterRef( const char* p, char* value, int* length );
     static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
 
     // converts primitive types to strings
@@ -627,13 +627,13 @@ public:
     static void ToStr(uint64_t v, char* buffer, int bufferSize);
 
     // converts strings to primitive types
-    static bool	ToInt( const char* str, int* value );
-    static bool ToUnsigned( const char* str, unsigned* value );
-    static bool	ToBool( const char* str, bool* value );
-    static bool	ToFloat( const char* str, float* value );
-    static bool ToDouble( const char* str, double* value );
-	static bool ToInt64(const char* str, int64_t* value);
-    static bool ToUnsigned64(const char* str, uint64_t* value);
+    LLBC_WARN_UNUSED_RESULT static bool	ToInt( const char* str, int* value );
+    LLBC_WARN_UNUSED_RESULT static bool ToUnsigned( const char* str, unsigned* value );
+    LLBC_WARN_UNUSED_RESULT static bool	ToBool( const char* str, bool* value );
+    LLBC_WARN_UNUSED_RESULT static bool	ToFloat( const char* str, float* value );
+    LLBC_WARN_UNUSED_RESULT static bool ToDouble( const char* str, double* value );
+	LLBC_WARN_UNUSED_RESULT static bool ToInt64(const char* str, int64_t* value);
+    LLBC_WARN_UNUSED_RESULT static bool ToUnsigned64(const char* str, uint64_t* value);
 	// Changes what is serialized for a boolean value.
 	// Default to "true" and "false". Shouldn't be changed
 	// unless you have a special testing or compatibility need.
@@ -1887,7 +1887,7 @@ public:
         return _errorID;
     }
 	const char* ErrorName() const;
-    static const char* ErrorIDToName(XMLError errorID);
+    LLBC_WARN_UNUSED_RESULT static const char* ErrorIDToName(XMLError errorID);
 
     /** Returns a "long form" error description. A hopefully helpful
         diagnostic with location, line number, and/or additional info.

--- a/llbc/include/llbc/core/tinyxml2/tinyxml2.h
+++ b/llbc/include/llbc/core/tinyxml2/tinyxml2.h
@@ -552,7 +552,7 @@ enum XMLError {
 class LLBC_TINYXML2_LIB XMLUtil
 {
 public:
-    LLBC_WARN_UNUSED_RESULT static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
+    LLBC_NO_DISCARD static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
         TIXMLASSERT( p );
 
         while( IsWhiteSpace(*p) ) {
@@ -564,13 +564,13 @@ public:
         TIXMLASSERT( p );
         return p;
     }
-    LLBC_WARN_UNUSED_RESULT static char* SkipWhiteSpace( char* const p, int* curLineNumPtr ) {
+    LLBC_NO_DISCARD static char* SkipWhiteSpace( char* const p, int* curLineNumPtr ) {
         return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
     }
 
     // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
     // correct, but simple, and usually works.
-    LLBC_WARN_UNUSED_RESULT static bool IsWhiteSpace( char p )					{
+    LLBC_NO_DISCARD static bool IsWhiteSpace( char p )					{
         return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
     }
 
@@ -611,10 +611,10 @@ public:
         return ( p & 0x80 ) != 0;
     }
 
-    LLBC_WARN_UNUSED_RESULT static const char* ReadBOM( const char* p, bool* hasBOM );
+    LLBC_NO_DISCARD static const char* ReadBOM( const char* p, bool* hasBOM );
     // p is the starting location,
     // the UTF-8 value of the entity will be placed in value, and length filled in.
-    LLBC_WARN_UNUSED_RESULT static const char* GetCharacterRef( const char* p, char* value, int* length );
+    LLBC_NO_DISCARD static const char* GetCharacterRef( const char* p, char* value, int* length );
     static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
 
     // converts primitive types to strings
@@ -627,13 +627,13 @@ public:
     static void ToStr(uint64_t v, char* buffer, int bufferSize);
 
     // converts strings to primitive types
-    LLBC_WARN_UNUSED_RESULT static bool	ToInt( const char* str, int* value );
-    LLBC_WARN_UNUSED_RESULT static bool ToUnsigned( const char* str, unsigned* value );
-    LLBC_WARN_UNUSED_RESULT static bool	ToBool( const char* str, bool* value );
-    LLBC_WARN_UNUSED_RESULT static bool	ToFloat( const char* str, float* value );
-    LLBC_WARN_UNUSED_RESULT static bool ToDouble( const char* str, double* value );
-	LLBC_WARN_UNUSED_RESULT static bool ToInt64(const char* str, int64_t* value);
-    LLBC_WARN_UNUSED_RESULT static bool ToUnsigned64(const char* str, uint64_t* value);
+    LLBC_NO_DISCARD static bool	ToInt( const char* str, int* value );
+    LLBC_NO_DISCARD static bool ToUnsigned( const char* str, unsigned* value );
+    LLBC_NO_DISCARD static bool	ToBool( const char* str, bool* value );
+    LLBC_NO_DISCARD static bool	ToFloat( const char* str, float* value );
+    LLBC_NO_DISCARD static bool ToDouble( const char* str, double* value );
+	LLBC_NO_DISCARD static bool ToInt64(const char* str, int64_t* value);
+    LLBC_NO_DISCARD static bool ToUnsigned64(const char* str, uint64_t* value);
 	// Changes what is serialized for a boolean value.
 	// Default to "true" and "false". Shouldn't be changed
 	// unless you have a special testing or compatibility need.
@@ -1887,7 +1887,7 @@ public:
         return _errorID;
     }
 	const char* ErrorName() const;
-    LLBC_WARN_UNUSED_RESULT static const char* ErrorIDToName(XMLError errorID);
+    LLBC_NO_DISCARD static const char* ErrorIDToName(XMLError errorID);
 
     /** Returns a "long form" error description. A hopefully helpful
         diagnostic with location, line number, and/or additional info.

--- a/llbc/include/llbc/core/transcoder/Transcoder.h
+++ b/llbc/include/llbc/core/transcoder/Transcoder.h
@@ -44,10 +44,15 @@ public:
      * @param[out] destFile - wide-character string file.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src, LLBC_WString &dest);
-    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToWideChar(const LLBC_String &fromCode, const LLBC_String &srcFile, LLBC_WString &dest);
-    LLBC_WARN_UNUSED_RESULT static int MultiByteToWideCharFile(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &destFile);
-    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToWideCharFile(const LLBC_String &fromCode, const LLBC_String &srcFile, const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static
+    int MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src, LLBC_WString &dest);
+    LLBC_WARN_UNUSED_RESULT static
+    int MultiByteFileToWideChar(const LLBC_String &fromCode, const LLBC_String &srcFile, LLBC_WString &dest);
+    LLBC_WARN_UNUSED_RESULT static
+    int MultiByteToWideCharFile(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToWideCharFile(const LLBC_String &fromCode,
+                                                                   const LLBC_String &srcFile,
+                                                                   const LLBC_String &destFile);
 
     /**
      * Map a wide-character(Unicode) to a character string.

--- a/llbc/include/llbc/core/transcoder/Transcoder.h
+++ b/llbc/include/llbc/core/transcoder/Transcoder.h
@@ -44,10 +44,10 @@ public:
      * @param[out] destFile - wide-character string file.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src, LLBC_WString &dest);
-    static int MultiByteFileToWideChar(const LLBC_String &fromCode, const LLBC_String &srcFile, LLBC_WString &dest);
-    static int MultiByteToWideCharFile(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &destFile);
-    static int MultiByteFileToWideCharFile(const LLBC_String &fromCode, const LLBC_String &srcFile, const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src, LLBC_WString &dest);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToWideChar(const LLBC_String &fromCode, const LLBC_String &srcFile, LLBC_WString &dest);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteToWideCharFile(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToWideCharFile(const LLBC_String &fromCode, const LLBC_String &srcFile, const LLBC_String &destFile);
 
     /**
      * Map a wide-character(Unicode) to a character string.
@@ -58,10 +58,10 @@ public:
      * @param[out] destFile - multi-byte character string file.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src, LLBC_String &dest);
-    static int WideCharFileToMultiByte(const LLBC_String &toCode, const LLBC_String &srcFile, LLBC_String &dest);
-    static int WideCharToMultiByteFile(const LLBC_String &toCode, const LLBC_WString &src, const LLBC_String &destFile);
-    static int WideCharFileToMultiByteFile(const LLBC_String &toCode, const LLBC_String &srcFile, const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static int WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src, LLBC_String &dest);
+    LLBC_WARN_UNUSED_RESULT static int WideCharFileToMultiByte(const LLBC_String &toCode, const LLBC_String &srcFile, LLBC_String &dest);
+    LLBC_WARN_UNUSED_RESULT static int WideCharToMultiByteFile(const LLBC_String &toCode, const LLBC_WString &src, const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static int WideCharFileToMultiByteFile(const LLBC_String &toCode, const LLBC_String &srcFile, const LLBC_String &destFile);
 
     /**
      * Map a multi-byte character string to another character-set's multi-byte character string.
@@ -73,22 +73,22 @@ public:
      * @param[out] destFile - multi-byte character string file.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int MultiByteToMultiByte(const LLBC_String &fromCode,
-                                    const LLBC_String &src,
-                                    const LLBC_String &toCode,
-                                    LLBC_String &dest);
-    static int MultiByteFileToMultiByte(const LLBC_String &fromCode,
-                                        const LLBC_String &srcFile,
-                                        const LLBC_String &toCode,
-                                        LLBC_String &dest);
-    static int MultiByteToMultiByteFile(const LLBC_String &fromCode,
-                                        const LLBC_String &src,
-                                        const LLBC_String &toCode,
-                                        const LLBC_String &destFile);
-    static int MultiByteFileToMultiByteFile(const LLBC_String &fromCode,
-                                            const LLBC_String &srcFile,
-                                            const LLBC_String &toCode,
-                                            const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteToMultiByte(const LLBC_String &fromCode,
+                                                            const LLBC_String &src,
+                                                            const LLBC_String &toCode,
+                                                            LLBC_String &dest);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToMultiByte(const LLBC_String &fromCode,
+                                                                const LLBC_String &srcFile,
+                                                                const LLBC_String &toCode,
+                                                                LLBC_String &dest);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteToMultiByteFile(const LLBC_String &fromCode,
+                                                                const LLBC_String &src,
+                                                                const LLBC_String &toCode,
+                                                                const LLBC_String &destFile);
+    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToMultiByteFile(const LLBC_String &fromCode,
+                                                                    const LLBC_String &srcFile,
+                                                                    const LLBC_String &toCode,
+                                                                    const LLBC_String &destFile);
 
     /**
      * Map a character string to a wide-character(Unicode) string.
@@ -96,7 +96,7 @@ public:
      * @param[in] src      - string to map.
      * @return LLBC_WString - the wide-character string.
      */
-    static LLBC_WString MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src);
+    LLBC_WARN_UNUSED_RESULT static LLBC_WString MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src);
 
     /**
      * Map a wide-character(Unicode) to a character string.
@@ -104,7 +104,7 @@ public:
      * @param[in] src    - string to map.
      * @return LLBC_String - the character string.
      */
-    static LLBC_String WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src);
 
     /**
      * Map a multi-byte character string to another character-set's multi-byte character string.
@@ -113,7 +113,7 @@ public:
      * @param[in]  toCode   - another codepage name.
      * @return LLBC_String - the another character-set's multi-byte character string.
      */
-    static LLBC_String MultiByteToMultiByte(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &toCode);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String MultiByteToMultiByte(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &toCode);
 
 private:
     /**
@@ -122,8 +122,8 @@ private:
      * @param[out] content  - file content.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int ReadMultiByteFile(const LLBC_String &fileName, LLBC_String &content);
-    static int ReadWideCharFile(const LLBC_String &fileName, LLBC_WString &content);
+    LLBC_WARN_UNUSED_RESULT static int ReadMultiByteFile(const LLBC_String &fileName, LLBC_String &content);
+    LLBC_WARN_UNUSED_RESULT static int ReadWideCharFile(const LLBC_String &fileName, LLBC_WString &content);
 
     /**
      * Save multi-byte/wide-char content to file.
@@ -131,8 +131,8 @@ private:
      * @param[in] fileName - will save file name.
      * @return int - return 0 if success, otherwise return -1.
      */
-    static int WriteMultiByteToFile(const LLBC_String &content, const LLBC_String &fileName);
-    static int WriteWideCharToFile(const LLBC_WString &content, const LLBC_String &fileName);
+    LLBC_WARN_UNUSED_RESULT static int WriteMultiByteToFile(const LLBC_String &content, const LLBC_String &fileName);
+    LLBC_WARN_UNUSED_RESULT static int WriteWideCharToFile(const LLBC_WString &content, const LLBC_String &fileName);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/transcoder/Transcoder.h
+++ b/llbc/include/llbc/core/transcoder/Transcoder.h
@@ -44,15 +44,14 @@ public:
      * @param[out] destFile - wide-character string file.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     int MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src, LLBC_WString &dest);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     int MultiByteFileToWideChar(const LLBC_String &fromCode, const LLBC_String &srcFile, LLBC_WString &dest);
-    LLBC_WARN_UNUSED_RESULT static
+    LLBC_NO_DISCARD static
     int MultiByteToWideCharFile(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &destFile);
-    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToWideCharFile(const LLBC_String &fromCode,
-                                                                   const LLBC_String &srcFile,
-                                                                   const LLBC_String &destFile);
+    LLBC_NO_DISCARD static
+    int MultiByteFileToWideCharFile(const LLBC_String &fromCode, const LLBC_String &srcFile, const LLBC_String &destFile);
 
     /**
      * Map a wide-character(Unicode) to a character string.
@@ -63,10 +62,10 @@ public:
      * @param[out] destFile - multi-byte character string file.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src, LLBC_String &dest);
-    LLBC_WARN_UNUSED_RESULT static int WideCharFileToMultiByte(const LLBC_String &toCode, const LLBC_String &srcFile, LLBC_String &dest);
-    LLBC_WARN_UNUSED_RESULT static int WideCharToMultiByteFile(const LLBC_String &toCode, const LLBC_WString &src, const LLBC_String &destFile);
-    LLBC_WARN_UNUSED_RESULT static int WideCharFileToMultiByteFile(const LLBC_String &toCode, const LLBC_String &srcFile, const LLBC_String &destFile);
+    LLBC_NO_DISCARD static int WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src, LLBC_String &dest);
+    LLBC_NO_DISCARD static int WideCharFileToMultiByte(const LLBC_String &toCode, const LLBC_String &srcFile, LLBC_String &dest);
+    LLBC_NO_DISCARD static int WideCharToMultiByteFile(const LLBC_String &toCode, const LLBC_WString &src, const LLBC_String &destFile);
+    LLBC_NO_DISCARD static int WideCharFileToMultiByteFile(const LLBC_String &toCode, const LLBC_String &srcFile, const LLBC_String &destFile);
 
     /**
      * Map a multi-byte character string to another character-set's multi-byte character string.
@@ -78,22 +77,22 @@ public:
      * @param[out] destFile - multi-byte character string file.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int MultiByteToMultiByte(const LLBC_String &fromCode,
-                                                            const LLBC_String &src,
+    LLBC_NO_DISCARD static int MultiByteToMultiByte(const LLBC_String &fromCode,
+                                                    const LLBC_String &src,
+                                                    const LLBC_String &toCode,
+                                                    LLBC_String &dest);
+    LLBC_NO_DISCARD static int MultiByteFileToMultiByte(const LLBC_String &fromCode,
+                                                        const LLBC_String &srcFile,
+                                                        const LLBC_String &toCode,
+                                                        LLBC_String &dest);
+    LLBC_NO_DISCARD static int MultiByteToMultiByteFile(const LLBC_String &fromCode,
+                                                        const LLBC_String &src,
+                                                        const LLBC_String &toCode,
+                                                        const LLBC_String &destFile);
+    LLBC_NO_DISCARD static int MultiByteFileToMultiByteFile(const LLBC_String &fromCode,
+                                                            const LLBC_String &srcFile,
                                                             const LLBC_String &toCode,
-                                                            LLBC_String &dest);
-    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToMultiByte(const LLBC_String &fromCode,
-                                                                const LLBC_String &srcFile,
-                                                                const LLBC_String &toCode,
-                                                                LLBC_String &dest);
-    LLBC_WARN_UNUSED_RESULT static int MultiByteToMultiByteFile(const LLBC_String &fromCode,
-                                                                const LLBC_String &src,
-                                                                const LLBC_String &toCode,
-                                                                const LLBC_String &destFile);
-    LLBC_WARN_UNUSED_RESULT static int MultiByteFileToMultiByteFile(const LLBC_String &fromCode,
-                                                                    const LLBC_String &srcFile,
-                                                                    const LLBC_String &toCode,
-                                                                    const LLBC_String &destFile);
+                                                            const LLBC_String &destFile);
 
     /**
      * Map a character string to a wide-character(Unicode) string.
@@ -101,7 +100,7 @@ public:
      * @param[in] src      - string to map.
      * @return LLBC_WString - the wide-character string.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_WString MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src);
+    LLBC_NO_DISCARD static LLBC_WString MultiByteToWideChar(const LLBC_String &fromCode, const LLBC_String &src);
 
     /**
      * Map a wide-character(Unicode) to a character string.
@@ -109,7 +108,7 @@ public:
      * @param[in] src    - string to map.
      * @return LLBC_String - the character string.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src);
+    LLBC_NO_DISCARD static LLBC_String WideCharToMultiByte(const LLBC_String &toCode, const LLBC_WString &src);
 
     /**
      * Map a multi-byte character string to another character-set's multi-byte character string.
@@ -118,7 +117,7 @@ public:
      * @param[in]  toCode   - another codepage name.
      * @return LLBC_String - the another character-set's multi-byte character string.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String MultiByteToMultiByte(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &toCode);
+    LLBC_NO_DISCARD static LLBC_String MultiByteToMultiByte(const LLBC_String &fromCode, const LLBC_String &src, const LLBC_String &toCode);
 
 private:
     /**
@@ -127,8 +126,8 @@ private:
      * @param[out] content  - file content.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int ReadMultiByteFile(const LLBC_String &fileName, LLBC_String &content);
-    LLBC_WARN_UNUSED_RESULT static int ReadWideCharFile(const LLBC_String &fileName, LLBC_WString &content);
+    LLBC_NO_DISCARD static int ReadMultiByteFile(const LLBC_String &fileName, LLBC_String &content);
+    LLBC_NO_DISCARD static int ReadWideCharFile(const LLBC_String &fileName, LLBC_WString &content);
 
     /**
      * Save multi-byte/wide-char content to file.
@@ -136,8 +135,8 @@ private:
      * @param[in] fileName - will save file name.
      * @return int - return 0 if success, otherwise return -1.
      */
-    LLBC_WARN_UNUSED_RESULT static int WriteMultiByteToFile(const LLBC_String &content, const LLBC_String &fileName);
-    LLBC_WARN_UNUSED_RESULT static int WriteWideCharToFile(const LLBC_WString &content, const LLBC_String &fileName);
+    LLBC_NO_DISCARD static int WriteMultiByteToFile(const LLBC_String &content, const LLBC_String &fileName);
+    LLBC_NO_DISCARD static int WriteWideCharToFile(const LLBC_WString &content, const LLBC_String &fileName);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/utils/Util_Algorithm.h
+++ b/llbc/include/llbc/core/utils/Util_Algorithm.h
@@ -43,12 +43,12 @@ public:
     /**
      * Convert flow type to string format.
      */
-    static const char *Type2Str(int type);
+    LLBC_WARN_UNUSED_RESULT static const char *Type2Str(int type);
 
     /**
      * Convert flow string format to flow type.
      */
-    static int Str2Type(const char *type);
+    LLBC_WARN_UNUSED_RESULT static int Str2Type(const char *type);
 
     LLBC_DISABLE_ASSIGNMENT(LLBC_FlowType);
 };

--- a/llbc/include/llbc/core/utils/Util_Algorithm.h
+++ b/llbc/include/llbc/core/utils/Util_Algorithm.h
@@ -43,12 +43,12 @@ public:
     /**
      * Convert flow type to string format.
      */
-    LLBC_WARN_UNUSED_RESULT static const char *Type2Str(int type);
+    LLBC_NO_DISCARD static const char *Type2Str(int type);
 
     /**
      * Convert flow string format to flow type.
      */
-    LLBC_WARN_UNUSED_RESULT static int Str2Type(const char *type);
+    LLBC_NO_DISCARD static int Str2Type(const char *type);
 
     LLBC_DISABLE_ASSIGNMENT(LLBC_FlowType);
 };

--- a/llbc/include/llbc/core/utils/Util_Base64.h
+++ b/llbc/include/llbc/core/utils/Util_Base64.h
@@ -40,14 +40,14 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      * @return std::string/LLBC_String - the encoded string.
      */
-    LLBC_WARN_UNUSED_RESULT static std::string Encode(const std::string &input);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Encode(const LLBC_String &input);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Encode(const char *input, size_t inputLen);
-    LLBC_WARN_UNUSED_RESULT static int Encode(const std::string &input, std::string &output);
-    LLBC_WARN_UNUSED_RESULT static int Encode(const LLBC_String &input, LLBC_String &output);
-    LLBC_WARN_UNUSED_RESULT static int Encode(const char *input, size_t inputLen, std::string &output);
-    LLBC_WARN_UNUSED_RESULT static int Encode(const char *input, size_t inputLen, LLBC_String &output);
-    LLBC_WARN_UNUSED_RESULT static int Encode(const char *input, size_t inputLen, char *output, size_t &outputLen);
+    LLBC_NO_DISCARD static std::string Encode(const std::string &input);
+    LLBC_NO_DISCARD static LLBC_String Encode(const LLBC_String &input);
+    LLBC_NO_DISCARD static LLBC_String Encode(const char *input, size_t inputLen);
+    LLBC_NO_DISCARD static int Encode(const std::string &input, std::string &output);
+    LLBC_NO_DISCARD static int Encode(const LLBC_String &input, LLBC_String &output);
+    LLBC_NO_DISCARD static int Encode(const char *input, size_t inputLen, std::string &output);
+    LLBC_NO_DISCARD static int Encode(const char *input, size_t inputLen, LLBC_String &output);
+    LLBC_NO_DISCARD static int Encode(const char *input, size_t inputLen, char *output, size_t &outputLen);
 
     /**
      * Decode a base64 encoded string into bytes.
@@ -58,14 +58,14 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      * @return std::string/LLBC_String - the decoded string.
      */
-    LLBC_WARN_UNUSED_RESULT static std::string Decode(const std::string &input);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Decode(const LLBC_String &output);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Decode(const char *input, size_t inputLen);
-    LLBC_WARN_UNUSED_RESULT static int Decode(const std::string &input, std::string &output);
-    LLBC_WARN_UNUSED_RESULT static int Decode(const LLBC_String &input, LLBC_String &output);
-    LLBC_WARN_UNUSED_RESULT static int Decode(const char *input, size_t inputLen, std::string &output);
-    LLBC_WARN_UNUSED_RESULT static int Decode(const char *input, size_t inputLen, LLBC_String &output);
-    LLBC_WARN_UNUSED_RESULT static int Decode(const char *input, size_t inputLen, char *output, size_t &outputLen);
+    LLBC_NO_DISCARD static std::string Decode(const std::string &input);
+    LLBC_NO_DISCARD static LLBC_String Decode(const LLBC_String &output);
+    LLBC_NO_DISCARD static LLBC_String Decode(const char *input, size_t inputLen);
+    LLBC_NO_DISCARD static int Decode(const std::string &input, std::string &output);
+    LLBC_NO_DISCARD static int Decode(const LLBC_String &input, LLBC_String &output);
+    LLBC_NO_DISCARD static int Decode(const char *input, size_t inputLen, std::string &output);
+    LLBC_NO_DISCARD static int Decode(const char *input, size_t inputLen, LLBC_String &output);
+    LLBC_NO_DISCARD static int Decode(const char *input, size_t inputLen, char *output, size_t &outputLen);
 
 public:
     /**
@@ -73,7 +73,7 @@ public:
      * @param[in] bytesLen - the bytes length.
      * @return - size_t - the encoded string length.
      */
-    LLBC_WARN_UNUSED_RESULT static size_t CalcEncodeLen(size_t bytesLen);
+    LLBC_NO_DISCARD static size_t CalcEncodeLen(size_t bytesLen);
 
     /**
      * Calculate decoded length.
@@ -81,7 +81,7 @@ public:
      * @param[in] inputLen - the input characters length(not included \0).
      * @return size_t the decoded length.
      */
-    LLBC_WARN_UNUSED_RESULT static size_t CalcDecodedLen(const char *input, size_t inputLen);
+    LLBC_NO_DISCARD static size_t CalcDecodedLen(const char *input, size_t inputLen);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/utils/Util_Base64.h
+++ b/llbc/include/llbc/core/utils/Util_Base64.h
@@ -40,14 +40,14 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      * @return std::string/LLBC_String - the encoded string.
      */
-    static std::string Encode(const std::string &input);
-    static LLBC_String Encode(const LLBC_String &input);
-    static LLBC_String Encode(const char *input, size_t inputLen);
-    static int Encode(const std::string &input, std::string &output);
-    static int Encode(const LLBC_String &input, LLBC_String &output);
-    static int Encode(const char *input, size_t inputLen, std::string &output);
-    static int Encode(const char *input, size_t inputLen, LLBC_String &output);
-    static int Encode(const char *input, size_t inputLen, char *output, size_t &outputLen);
+    LLBC_WARN_UNUSED_RESULT static std::string Encode(const std::string &input);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Encode(const LLBC_String &input);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Encode(const char *input, size_t inputLen);
+    LLBC_WARN_UNUSED_RESULT static int Encode(const std::string &input, std::string &output);
+    LLBC_WARN_UNUSED_RESULT static int Encode(const LLBC_String &input, LLBC_String &output);
+    LLBC_WARN_UNUSED_RESULT static int Encode(const char *input, size_t inputLen, std::string &output);
+    LLBC_WARN_UNUSED_RESULT static int Encode(const char *input, size_t inputLen, LLBC_String &output);
+    LLBC_WARN_UNUSED_RESULT static int Encode(const char *input, size_t inputLen, char *output, size_t &outputLen);
 
     /**
      * Decode a base64 encoded string into bytes.
@@ -58,14 +58,14 @@ public:
      * @return int - return 0 if success, otherwise return -1.
      * @return std::string/LLBC_String - the decoded string.
      */
-    static std::string Decode(const std::string &input);
-    static LLBC_String Decode(const LLBC_String &output);
-    static LLBC_String Decode(const char *input, size_t inputLen);
-    static int Decode(const std::string &input, std::string &output);
-    static int Decode(const LLBC_String &input, LLBC_String &output);
-    static int Decode(const char *input, size_t inputLen, std::string &output);
-    static int Decode(const char *input, size_t inputLen, LLBC_String &output);
-    static int Decode(const char *input, size_t inputLen, char *output, size_t &outputLen);
+    LLBC_WARN_UNUSED_RESULT static std::string Decode(const std::string &input);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Decode(const LLBC_String &output);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Decode(const char *input, size_t inputLen);
+    LLBC_WARN_UNUSED_RESULT static int Decode(const std::string &input, std::string &output);
+    LLBC_WARN_UNUSED_RESULT static int Decode(const LLBC_String &input, LLBC_String &output);
+    LLBC_WARN_UNUSED_RESULT static int Decode(const char *input, size_t inputLen, std::string &output);
+    LLBC_WARN_UNUSED_RESULT static int Decode(const char *input, size_t inputLen, LLBC_String &output);
+    LLBC_WARN_UNUSED_RESULT static int Decode(const char *input, size_t inputLen, char *output, size_t &outputLen);
 
 public:
     /**
@@ -73,7 +73,7 @@ public:
      * @param[in] bytesLen - the bytes length.
      * @return - size_t - the encoded string length.
      */
-    static size_t CalcEncodeLen(size_t bytesLen);
+    LLBC_WARN_UNUSED_RESULT static size_t CalcEncodeLen(size_t bytesLen);
 
     /**
      * Calculate decoded length.
@@ -81,7 +81,7 @@ public:
      * @param[in] inputLen - the input characters length(not included \0).
      * @return size_t the decoded length.
      */
-    static size_t CalcDecodedLen(const char *input, size_t inputLen);
+    LLBC_WARN_UNUSED_RESULT static size_t CalcDecodedLen(const char *input, size_t inputLen);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/utils/Util_Base64Inl.h
+++ b/llbc/include/llbc/core/utils/Util_Base64Inl.h
@@ -26,21 +26,24 @@ __LLBC_NS_BEGIN
 inline std::string LLBC_Base64::Encode(const std::string &input)
 {
     std::string output;
-    Encode(input, output);
+    LLBC_ReturnIf(Encode(input, output) == LLBC_OK, output);
+    output.clear();
     return output;
 }
 
 inline LLBC_String LLBC_Base64::Encode(const LLBC_String &input)
 {
     LLBC_String output;
-    Encode(input, output);
+    LLBC_ReturnIf(Encode(input, output) == LLBC_OK, output);
+    output.clear();
     return output;
 }
 
 inline LLBC_String LLBC_Base64::Encode(const char *input, size_t inputLen)
 {
     LLBC_String output;
-    Encode(input, inputLen, output);
+    LLBC_ReturnIf(Encode(input, inputLen, output) == LLBC_OK, output);
+    output.clear();
     return output;
 }
 
@@ -83,21 +86,24 @@ inline int LLBC_Base64::Encode(const char *input, size_t inputLen, LLBC_String &
 inline std::string LLBC_Base64::Decode(const std::string &input)
 {
     std::string output;
-    Decode(input, output);
+    LLBC_ReturnIf(Decode(input, output) == LLBC_OK, output);
+    output.clear();
     return output;
 }
 
 inline LLBC_String LLBC_Base64::Decode(const LLBC_String &input)
 {
     LLBC_String output;
-    Decode(input, output);
+    LLBC_ReturnIf(Decode(input, output) == LLBC_OK, output);
+    output.clear();
     return output;
 }
 
 inline LLBC_String LLBC_Base64::Decode(const char *input, size_t inputLen)
 {
     LLBC_String output;
-    Decode(input, inputLen, output);
+    LLBC_ReturnIf(Decode(input, inputLen, output) == LLBC_OK, output);
+    output.clear();
     return output;
 }
 

--- a/llbc/include/llbc/core/utils/Util_Debug.h
+++ b/llbc/include/llbc/core/utils/Util_Debug.h
@@ -98,7 +98,7 @@ public:
      * Indicates whether the timer is based on a high-resolution performance counter. This field is read-only.
      * @return bool - the high resolution flag.
      */
-    LLBC_WARN_UNUSED_RESULT static constexpr bool IsHighResolution()
+    LLBC_NO_DISCARD static constexpr bool IsHighResolution()
     {
         #if LLBC_SUPPORT_RDTSC
         return true;
@@ -111,7 +111,7 @@ public:
      * Gets the frequency of the timer as the number of ticks per second. This field is read-only.
      * @return uint64 - the watcher frequency.
      */
-    LLBC_WARN_UNUSED_RESULT static uint64 GetFrequency() { return _frequency; }
+    LLBC_NO_DISCARD static uint64 GetFrequency() { return _frequency; }
 
     /**
      * Gets the total elapsed time measured by the current instance.

--- a/llbc/include/llbc/core/utils/Util_Debug.h
+++ b/llbc/include/llbc/core/utils/Util_Debug.h
@@ -98,7 +98,7 @@ public:
      * Indicates whether the timer is based on a high-resolution performance counter. This field is read-only.
      * @return bool - the high resolution flag.
      */
-    static constexpr bool IsHighResolution()
+    LLBC_WARN_UNUSED_RESULT static constexpr bool IsHighResolution()
     {
         #if LLBC_SUPPORT_RDTSC
         return true;
@@ -111,7 +111,7 @@ public:
      * Gets the frequency of the timer as the number of ticks per second. This field is read-only.
      * @return uint64 - the watcher frequency.
      */
-    static uint64 GetFrequency() { return _frequency; }
+    LLBC_WARN_UNUSED_RESULT static uint64 GetFrequency() { return _frequency; }
 
     /**
      * Gets the total elapsed time measured by the current instance.

--- a/llbc/include/llbc/core/utils/Util_MD5.h
+++ b/llbc/include/llbc/core/utils/Util_MD5.h
@@ -148,8 +148,8 @@ public:
      * @param[in] bytes - bytes string.
      * @return LLBC_String - MD5 digest/hex digest.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Digest(const LLBC_String &bytes);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String HexDigest(const LLBC_String &bytes);
+    LLBC_NO_DISCARD static LLBC_String Digest(const LLBC_String &bytes);
+    LLBC_NO_DISCARD static LLBC_String HexDigest(const LLBC_String &bytes);
 
     /**
      * Get bytes MD5 digest/hex digest.
@@ -157,16 +157,16 @@ public:
      * @param[in] len   - bytes length.
      * @return LLBC_String - MD5 digest/hex digest.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String Digest(const void *bytes, size_t len);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String HexDigest(const void *bytes, size_t len);
+    LLBC_NO_DISCARD static LLBC_String Digest(const void *bytes, size_t len);
+    LLBC_NO_DISCARD static LLBC_String HexDigest(const void *bytes, size_t len);
 
     /**
      * Get file MD5 digest/hex digest.
      * @param[in] file - file name.
      * @return LLBC_String - MD5 digest/hex digest.
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_String FileDigest(const LLBC_String &file);
-    LLBC_WARN_UNUSED_RESULT static LLBC_String FileHexDigest(const LLBC_String &file);
+    LLBC_NO_DISCARD static LLBC_String FileDigest(const LLBC_String &file);
+    LLBC_NO_DISCARD static LLBC_String FileHexDigest(const LLBC_String &file);
 
 private:
     static const uint32 _chainingValA;

--- a/llbc/include/llbc/core/utils/Util_MD5.h
+++ b/llbc/include/llbc/core/utils/Util_MD5.h
@@ -148,8 +148,8 @@ public:
      * @param[in] bytes - bytes string.
      * @return LLBC_String - MD5 digest/hex digest.
      */
-    static LLBC_String Digest(const LLBC_String &bytes);
-    static LLBC_String HexDigest(const LLBC_String &bytes);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Digest(const LLBC_String &bytes);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String HexDigest(const LLBC_String &bytes);
 
     /**
      * Get bytes MD5 digest/hex digest.
@@ -157,16 +157,16 @@ public:
      * @param[in] len   - bytes length.
      * @return LLBC_String - MD5 digest/hex digest.
      */
-    static LLBC_String Digest(const void *bytes, size_t len);
-    static LLBC_String HexDigest(const void *bytes, size_t len);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String Digest(const void *bytes, size_t len);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String HexDigest(const void *bytes, size_t len);
 
     /**
      * Get file MD5 digest/hex digest.
      * @param[in] file - file name.
      * @return LLBC_String - MD5 digest/hex digest.
      */
-    static LLBC_String FileDigest(const LLBC_String &file);
-    static LLBC_String FileHexDigest(const LLBC_String &file);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String FileDigest(const LLBC_String &file);
+    LLBC_WARN_UNUSED_RESULT static LLBC_String FileHexDigest(const LLBC_String &file);
 
 private:
     static const uint32 _chainingValA;

--- a/llbc/include/llbc/core/variant/Variant.h
+++ b/llbc/include/llbc/core/variant/Variant.h
@@ -100,7 +100,7 @@ public:
      * @param[in] type - the variant type enumeration.
      * @return const LLBC_String & - the type string representation.
      */
-    LLBC_WARN_UNUSED_RESULT static const LLBC_String &Type2Str(int type);
+    LLBC_NO_DISCARD static const LLBC_String &Type2Str(int type);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/variant/Variant.h
+++ b/llbc/include/llbc/core/variant/Variant.h
@@ -100,7 +100,7 @@ public:
      * @param[in] type - the variant type enumeration.
      * @return const LLBC_String & - the type string representation.
      */
-    static const LLBC_String &Type2Str(int type);
+    LLBC_WARN_UNUSED_RESULT static const LLBC_String &Type2Str(int type);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/variant/VariantArithmetic.h
+++ b/llbc/include/llbc/core/variant/VariantArithmetic.h
@@ -81,7 +81,7 @@ private:
      * Implementation function.
      */
     template <typename RawType>
-    static RawType Performs_raw_operation(RawType left, RawType right, int type);
+    LLBC_WARN_UNUSED_RESULT static RawType Performs_raw_operation(RawType left, RawType right, int type);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/variant/VariantArithmetic.h
+++ b/llbc/include/llbc/core/variant/VariantArithmetic.h
@@ -81,7 +81,7 @@ private:
      * Implementation function.
      */
     template <typename RawType>
-    LLBC_WARN_UNUSED_RESULT static RawType Performs_raw_operation(RawType left, RawType right, int type);
+    static RawType Performs_raw_operation(RawType left, RawType right, int type);
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/variant/VariantTraits.h
+++ b/llbc/include/llbc/core/variant/VariantTraits.h
@@ -46,22 +46,22 @@ public:
      * Relational operators.
      * ==, !=, <, >, <=, >=
      */
-    LLBC_WARN_UNUSED_RESULT static bool eq(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static bool ne(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static bool lt(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static bool gt(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static bool le(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static bool ge(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static bool eq(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static bool ne(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static bool lt(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static bool gt(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static bool le(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static bool ge(const LLBC_Variant &left, const LLBC_Variant &right);
 
     /**
      * Arithmetic operators.
      * +, -, *, /, %
      */
-    LLBC_WARN_UNUSED_RESULT static LLBC_Variant add(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Variant sub(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Variant mul(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Variant div(const LLBC_Variant &left, const LLBC_Variant &right);
-    LLBC_WARN_UNUSED_RESULT static LLBC_Variant mod(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static LLBC_Variant add(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static LLBC_Variant sub(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static LLBC_Variant mul(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static LLBC_Variant div(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_NO_DISCARD static LLBC_Variant mod(const LLBC_Variant &left, const LLBC_Variant &right);
 
     /**
      * Arithmetic operators.

--- a/llbc/include/llbc/core/variant/VariantTraits.h
+++ b/llbc/include/llbc/core/variant/VariantTraits.h
@@ -46,22 +46,22 @@ public:
      * Relational operators.
      * ==, !=, <, >, <=, >=
      */
-    static bool eq(const LLBC_Variant &left, const LLBC_Variant &right);
-    static bool ne(const LLBC_Variant &left, const LLBC_Variant &right);
-    static bool lt(const LLBC_Variant &left, const LLBC_Variant &right);
-    static bool gt(const LLBC_Variant &left, const LLBC_Variant &right);
-    static bool le(const LLBC_Variant &left, const LLBC_Variant &right);
-    static bool ge(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static bool eq(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static bool ne(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static bool lt(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static bool gt(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static bool le(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static bool ge(const LLBC_Variant &left, const LLBC_Variant &right);
 
     /**
      * Arithmetic operators.
      * +, -, *, /, %
      */
-    static LLBC_Variant add(const LLBC_Variant &left, const LLBC_Variant &right);
-    static LLBC_Variant sub(const LLBC_Variant &left, const LLBC_Variant &right);
-    static LLBC_Variant mul(const LLBC_Variant &left, const LLBC_Variant &right);
-    static LLBC_Variant div(const LLBC_Variant &left, const LLBC_Variant &right);
-    static LLBC_Variant mod(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Variant add(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Variant sub(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Variant mul(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Variant div(const LLBC_Variant &left, const LLBC_Variant &right);
+    LLBC_WARN_UNUSED_RESULT static LLBC_Variant mod(const LLBC_Variant &left, const LLBC_Variant &right);
 
     /**
      * Arithmetic operators.

--- a/llbc/src/core/log/LogFileAppender.cpp
+++ b/llbc/src/core/log/LogFileAppender.cpp
@@ -361,7 +361,7 @@ void LLBC_LogFileAppender::BackupFiles()
         moveTo.format("%s.%d%s", filePathNoSuffix.c_str(), willMoveIndex + 1, _fileSuffix.c_str());
 
 #ifdef LLBC_RELEASE
-        if (LLBC_File::MoveFile(willMove, moveTo, true) != LLBC_OK);
+        if (LLBC_File::MoveFile(willMove, moveTo, true) != LLBC_OK) {}
 #else
         if (LLBC_File::MoveFile(willMove, moveTo, true) != LLBC_OK)
         {

--- a/llbc/src/core/log/LogFileAppender.cpp
+++ b/llbc/src/core/log/LogFileAppender.cpp
@@ -361,7 +361,7 @@ void LLBC_LogFileAppender::BackupFiles()
         moveTo.format("%s.%d%s", filePathNoSuffix.c_str(), willMoveIndex + 1, _fileSuffix.c_str());
 
 #ifdef LLBC_RELEASE
-        LLBC_File::MoveFile(willMove, moveTo, true);
+        if (LLBC_File::MoveFile(willMove, moveTo, true) != LLBC_OK);
 #else
         if (LLBC_File::MoveFile(willMove, moveTo, true) != LLBC_OK)
         {

--- a/testsuite/TestTraits.h
+++ b/testsuite/TestTraits.h
@@ -15,11 +15,11 @@ ObjType* __CreateTestCaseIns()
 template <int idx>
 struct __TestCaseTraits
 {
-    LLBC_WARN_UNUSED_RESULT static const char* Name()
+    LLBC_NO_DISCARD static const char* Name()
     {
         return nullptr;
     }
-    LLBC_WARN_UNUSED_RESULT static LLBC_NS LLBC_ITestCase* CreateTestCaseIns()
+    LLBC_NO_DISCARD static LLBC_NS LLBC_ITestCase* CreateTestCaseIns()
     {
         return nullptr;
     }

--- a/testsuite/TestTraits.h
+++ b/testsuite/TestTraits.h
@@ -15,11 +15,11 @@ ObjType* __CreateTestCaseIns()
 template <int idx>
 struct __TestCaseTraits
 {
-    static const char* Name()
+    LLBC_WARN_UNUSED_RESULT static const char* Name()
     {
         return nullptr;
     }
-    static LLBC_NS LLBC_ITestCase* CreateTestCaseIns()
+    LLBC_WARN_UNUSED_RESULT static LLBC_NS LLBC_ITestCase* CreateTestCaseIns()
     {
         return nullptr;
     }

--- a/testsuite/core/bundle/TestCase_Core_Bundle.cpp
+++ b/testsuite/core/bundle/TestCase_Core_Bundle.cpp
@@ -42,7 +42,7 @@ int TestCase_Core_Bundle::Run(int argc, char *argv[])
     
     // Try to access resource: Default.png.
 #if LLBC_TARGET_PLATFORM_NON_IPHONE
-    LLBC_File::TouchFile(mainBundle->GetBundlePath() + "/" + "Default.png");
+    assert(LLBC_File::TouchFile(mainBundle->GetBundlePath() + "/" + "Default.png") == LLBC_OK);
 #endif // LLBC_TARGET_PLATFORM_NON_IPHONE
     LLBC_PrintLn("Default.png path: %s", mainBundle->GetResPath("Default", "png").c_str());
     
@@ -72,7 +72,7 @@ int TestCase_Core_Bundle::Run(int argc, char *argv[])
     }
     
 #if LLBC_TARGET_PLATFORM_NON_IPHONE
-    LLBC_File::DeleteFile(mainBundle->GetBundlePath() + "/" + "Default.png");
+    assert(LLBC_File::DeleteFile(mainBundle->GetBundlePath() + "/" + "Default.png") == LLBC_OK);
 #endif // LLBC_TARGET_PLATFORM_NON_IPHONE
     
     LLBC_PrintLn("Press any key to continue ...");

--- a/testsuite/core/file/TestCase_Core_File_Directory.cpp
+++ b/testsuite/core/file/TestCase_Core_File_Directory.cpp
@@ -82,7 +82,7 @@ int TestCase_Core_File_Directory::CurDirTest()
     }
 
     LLBC_PrintLn("After set, current directory: %s", LLBC_Directory::CurDir().c_str());
-    LLBC_Directory::SetCurDir(curDir);
+    assert(LLBC_Directory::SetCurDir(curDir) == LLBC_OK);
 
     LLBC_Print("\n");
 
@@ -237,31 +237,31 @@ int TestCase_Core_File_Directory::GetFilesTest()
     LLBC_PrintLn("GetFiles test:");
 
     LLBC_PrintLn("Create some directories and files for test:");
-    LLBC_Directory::Create("a/b");
-    LLBC_Directory::Create("a/c");
-    LLBC_Directory::Create("a/d");
-    LLBC_File::TouchFile("a/z");
+    assert(LLBC_Directory::Create("a/b") == LLBC_OK);
+    assert(LLBC_Directory::Create("a/c") == LLBC_OK);
+    assert(LLBC_Directory::Create("a/d") == LLBC_OK);
+    assert(LLBC_File::TouchFile("a/z") == LLBC_OK);
 
-    LLBC_File::TouchFile("a/b/bb");
-    LLBC_File::TouchFile("a/c/cc");
-    LLBC_File::TouchFile("a/d/dd");
-    LLBC_Directory::Create("a/b/zz");
+    assert(LLBC_File::TouchFile("a/b/bb") == LLBC_OK);
+    assert(LLBC_File::TouchFile("a/c/cc") == LLBC_OK);
+    assert(LLBC_File::TouchFile("a/d/dd") == LLBC_OK);
+    assert(LLBC_Directory::Create("a/b/zz") == LLBC_OK);
 
     LLBC_PrintLn("Get files from directory a(recursive = false)");
     if (GetFilesTest("a", false) != LLBC_OK)
     {
-        LLBC_Directory::Remove("a");
+        assert(LLBC_Directory::Remove("a") == LLBC_OK);
         return LLBC_FAILED;
     }
 
     LLBC_PrintLn("Get files from directory a(recursive = true)");
     if (GetFilesTest("a", true) != LLBC_OK)
     {
-        LLBC_Directory::Remove("a");
+        assert(LLBC_Directory::Remove("a") == LLBC_OK);
         return LLBC_FAILED;
     }
 
-    LLBC_Directory::Remove("a");
+    assert(LLBC_Directory::Remove("a") == LLBC_OK);
     LLBC_Print("\n");
 
     return LLBC_OK;
@@ -272,31 +272,31 @@ int TestCase_Core_File_Directory::GetDirectoriesTest()
     LLBC_PrintLn("GetDirectories test:");
 
     LLBC_PrintLn("Create some directories and files for test:");
-    LLBC_Directory::Create("a/b");
-    LLBC_Directory::Create("a/c");
-    LLBC_Directory::Create("a/d");
-    LLBC_File::TouchFile("a/z");
+    assert(LLBC_Directory::Create("a/b") == LLBC_OK);
+    assert(LLBC_Directory::Create("a/c") == LLBC_OK);
+    assert(LLBC_Directory::Create("a/d") == LLBC_OK);
+    assert(LLBC_File::TouchFile("a/z") == LLBC_OK);
 
-    LLBC_File::TouchFile("a/b/bb");
-    LLBC_File::TouchFile("a/c/cc");
-    LLBC_File::TouchFile("a/d/dd");
-    LLBC_Directory::Create("a/b/zz");
+    assert(LLBC_File::TouchFile("a/b/bb") == LLBC_OK);
+    assert(LLBC_File::TouchFile("a/c/cc") == LLBC_OK);
+    assert(LLBC_File::TouchFile("a/d/dd") == LLBC_OK);
+    assert(LLBC_Directory::Create("a/b/zz") == LLBC_OK);
 
     LLBC_PrintLn("Get directories from directory a(recursive = false)");
     if (GetDirectoriesTest("a", false) != LLBC_OK)
     {
-        LLBC_Directory::Remove("a");
+        assert(LLBC_Directory::Remove("a") == LLBC_OK);
         return LLBC_FAILED;
     }
 
     LLBC_PrintLn("Get directories from directory a(recursive = true)");
     if (GetDirectoriesTest("a", true) != LLBC_OK)
     {
-        LLBC_Directory::Remove("a");
+        assert(LLBC_Directory::Remove("a") == LLBC_OK);
         return LLBC_FAILED;
     }
 
-    LLBC_Directory::Remove("a");
+    assert(LLBC_Directory::Remove("a") == LLBC_OK);
     LLBC_Print("\n");
 
     return LLBC_OK;

--- a/testsuite/core/file/TestCase_Core_File_File.cpp
+++ b/testsuite/core/file/TestCase_Core_File_File.cpp
@@ -32,7 +32,7 @@ TestCase_Core_File_File::TestCase_Core_File_File()
 
 TestCase_Core_File_File::~TestCase_Core_File_File()
 {
-    LLBC_File::DeleteFile(_testFileName);
+    if (LLBC_File::DeleteFile(_testFileName) != LLBC_OK);
 }
 
 int TestCase_Core_File_File::Run(int argc, char *argv[])
@@ -341,23 +341,23 @@ bool TestCase_Core_File_File::FileAttributeTest()
     }
 
     LLBC_PrintLn("Touched, attributes:");
-    LLBC_File::GetFileAttributes(_testFileName, fileAttrs);
+    assert(LLBC_File::GetFileAttributes(_testFileName, fileAttrs) == LLBC_OK);
     PrintFileAttributes(fileAttrs);
 
     LLBC_PrintLn("Sleep 2 seconds...");
     LLBC_Sleep(2000);
     LLBC_PrintLn("Touch last access time to now");
-    LLBC_File::TouchFile(_testFileName, true, nullptr, false, nullptr);
+    assert(LLBC_File::TouchFile(_testFileName, true, nullptr, false, nullptr) == LLBC_OK);
     LLBC_PrintLn("Touched, attributes:");
-    LLBC_File::GetFileAttributes(_testFileName, fileAttrs);
+    assert(LLBC_File::GetFileAttributes(_testFileName, fileAttrs) == LLBC_OK);
     PrintFileAttributes(fileAttrs);
 
     LLBC_PrintLn("Sleep 2 seconds...");
     LLBC_Sleep(2000);
     LLBC_PrintLn("Touch last modify time to now");
-    LLBC_File::TouchFile(_testFileName, false, nullptr, true, nullptr);
+    assert(LLBC_File::TouchFile(_testFileName, false, nullptr, true, nullptr) == LLBC_OK);
     LLBC_PrintLn("Touched, attributes:");
-    LLBC_File::GetFileAttributes(_testFileName, fileAttrs);
+    assert(LLBC_File::GetFileAttributes(_testFileName, fileAttrs) == LLBC_OK);
     PrintFileAttributes(fileAttrs);
 
     LLBC_Print("\n");
@@ -402,7 +402,7 @@ bool TestCase_Core_File_File::CopyFileTest()
     if (file.CopyFile(copyFileName, false) == LLBC_OK)
     {
         LLBC_PrintLn("Copy success, failed. check your code!");
-        LLBC_File::DeleteFile(copyFileName);
+        assert(LLBC_File::DeleteFile(copyFileName) == LLBC_OK);
 
         return false;
     }
@@ -412,7 +412,7 @@ bool TestCase_Core_File_File::CopyFileTest()
     }
 
     LLBC_PrintLn("Delete copy file");
-    LLBC_File::DeleteFile(copyFileName);
+    assert(LLBC_File::DeleteFile(copyFileName) == LLBC_OK);
 
     LLBC_Print("\n");
 
@@ -453,13 +453,13 @@ bool TestCase_Core_File_File::MoveFileTest()
     moveFile.Close();
 
     const LLBC_String copyFileName = _testFileName + ".copy";
-    LLBC_File::CopyFile(moveFileName, copyFileName, true);
+    assert(LLBC_File::CopyFile(moveFileName, copyFileName, true) == LLBC_OK);
     LLBC_PrintLn("Copy move file and move again(don't overlapped): %s ---> %s", copyFileName.c_str(), copyFileName.c_str());
     if (LLBC_File::MoveFile(copyFileName, moveFileName, false) == LLBC_OK)
     {
         LLBC_PrintLn("Move success, failed. check your code!");
-        LLBC_File::DeleteFile(copyFileName);
-        LLBC_File::DeleteFile(moveFileName);
+        assert(LLBC_File::DeleteFile(copyFileName) == LLBC_OK);
+        assert(LLBC_File::DeleteFile(moveFileName) == LLBC_OK);
 
         return false;
     }
@@ -469,8 +469,8 @@ bool TestCase_Core_File_File::MoveFileTest()
     }
 
     LLBC_PrintLn("Delete copy file and move file");
-    LLBC_File::DeleteFile(copyFileName);
-    LLBC_File::DeleteFile(moveFileName);
+    assert(LLBC_File::DeleteFile(copyFileName) == LLBC_OK);
+    assert(LLBC_File::DeleteFile(moveFileName) == LLBC_OK);
 
     LLBC_Print("\n");
 

--- a/testsuite/core/file/TestCase_Core_File_File.cpp
+++ b/testsuite/core/file/TestCase_Core_File_File.cpp
@@ -32,7 +32,7 @@ TestCase_Core_File_File::TestCase_Core_File_File()
 
 TestCase_Core_File_File::~TestCase_Core_File_File()
 {
-    if (LLBC_File::DeleteFile(_testFileName) != LLBC_OK);
+    if (LLBC_File::DeleteFile(_testFileName) != LLBC_OK) { }
 }
 
 int TestCase_Core_File_File::Run(int argc, char *argv[])

--- a/testsuite/core/time/TestCase_Core_Time_Time.cpp
+++ b/testsuite/core/time/TestCase_Core_Time_Time.cpp
@@ -258,7 +258,12 @@ void TestCase_Core_Time_Time::TimeClassTest()
     for (size_t i = 0; i < fromTimeStrPerfTestTimes; ++i)
     {
         for (size_t j = 0; j < testTimeStrs.size(); ++j)
+        {
             auto temp_time = LLBC_Time::FromTimeStr(testTimeStrs[j]);
+            std::cout << "LLBC_Time::FromTimeStr(): " << testTimeStrs[j]
+                      << "to " << temp_time.GetTimestampInSecs()
+                      << std::endl;
+        }
     }
     const auto costTime = LLBC_GetMicroseconds() - begTime;
     std::cout << "LLBC_Time::FromTimeStr() perf test finished"

--- a/testsuite/core/time/TestCase_Core_Time_Time.cpp
+++ b/testsuite/core/time/TestCase_Core_Time_Time.cpp
@@ -258,7 +258,7 @@ void TestCase_Core_Time_Time::TimeClassTest()
     for (size_t i = 0; i < fromTimeStrPerfTestTimes; ++i)
     {
         for (size_t j = 0; j < testTimeStrs.size(); ++j)
-            LLBC_Time::FromTimeStr(testTimeStrs[j]);
+            auto temp_time = LLBC_Time::FromTimeStr(testTimeStrs[j]);
     }
     const auto costTime = LLBC_GetMicroseconds() - begTime;
     std::cout << "LLBC_Time::FromTimeStr() perf test finished"

--- a/testsuite/core/utils/TestCase_Core_Utils_Base64.cpp
+++ b/testsuite/core/utils/TestCase_Core_Utils_Base64.cpp
@@ -42,16 +42,16 @@ int TestCase_Core_Utils_Base64::Run(int argc, char *argv[])
     std::string decodedEmptyText;
 
     // Test encode.
-    LLBC_Base64::Encode(plainText, encodedText);
+    assert(LLBC_Base64::Encode(plainText, encodedText) == LLBC_OK);
     LLBC_PrintLn("Text: [%s]", plainText.c_str());
     LLBC_PrintLn("Encoded: [%s]", encodedText.c_str());
-    LLBC_Base64::Encode(emptyPlainText, encodedEmptyText);
+    assert(LLBC_Base64::Encode(emptyPlainText, encodedEmptyText) == LLBC_OK);
     LLBC_PrintLn("Empty Text Encoded: [%s]", encodedEmptyText.c_str());
 
     // Test decode.
-    LLBC_Base64::Decode(encodedText, decodedText);
+    assert(LLBC_Base64::Decode(encodedText, decodedText) == LLBC_OK);
     LLBC_PrintLn("Decoded: [%s]", decodedText.c_str());
-    LLBC_Base64::Decode(encodedEmptyText, decodedEmptyText);
+    assert(LLBC_Base64::Decode(encodedEmptyText, decodedEmptyText) == LLBC_OK);
     LLBC_PrintLn("Decoded Empty Text: [%s]", decodedEmptyText.c_str());
 
     LLBC_PrintLn("Press any key to continue...");


### PR DESCRIPTION
## 调整目的
业务中发现某些地方获取跨天跨月的结果异常，经排查发现下述用法导致
```
LLBC_Time time_obj;
time_obj.FromSeconds(xxxx);
if (GetCrossedDay(time_obj, LLBC_Time::Now()) > 0)
{
    xxxx;
}
```
``` static LLBC_Time FromSeconds(time_t clanderTimeInSeconds)``` 是一个 LLBC_Time 的静态成员函数，通过实例调用并不会对实例赋值，导致这里的 time_obj 一直是默认初始值，导致跨天判断永远成立

现在准备对所有的带返回值的静态成员函数增加返回值丢弃检查

## 调整方式
### 考虑使用 [[nodiscard]] （放弃）
[c++17 standard for nodiscard](https://en.cppreference.com/w/cpp/language/attributes/nodiscard)
这个是最好用的方案，由 C++17 特性直接支持，无需考虑编译器
但是由于框架需要兼容 C++11 环境，故放弃该方案
### 采用编译器方案  （采用）
这个需要兼容不同的编译器，但是无需 C++ 版本支持
```
#if defined(__GNUC__) || defined(__clang__)
    #define LLBC_NO_DISCARD __attribute__((warn_unused_result))
#elif defined(_MSC_VER) && _MSC_VER >= 1700 // VS 2012 or higher
    #define LLBC_NO_DISCARD _Check_return_
#else
    #define LLBC_NO_DISCARD
#endif
```
对于 GCC/Clang 采用 **``` __attribute__((warn_unused_result)) ```** 来检查
对于 VS2012 及以上版本的 MSVC 采用 **``` _Check_return_ ```** 来检查

目前来看这样就能覆盖到大部分场景，故采用此方案