### PR TITLE
【llbc】App运行时能力扩充 - 只允许启动一个实例 #224

### DIFF
--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -59,5 +59,5 @@ LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
  *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetExclusive(const LLBC_String &pidFilePath = "");
+LLBC_EXPORT int LLBC_SetProcessExclusive(const LLBC_String &pidFilePath = "");
 __LLBC_NS_END

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -26,10 +26,10 @@
 // Handle crash support macro define.
 #if LLBC_TARGET_PLATFORM_WIN32 || LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
  #define LLBC_SUPPORT_HANDLE_CRASH 1
- #define LLBC_SUPPORT_SET_EXCLUSIVE 1
+ #define LLBC_SUPPORT_SET_PROCESS_EXCLUSIVE 1
 #else // Non Win32 and Linux
  #define LLBC_SUPPORT_HANDLE_CRASH 0
- #define LLBC_SUPPORT_SET_EXCLUSIVE 0
+ #define LLBC_SUPPORT_SET_PROCESS_EXCLUSIVE 0
 #endif
 
 __LLBC_NS_BEGIN
@@ -54,10 +54,10 @@ LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
 
 /**
  * Set process exclusive(only one instance of process can run).
- * @param[in] pidFilePath  - the pid file path.
- *                            in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
- *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
+ * @param[in] pidFilePath - the pid file path.
+ *                          in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
+ *                          in Non-Windows platform, is a core pattern, if is empty, will use system default config.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetProcessExclusive(const LLBC_String &pidFilePath = "");
+LLBC_EXPORT int LLBC_SetProcessExclusive(const LLBC_CString &pidFilePath = "");
 __LLBC_NS_END

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -54,10 +54,9 @@ LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
 
 /**
  * Set process exclusive(only one instance of process can run).
- * @param[in] pidFilePath - the pid file path.
- *                          in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
- *                          in Non-Windows platform, is a core pattern, if is empty, will use system default config.
+ * @param[in] pidFileDirectoryPath - the pid file directory path.
+ *                                   if is empty, pid file directory is <your_app_path>
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetProcessExclusive(const LLBC_CString &pidFilePath = "");
+LLBC_EXPORT int LLBC_SetProcessExclusive(const LLBC_CString &pidFileDirectoryPath = "");
 __LLBC_NS_END

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -54,9 +54,10 @@ LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
 
 /**
  * Set process exclusive(only one instance of process can run).
- * @param[in] pidFileDirectoryPath - the pid file directory path.
- *                                   if is empty, pid file directory is <your_app_path>
+ * @param[in] exclusiveInfoFilePath - the exclusive info file path.
+ *                                    contains exclusive info, currently only contain pid.
+ *                                    if is empty, exclusive file path is <your_app_path>.pid.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetProcessExclusive(const LLBC_CString &pidFileDirectoryPath = "");
+LLBC_EXPORT int LLBC_SetProcessExclusive(const LLBC_CString &exclusiveInfoFilePath = "");
 __LLBC_NS_END

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -26,8 +26,10 @@
 // Handle crash support macro define.
 #if LLBC_TARGET_PLATFORM_WIN32 || LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
  #define LLBC_SUPPORT_HANDLE_CRASH 1
+ #define LLBC_SUPPORT_SET_EXCLUSIVE 1
 #else // Non Win32 and Linux
  #define LLBC_SUPPORT_HANDLE_CRASH 0
+ #define LLBC_SUPPORT_SET_EXCLUSIVE 0
 #endif
 
 __LLBC_NS_BEGIN
@@ -50,4 +52,12 @@ LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
                                  const LLBC_Delegate<void(const char *stackBacktrace,
                                                           int sig)> &crashCallback = nullptr);
 
+/**
+ * Set process exclusive(only one instance of process can run).
+ * @param[in] pidFilePath  - the pid file path.
+ *                            in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
+ *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
+ * @return int - return 0 if success, otherwise return -1.
+ */
+LLBC_EXPORT int LLBC_SetExclusive(const LLBC_String &pidFilePath = "");
 __LLBC_NS_END

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -585,34 +585,27 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
 
             for (auto cfgSecItem : cfgItem.second.AsDict())
             {
-                if (cfgSecItem.first.AsStr().tolower() == "fps")
-                {
+                const auto cfgSecItemKey = cfgSecItem.first.AsStr().tolower();
+                if (cfgSecItemKey == "fps")
                     SetFPS(cfgSecItem.second);
-                    continue;
-                }
-
-                if (cfgSecItem.first.AsStr().tolower() == "exclusive" && cfgSecItem.second.AsLooseBool())
-                {
+                else if (cfgSecItemKey == "exclusive" && cfgSecItem.second.AsLooseBool())
                     LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
-                    continue;
-                }
+
+                continue;
             }
 
             break;
         }
 
-        if (cfgItem.first.AsStr().tolower() == "fps")
+        const auto cfgItemKey = cfgItem.first.AsStr().tolower();
+        if (cfgItemKey == "fps" || cfgItemKey == "exclusive")
         {
-            const auto &fps = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
-            SetFPS(fps);
-            continue;
-        }
-
-        if (cfgItem.first.AsStr().tolower() == "exclusive")
-        {
-            const auto &isExclusive = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
-            if (isExclusive.AsLooseBool())
+            const auto &cfgItemValue = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
+            if (cfgItemKey == "fps")
+                SetFPS(cfgItemValue);
+            else if (cfgItemKey == "exclusive" && cfgItemValue.AsLooseBool())
                 LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
+
             continue;
         }
     }

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -593,7 +593,7 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
 
                 if (cfgSecItem.first.AsStr().tolower() == "exclusive" && cfgSecItem.second.AsLooseBool())
                 {
-                    LLBC_ReturnIf(LLBC_SetExclusive() != LLBC_OK, LLBC_FAILED);
+                    LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
                     break;
                 }
             }
@@ -613,7 +613,7 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
             const auto& isExclusive = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
             if (isExclusive.AsLooseBool())
             {
-                LLBC_ReturnIf(LLBC_SetExclusive() != LLBC_OK, LLBC_FAILED);
+                LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
             }
             break;
         }

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -590,6 +590,12 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
                     SetFPS(cfgSecItem.second);
                     break;
                 }
+
+                if (cfgSecItem.first.AsStr().tolower() == "exclusive" && cfgSecItem.second.AsLooseBool())
+                {
+                    LLBC_ReturnIf(LLBC_SetExclusive() != LLBC_OK, LLBC_FAILED);
+                    break;
+                }
             }
 
             break;
@@ -599,6 +605,16 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
         {
             const auto& fps = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
             SetFPS(fps);
+            break;
+        }
+
+        if (cfgItem.first.AsStr().tolower() == "exclusive")
+        {
+            const auto& isExclusive = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
+            if (isExclusive.AsLooseBool())
+            {
+                LLBC_ReturnIf(LLBC_SetExclusive() != LLBC_OK, LLBC_FAILED);
+            }
             break;
         }
     }

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -588,13 +588,13 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
                 if (cfgSecItem.first.AsStr().tolower() == "fps")
                 {
                     SetFPS(cfgSecItem.second);
-                    break;
+                    continue;
                 }
 
                 if (cfgSecItem.first.AsStr().tolower() == "exclusive" && cfgSecItem.second.AsLooseBool())
                 {
                     LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
-                    break;
+                    continue;
                 }
             }
 
@@ -603,19 +603,17 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
 
         if (cfgItem.first.AsStr().tolower() == "fps")
         {
-            const auto& fps = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
+            const auto &fps = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
             SetFPS(fps);
-            break;
+            continue;
         }
 
         if (cfgItem.first.AsStr().tolower() == "exclusive")
         {
-            const auto& isExclusive = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
+            const auto &isExclusive = _cfgType == LLBC_AppConfigType::Xml ? cfgItem.second[LLBC_XMLKeys::Value] : cfgItem.second;
             if (isExclusive.AsLooseBool())
-            {
                 LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
-            }
-            break;
+            continue;
         }
     }
 

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -590,8 +590,6 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
                     SetFPS(cfgSecItem.second);
                 else if (cfgSecItemKey == "exclusive" && cfgSecItem.second.AsLooseBool())
                     LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
-
-                continue;
             }
 
             break;
@@ -605,8 +603,6 @@ int LLBC_App::ReloadImpl(bool checkAppStarted, bool callEvMeth)
                 SetFPS(cfgItemValue);
             else if (cfgItemKey == "exclusive" && cfgItemValue.AsLooseBool())
                 LLBC_ReturnIf(LLBC_SetProcessExclusive() != LLBC_OK, LLBC_FAILED);
-
-            continue;
         }
     }
 

--- a/llbc/src/core/file/Directory_Com.cpp
+++ b/llbc/src/core/file/Directory_Com.cpp
@@ -640,7 +640,7 @@ LLBC_String LLBC_Directory::ModuleFilePath()
         return "";
     }
 
-    return LLBC_String(buf, size);
+    return LLBC_String(buf, strlen(buf));
 #else // Linux/Android
     ssize_t ret = -1;
     char buf[PATH_MAX + 1];

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -482,7 +482,7 @@ __LLBC_NS_END
 #include <libproc.h>
 #endif
 __LLBC_NS_BEGIN
-int LLBC_SetExclusive(const LLBC_String &pidFilePath)
+int LLBC_SetProcessExclusive(const LLBC_String &pidFilePath)
 {
 #if LLBC_TARGET_PLATFORM_WIN32
     static char pidBuf[MAX_FORM_KEYWORD_LENGTH + 1] = { 0 };

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -558,7 +558,7 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
 
     // Open executable file by pid.
 #if LLBC_TARGET_PLATFORM_MAC
-    pidPathRet = proc_pidpath(atoi(pidBuf), runningExeFilePath, PATH_MAX);
+    int pidPathRet = proc_pidpath(atoi(pidBuf), runningExeFilePath, PATH_MAX);
     LLBC_DoIf(pidPathRet != -1, runningExeFilePath[pidPathRet] = '\0');
 #else
     llbc::LLBC_String runingExe;

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -492,14 +492,15 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     LLBC_String selfExeFilePath = LLBC_Directory::ModuleFilePath();
 
     // Set .pid file path
-    LLBC_String pidFile = LLBC_Directory::Join(pidFilePath, LLBC_Directory::ModuleFileName()).append(".pid");
+    LLBC_String pidFile = LLBC_Directory::Join(pidFilePath, LLBC_Directory::ModuleFileName());
     if (pidFilePath == "")
     {
-        pidFile = selfExeFilePath.append(".pid");
+        pidFile = selfExeFilePath;
     }
+    pidFile.append(".pid");
 
     // Create or read-lock .pid file
-    HANDLE file = CreateFileA(exePidFilePath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE file = CreateFileA(pidFile.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     LLBC_ReturnIf(file == INVALID_HANDLE_VALUE, LLBC_FAILED);
     LLBC_Defer(CloseHandle(file));
 
@@ -515,14 +516,14 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     if (processHandle != NULL)
     {
         // Get executable file path refer to pid.
-        getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
+        DWORD getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
         CloseHandle(processHandle);
         LLBC_ReturnIf(getModuleFileNameRet == 0, LLBC_FAILED);
         runningExeFilePath[getModuleFileNameRet] = '\0';
     }
 
     // Compare self name and running process path
-    LLBC_ReturnIf(strcmp(runningExeFilePath, selfExeFilePath) == 0, LLBC_FAILED);
+    LLBC_ReturnIf(runningExeFilePath == selfExeFilePath, LLBC_FAILED);
 
     // Clear .pid file and write pid into it
     SetFilePointer(file, 0, NULL, FILE_BEGIN);

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -500,7 +500,7 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     pidFile.append(".pid");
 
     // Create or read-lock .pid file
-    HANDLE file = CreateFileA(pidFile.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE file = CreateFileA(pidFile.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_HIDDEN, NULL);
     LLBC_ReturnIf(file == INVALID_HANDLE_VALUE, LLBC_FAILED);
     LLBC_Defer(CloseHandle(file));
 

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -104,14 +104,14 @@ static void __GetExceptionBackTrace(PCONTEXT ctx, char *stackBacktrace, size_t b
     while (true)
     {
         if (!::StackWalk64(machineType,
-                           curProc,
-                           curThread,
-                           &stackFrame64,
-                           ctx,
-                           nullptr,
-                           ::SymFunctionTableAccess64,
-                           ::SymGetModuleBase64,
-                           nullptr))
+            curProc,
+            curThread,
+            &stackFrame64,
+            ctx,
+            nullptr,
+            ::SymFunctionTableAccess64,
+            ::SymGetModuleBase64,
+            nullptr))
             break;
 
         if (stackFrame64.AddrFrame.Offset == 0)
@@ -138,13 +138,13 @@ static void __GetExceptionBackTrace(PCONTEXT ctx, char *stackBacktrace, size_t b
         }
 
         const auto usedCap = snprintf(stackBacktrace,
-                                      backtraceSize,
-                                      "#%d 0x%p in %s at %s:%d\n",
-                                      frameNo++,
+            backtraceSize,
+            "#%d 0x%p in %s at %s:%d\n",
+            frameNo++,
                                       reinterpret_cast<void *>(symbol->Address),
-                                      symbol->Name,
-                                      fileName ? fileName : "",
-                                      lineNo);
+            symbol->Name,
+            fileName ? fileName : "",
+            lineNo);
         if (usedCap <= 0 ||
             usedCap >= static_cast<int>(backtraceSize) - 1)
             return;
@@ -157,12 +157,12 @@ static void __GetExceptionBackTrace(PCONTEXT ctx, char *stackBacktrace, size_t b
 static LONG WINAPI __Win32CrashHandler(::EXCEPTION_POINTERS *exception)
 {
     HANDLE dmpFile = ::CreateFileA(__dumpFilePath,
-                                   GENERIC_WRITE,
-                                   FILE_SHARE_READ,
-                                   nullptr,
-                                   CREATE_ALWAYS,
-                                   FILE_ATTRIBUTE_NORMAL,
-                                   nullptr);
+        GENERIC_WRITE,
+        FILE_SHARE_READ,
+        nullptr,
+        CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
     if (UNLIKELY(dmpFile == INVALID_HANDLE_VALUE))
         return EXCEPTION_CONTINUE_SEARCH;
 
@@ -176,12 +176,12 @@ static LONG WINAPI __Win32CrashHandler(::EXCEPTION_POINTERS *exception)
     dmpInfo.ClientPointers = TRUE;
 
     const BOOL writeDumpSucc = ::MiniDumpWriteDump(::GetCurrentProcess(),
-                                                   ::GetCurrentProcessId(),
-                                                   dmpFile,
-                                                   (MINIDUMP_TYPE)LLBC_CFG_APP_DUMPFILE_DUMPTYPES,
-                                                   &dmpInfo,
-                                                   nullptr,
-                                                   nullptr);
+        ::GetCurrentProcessId(),
+        dmpFile,
+        (MINIDUMP_TYPE)LLBC_CFG_APP_DUMPFILE_DUMPTYPES,
+        &dmpInfo,
+        nullptr,
+        nullptr);
     if (UNLIKELY(!writeDumpSucc))
     {
         LLBC_NS LLBC_SetLastError(LLBC_ERROR_OSAPI);
@@ -225,15 +225,15 @@ static BOOL __PreventSetUnhandledExceptionFilter()
     // c3       ret
     unsigned char execute[] = { 0x33, 0xc0, 0xc3 };
 #else
- #error "Unsupported architecture(on windows platform)!"
+#error "Unsupported architecture(on windows platform)!"
 #endif
 
     SIZE_T bytesWritten = 0;
     return ::WriteProcessMemory(GetCurrentProcess(),
-                                orgEntry,
-                                execute,
-                                sizeof(execute),
-                                &bytesWritten);
+        orgEntry,
+        execute,
+        sizeof(execute),
+        &bytesWritten);
 }
 
 __LLBC_INTERNAL_NS_END
@@ -245,9 +245,9 @@ __LLBC_INTERNAL_NS_END
 
 #include "llbc/core/file/File.h"
 
-__LLBC_INTERNAL_NS_BEGIN
+    __LLBC_INTERNAL_NS_BEGIN
 
-static char __exeFilePath[PATH_MAX + 1];
+    static char __exeFilePath[PATH_MAX + 1];
 static char __corePattern[PATH_MAX + 1];
 static char __coreDescFilePath[PATH_MAX + 1];
 static char __shellCmd[PATH_MAX * 2 + 256 + 1];
@@ -287,7 +287,7 @@ static void __NonWin32CrashHandler(int sig)
 
     ssize_t readRet = read(corePatternFd, __corePattern, sizeof(__corePattern) - 1);
     LLBC_DoIf(readRet == -1, close(corePatternFd); raise(sig));
-   
+
     close(corePatternFd);
     __corePattern[readRet >= 0 ? readRet : 0] = '\0';
 
@@ -301,25 +301,25 @@ static void __NonWin32CrashHandler(int sig)
     const int pid = getpid();
     const LLBC_NS uint32 now = time(nullptr);
     int fmtRet = snprintf(__shellCmd,
-                          sizeof(__shellCmd),
-                          "\\cp -rf \"%s\" \"%s/%s_%d_%u\"",
-                          __exeFilePath,
-                          corePatternDir,
-                          exeFileName,
-                          pid,
-                          now);
+        sizeof(__shellCmd),
+        "\\cp -rf \"%s\" \"%s/%s_%d_%u\"",
+        __exeFilePath,
+        corePatternDir,
+        exeFileName,
+        pid,
+        now);
     LLBC_DoIf(fmtRet < 0, raise(sig));
 
     system(__shellCmd);
 
     // Generate stack backtrace describe file(to txt).
     fmtRet = snprintf(__coreDescFilePath,
-                      sizeof(__coreDescFilePath),
-                      "%s/%s_%d_%u_stack_backtrace.txt",
-                      corePatternDir,
-                      exeFileName,
-                      pid,
-                      now);
+        sizeof(__coreDescFilePath),
+        "%s/%s_%d_%u_stack_backtrace.txt",
+        corePatternDir,
+        exeFileName,
+        pid,
+        now);
     LLBC_DoIf(fmtRet < 0, raise(sig));
 
     int coreDescFileFd = open(__coreDescFilePath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
@@ -327,9 +327,9 @@ static void __NonWin32CrashHandler(int sig)
 
     char descFileHead[64];
     fmtRet = snprintf(descFileHead,
-                      sizeof(descFileHead),
-                      "Stack BackTrace(signal:%d):\n",
-                      sig);
+        sizeof(descFileHead),
+        "Stack BackTrace(signal:%d):\n",
+        sig);
     if (fmtRet > 0)
     {
         write(coreDescFileFd, descFileHead, fmtRet);
@@ -385,8 +385,8 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
         const auto now = LLBC_Time::Now();
         nmlDumpFilePath = LLBC_Directory::SplitExt(LLBC_Directory::ModuleFilePath())[0];
         nmlDumpFilePath.append_format("_%d_%s.dmp",
-                                      LLBC_GetCurrentProcessId(),
-                                      now.Format("%Y%m%d_%H%M%S").c_str());
+            LLBC_GetCurrentProcessId(),
+            now.Format("%Y%m%d_%H%M%S").c_str());
     }
 
     if (nmlDumpFilePath.size() >= sizeof(LLBC_INL_NS __dumpFilePath))
@@ -401,9 +401,9 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
     if (!LLBC_INL_NS __hookedCrashSignals)
     {
         ::SetUnhandledExceptionFilter(LLBC_INL_NS __Win32CrashHandler);
-        #ifdef LLBC_RELEASE
+#ifdef LLBC_RELEASE
         LLBC_INL_NS __PreventSetUnhandledExceptionFilter();
-        #endif
+#endif
 
         LLBC_INL_NS __hookedCrashSignals = true;
     }
@@ -474,6 +474,7 @@ __LLBC_NS_END
 #endif // Supp hook process crash
 
 #if LLBC_SUPPORT_SET_PROCESS_EXCLUSIVE
+#include <llbc/core/utils/Util_Text.h>
 #if LLBC_TARGET_PLATFORM_WIN32
 #include <psapi.h>
 #elif LLBC_TARGET_PLATFORM_MAC
@@ -491,52 +492,50 @@ int LLBC_SetProcessExclusive(const LLBC_CString &exclusiveInfoFilePath)
     // Get current execute file path.
     LLBC_String selfExeFilePath = LLBC_Directory::ModuleFilePath();
 
-    // Set exclusive info file path.
-    LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath;
-    if (nmlExclusiveInfoFilePath.empty())
-    {
-        nmlExclusiveInfoFilePath = LLBC_Directory::Join(selfExeFilePath, LLBC_Directory::ModuleFileName());
-        nmlExclusiveInfoFilePath.append(".pid");
-    }
+	// Set exclusive info file path.
+	LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath.empty()
+		? LLBC_Directory::ModuleFilePath() + ".pid"
+		: exclusiveInfoFilePath;
 
     // Create then read-lock exclusive info file.
     HANDLE exclusiveInfoFile = CreateFileA(nmlExclusiveInfoFilePath.c_str(),
-                                           GENERIC_READ | GENERIC_WRITE,
-                                           FILE_SHARE_READ,
-                                           NULL,
-                                           OPEN_ALWAYS,
-                                           FILE_ATTRIBUTE_HIDDEN,
-                                           NULL);
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ,
+        NULL,
+        OPEN_ALWAYS,
+        FILE_ATTRIBUTE_HIDDEN,
+        NULL);
     LLBC_SetErrAndReturnIf(exclusiveInfoFile == INVALID_HANDLE_VALUE, LLBC_ERROR_OSAPI, LLBC_FAILED);
-    LLBC_Defer(CloseHandle(exclusiveInfoFile));
+    LLBC_Defer(
+        LLBC_SetErrAndReturnIf(!CloseHandle(exclusiveInfoFile), LLBC_ERROR_OSAPI,)
+    );
 
     // Read pid from exclusive info file.
     DWORD fileSize = GetFileSize(exclusiveInfoFile, NULL);
-    LLBC_ReturnIf(fileSize == -1, LLBC_FAILED);
+    LLBC_SetErrAndReturnIf(fileSize == -1 || fileSize >= 32, LLBC_ERROR_OSAPI, LLBC_FAILED);
 
     bool readSucc = ReadFile(exclusiveInfoFile, exclusiveInfoBuf, fileSize, &fileSize, NULL);
     LLBC_SetErrAndReturnIf(!readSucc, LLBC_ERROR_OSAPI, LLBC_FAILED);
     exclusiveInfoBuf[fileSize] = '\0';
 
     // Deal with exclusive info.
-    long exclusiveInfoPid = atoi(exclusiveInfoBuf);
-    if (strlen(exclusiveInfoBuf) != 0 && exclusiveInfoPid != getpid())
-    {
-        // Open executable process by pid.
-        HANDLE processHandle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
-                                           FALSE, exclusiveInfoPid);
-        if (processHandle != NULL)
-        {
-            // Get executable file path refer to pid.
-            DWORD getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
-            CloseHandle(processHandle);
-            LLBC_SetErrAndReturnIf(getModuleFileNameRet == 0, LLBC_ERROR_OSAPI, LLBC_FAILED);
-            runningExeFilePath[getModuleFileNameRet] = '\0';
-        }
+    long exclusiveInfoPid = LLBC_Str2Long(exclusiveInfoBuf);
+    LLBC_ReturnIf(exclusiveInfoPid == getpid(), LLBC_FAILED);
 
-        // Compare self name and running process path.
-        LLBC_ReturnIf(runningExeFilePath == selfExeFilePath, LLBC_FAILED);
-    }
+	// Open executable process by pid.
+	HANDLE processHandle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+		FALSE, exclusiveInfoPid);
+	if (processHandle != NULL)
+	{
+		// Get executable file path refer to pid.
+		DWORD getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
+		CloseHandle(processHandle);
+		LLBC_SetErrAndReturnIf(getModuleFileNameRet == 0, LLBC_ERROR_OSAPI, LLBC_FAILED);
+		runningExeFilePath[getModuleFileNameRet] = '\0';
+	}
+
+    // Compare self name and running process path.
+    LLBC_ReturnIf(runningExeFilePath == selfExeFilePath, LLBC_FAILED);
 
     // Clear .pid file and write pid into it.
     SetFilePointer(exclusiveInfoFile, 0, NULL, FILE_BEGIN);
@@ -553,40 +552,38 @@ int LLBC_SetProcessExclusive(const LLBC_CString &exclusiveInfoFilePath)
     LLBC_String selfExeFilePath = LLBC_Directory::ModuleFilePath();
 
     // Set exclusive info file path.
-    LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath;
-    if (nmlExclusiveInfoFilePath.empty())
-    {
-        nmlExclusiveInfoFilePath = LLBC_Directory::Join(selfExeFilePath, LLBC_Directory::ModuleFileName());
-        nmlExclusiveInfoFilePath.append(".pid");
-    }
+    LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath.empty()
+        ? LLBC_Directory::ModuleFilePath() + ".pid"
+        : exclusiveInfoFilePath;
 
     // Open exclusive info file and read pid.
     int exclusiveInfoFd = open(nmlExclusiveInfoFilePath.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
     LLBC_SetErrAndReturnIf(exclusiveInfoFd < 0, LLBC_ERROR_OSAPI, LLBC_FAILED);
-    LLBC_Defer(close(exclusiveInfoFd););
+    LLBC_Defer(
+        LLBC_SetErrAndReturnIf(close(exclusiveInfoFd) == -1, LLBC_ERROR_OSAPI, )
+    );
+    LLBC_Defer();
 
     int readRet = read(exclusiveInfoFd, exclusiveInfoBuf, MAX_INPUT);
     LLBC_SetErrAndReturnIf(readRet == -1, LLBC_ERROR_OSAPI, LLBC_FAILED);
     exclusiveInfoBuf[readRet] = '\0';
 
     // Deal with exclusive info.
-    long exclusiveInfoPid = atoi(exclusiveInfoBuf);
-    if (strlen(exclusiveInfoBuf) != 0 && exclusiveInfoPid != getpid())
-    {
-        // Get executable file by pid.
+    long exclusiveInfoPid = LLBC_Str2Long(exclusiveInfoBuf);
+    LLBC_ReturnIf(exclusiveInfoPid == getpid(), LLBC_OK);
+
+	// Get executable file by pid.
 #if LLBC_TARGET_PLATFORM_MAC
-        int pidPathRet = proc_pidpath(exclusiveInfoPid, runningExeFilePath, PATH_MAX);
-        LLBC_DoIf(pidPathRet != -1, runningExeFilePath[pidPathRet] = '\0');
+	int pidPathRet = proc_pidpath(exclusiveInfoPid, runningExeFilePath, PATH_MAX);
+	LLBC_DoIf(pidPathRet != -1, runningExeFilePath[pidPathRet] = '\0');
 #else
-        llbc::LLBC_String runingExe;
-        runingExe.format("/proc/%d/exe", exclusiveInfoPid);
-        ssize_t readLinkRet = readlink(runingExe.c_str(), runningExeFilePath, PATH_MAX);
-        LLBC_DoIf(readLinkRet != -1, runningExeFilePath[readLinkRet] = '\0');
+	llbc::LLBC_String runingExe;
+	runingExe.format("/proc/%d/exe", exclusiveInfoPid);
+	ssize_t readLinkRet = readlink(runingExe.c_str(), runningExeFilePath, PATH_MAX);
+	LLBC_DoIf(readLinkRet != -1, runningExeFilePath[readLinkRet] = '\0');
 #endif
 
-        // Compare self name and running process path.
-        LLBC_ReturnIf(selfExeFilePath == runningExeFilePath, LLBC_FAILED);
-    }
+    LLBC_ReturnIf(selfExeFilePath == runningExeFilePath, LLBC_FAILED);
 
     // Try to lock exclusive info file.
     struct flock fl;

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -104,14 +104,14 @@ static void __GetExceptionBackTrace(PCONTEXT ctx, char *stackBacktrace, size_t b
     while (true)
     {
         if (!::StackWalk64(machineType,
-            curProc,
-            curThread,
-            &stackFrame64,
-            ctx,
-            nullptr,
-            ::SymFunctionTableAccess64,
-            ::SymGetModuleBase64,
-            nullptr))
+                           curProc,
+                           curThread,
+                           &stackFrame64,
+                           ctx,
+                           nullptr,
+                           ::SymFunctionTableAccess64,
+                           ::SymGetModuleBase64,
+                           nullptr))
             break;
 
         if (stackFrame64.AddrFrame.Offset == 0)
@@ -138,13 +138,13 @@ static void __GetExceptionBackTrace(PCONTEXT ctx, char *stackBacktrace, size_t b
         }
 
         const auto usedCap = snprintf(stackBacktrace,
-            backtraceSize,
-            "#%d 0x%p in %s at %s:%d\n",
-            frameNo++,
+                                      backtraceSize,
+                                      "#%d 0x%p in %s at %s:%d\n",
+                                      frameNo++,
                                       reinterpret_cast<void *>(symbol->Address),
-            symbol->Name,
-            fileName ? fileName : "",
-            lineNo);
+                                      symbol->Name,
+                                      fileName ? fileName : "",
+                                      lineNo);
         if (usedCap <= 0 ||
             usedCap >= static_cast<int>(backtraceSize) - 1)
             return;
@@ -157,12 +157,12 @@ static void __GetExceptionBackTrace(PCONTEXT ctx, char *stackBacktrace, size_t b
 static LONG WINAPI __Win32CrashHandler(::EXCEPTION_POINTERS *exception)
 {
     HANDLE dmpFile = ::CreateFileA(__dumpFilePath,
-        GENERIC_WRITE,
-        FILE_SHARE_READ,
-        nullptr,
-        CREATE_ALWAYS,
-        FILE_ATTRIBUTE_NORMAL,
-        nullptr);
+                                   GENERIC_WRITE,
+                                   FILE_SHARE_READ,
+                                   nullptr,
+                                   CREATE_ALWAYS,
+                                   FILE_ATTRIBUTE_NORMAL,
+                                   nullptr);
     if (UNLIKELY(dmpFile == INVALID_HANDLE_VALUE))
         return EXCEPTION_CONTINUE_SEARCH;
 
@@ -176,12 +176,12 @@ static LONG WINAPI __Win32CrashHandler(::EXCEPTION_POINTERS *exception)
     dmpInfo.ClientPointers = TRUE;
 
     const BOOL writeDumpSucc = ::MiniDumpWriteDump(::GetCurrentProcess(),
-        ::GetCurrentProcessId(),
-        dmpFile,
-        (MINIDUMP_TYPE)LLBC_CFG_APP_DUMPFILE_DUMPTYPES,
-        &dmpInfo,
-        nullptr,
-        nullptr);
+                                                   ::GetCurrentProcessId(),
+                                                   dmpFile,
+                                                   (MINIDUMP_TYPE)LLBC_CFG_APP_DUMPFILE_DUMPTYPES,
+                                                   &dmpInfo,
+                                                   nullptr,
+                                                   nullptr);
     if (UNLIKELY(!writeDumpSucc))
     {
         LLBC_NS LLBC_SetLastError(LLBC_ERROR_OSAPI);
@@ -225,15 +225,15 @@ static BOOL __PreventSetUnhandledExceptionFilter()
     // c3       ret
     unsigned char execute[] = { 0x33, 0xc0, 0xc3 };
 #else
-#error "Unsupported architecture(on windows platform)!"
+ #error "Unsupported architecture(on windows platform)!"
 #endif
 
     SIZE_T bytesWritten = 0;
     return ::WriteProcessMemory(GetCurrentProcess(),
-        orgEntry,
-        execute,
-        sizeof(execute),
-        &bytesWritten);
+                                orgEntry,
+                                execute,
+                                sizeof(execute),
+                                &bytesWritten);
 }
 
 __LLBC_INTERNAL_NS_END
@@ -245,9 +245,9 @@ __LLBC_INTERNAL_NS_END
 
 #include "llbc/core/file/File.h"
 
-    __LLBC_INTERNAL_NS_BEGIN
+__LLBC_INTERNAL_NS_BEGIN
 
-    static char __exeFilePath[PATH_MAX + 1];
+static char __exeFilePath[PATH_MAX + 1];
 static char __corePattern[PATH_MAX + 1];
 static char __coreDescFilePath[PATH_MAX + 1];
 static char __shellCmd[PATH_MAX * 2 + 256 + 1];
@@ -287,7 +287,7 @@ static void __NonWin32CrashHandler(int sig)
 
     ssize_t readRet = read(corePatternFd, __corePattern, sizeof(__corePattern) - 1);
     LLBC_DoIf(readRet == -1, close(corePatternFd); raise(sig));
-
+   
     close(corePatternFd);
     __corePattern[readRet >= 0 ? readRet : 0] = '\0';
 
@@ -301,25 +301,25 @@ static void __NonWin32CrashHandler(int sig)
     const int pid = getpid();
     const LLBC_NS uint32 now = time(nullptr);
     int fmtRet = snprintf(__shellCmd,
-        sizeof(__shellCmd),
-        "\\cp -rf \"%s\" \"%s/%s_%d_%u\"",
-        __exeFilePath,
-        corePatternDir,
-        exeFileName,
-        pid,
-        now);
+                          sizeof(__shellCmd),
+                          "\\cp -rf \"%s\" \"%s/%s_%d_%u\"",
+                          __exeFilePath,
+                          corePatternDir,
+                          exeFileName,
+                          pid,
+                          now);
     LLBC_DoIf(fmtRet < 0, raise(sig));
 
     system(__shellCmd);
 
     // Generate stack backtrace describe file(to txt).
     fmtRet = snprintf(__coreDescFilePath,
-        sizeof(__coreDescFilePath),
-        "%s/%s_%d_%u_stack_backtrace.txt",
-        corePatternDir,
-        exeFileName,
-        pid,
-        now);
+                      sizeof(__coreDescFilePath),
+                      "%s/%s_%d_%u_stack_backtrace.txt",
+                      corePatternDir,
+                      exeFileName,
+                      pid,
+                      now);
     LLBC_DoIf(fmtRet < 0, raise(sig));
 
     int coreDescFileFd = open(__coreDescFilePath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
@@ -327,9 +327,9 @@ static void __NonWin32CrashHandler(int sig)
 
     char descFileHead[64];
     fmtRet = snprintf(descFileHead,
-        sizeof(descFileHead),
-        "Stack BackTrace(signal:%d):\n",
-        sig);
+                      sizeof(descFileHead),
+                      "Stack BackTrace(signal:%d):\n",
+                      sig);
     if (fmtRet > 0)
     {
         write(coreDescFileFd, descFileHead, fmtRet);
@@ -385,8 +385,8 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
         const auto now = LLBC_Time::Now();
         nmlDumpFilePath = LLBC_Directory::SplitExt(LLBC_Directory::ModuleFilePath())[0];
         nmlDumpFilePath.append_format("_%d_%s.dmp",
-            LLBC_GetCurrentProcessId(),
-            now.Format("%Y%m%d_%H%M%S").c_str());
+                                      LLBC_GetCurrentProcessId(),
+                                      now.Format("%Y%m%d_%H%M%S").c_str());
     }
 
     if (nmlDumpFilePath.size() >= sizeof(LLBC_INL_NS __dumpFilePath))
@@ -401,9 +401,9 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
     if (!LLBC_INL_NS __hookedCrashSignals)
     {
         ::SetUnhandledExceptionFilter(LLBC_INL_NS __Win32CrashHandler);
-#ifdef LLBC_RELEASE
+        #ifdef LLBC_RELEASE
         LLBC_INL_NS __PreventSetUnhandledExceptionFilter();
-#endif
+        #endif
 
         LLBC_INL_NS __hookedCrashSignals = true;
     }
@@ -474,7 +474,6 @@ __LLBC_NS_END
 #endif // Supp hook process crash
 
 #if LLBC_SUPPORT_SET_PROCESS_EXCLUSIVE
-#include <llbc/core/utils/Util_Text.h>
 #if LLBC_TARGET_PLATFORM_WIN32
 #include <psapi.h>
 #elif LLBC_TARGET_PLATFORM_MAC
@@ -492,50 +491,52 @@ int LLBC_SetProcessExclusive(const LLBC_CString &exclusiveInfoFilePath)
     // Get current execute file path.
     LLBC_String selfExeFilePath = LLBC_Directory::ModuleFilePath();
 
-	// Set exclusive info file path.
-	LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath.empty()
-		? LLBC_Directory::ModuleFilePath() + ".pid"
-		: exclusiveInfoFilePath;
+    // Set exclusive info file path.
+    LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath;
+    if (nmlExclusiveInfoFilePath.empty())
+    {
+        nmlExclusiveInfoFilePath = LLBC_Directory::Join(selfExeFilePath, LLBC_Directory::ModuleFileName());
+        nmlExclusiveInfoFilePath.append(".pid");
+    }
 
     // Create then read-lock exclusive info file.
     HANDLE exclusiveInfoFile = CreateFileA(nmlExclusiveInfoFilePath.c_str(),
-        GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ,
-        NULL,
-        OPEN_ALWAYS,
-        FILE_ATTRIBUTE_HIDDEN,
-        NULL);
+                                           GENERIC_READ | GENERIC_WRITE,
+                                           FILE_SHARE_READ,
+                                           NULL,
+                                           OPEN_ALWAYS,
+                                           FILE_ATTRIBUTE_HIDDEN,
+                                           NULL);
     LLBC_SetErrAndReturnIf(exclusiveInfoFile == INVALID_HANDLE_VALUE, LLBC_ERROR_OSAPI, LLBC_FAILED);
-    LLBC_Defer(
-        LLBC_SetErrAndReturnIf(!CloseHandle(exclusiveInfoFile), LLBC_ERROR_OSAPI,)
-    );
+    LLBC_Defer(CloseHandle(exclusiveInfoFile));
 
     // Read pid from exclusive info file.
     DWORD fileSize = GetFileSize(exclusiveInfoFile, NULL);
-    LLBC_SetErrAndReturnIf(fileSize == -1 || fileSize >= 32, LLBC_ERROR_OSAPI, LLBC_FAILED);
+    LLBC_ReturnIf(fileSize == -1, LLBC_FAILED);
 
     bool readSucc = ReadFile(exclusiveInfoFile, exclusiveInfoBuf, fileSize, &fileSize, NULL);
     LLBC_SetErrAndReturnIf(!readSucc, LLBC_ERROR_OSAPI, LLBC_FAILED);
     exclusiveInfoBuf[fileSize] = '\0';
 
     // Deal with exclusive info.
-    long exclusiveInfoPid = LLBC_Str2Long(exclusiveInfoBuf);
-    LLBC_ReturnIf(exclusiveInfoPid == getpid(), LLBC_FAILED);
+    long exclusiveInfoPid = atoi(exclusiveInfoBuf);
+    if (strlen(exclusiveInfoBuf) != 0 && exclusiveInfoPid != getpid())
+    {
+        // Open executable process by pid.
+        HANDLE processHandle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+                                           FALSE, exclusiveInfoPid);
+        if (processHandle != NULL)
+        {
+            // Get executable file path refer to pid.
+            DWORD getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
+            CloseHandle(processHandle);
+            LLBC_SetErrAndReturnIf(getModuleFileNameRet == 0, LLBC_ERROR_OSAPI, LLBC_FAILED);
+            runningExeFilePath[getModuleFileNameRet] = '\0';
+        }
 
-	// Open executable process by pid.
-	HANDLE processHandle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
-		FALSE, exclusiveInfoPid);
-	if (processHandle != NULL)
-	{
-		// Get executable file path refer to pid.
-		DWORD getModuleFileNameRet = GetModuleFileNameExA(processHandle, NULL, runningExeFilePath, MAX_PATH);
-		CloseHandle(processHandle);
-		LLBC_SetErrAndReturnIf(getModuleFileNameRet == 0, LLBC_ERROR_OSAPI, LLBC_FAILED);
-		runningExeFilePath[getModuleFileNameRet] = '\0';
-	}
-
-    // Compare self name and running process path.
-    LLBC_ReturnIf(runningExeFilePath == selfExeFilePath, LLBC_FAILED);
+        // Compare self name and running process path.
+        LLBC_ReturnIf(runningExeFilePath == selfExeFilePath, LLBC_FAILED);
+    }
 
     // Clear .pid file and write pid into it.
     SetFilePointer(exclusiveInfoFile, 0, NULL, FILE_BEGIN);
@@ -552,38 +553,40 @@ int LLBC_SetProcessExclusive(const LLBC_CString &exclusiveInfoFilePath)
     LLBC_String selfExeFilePath = LLBC_Directory::ModuleFilePath();
 
     // Set exclusive info file path.
-    LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath.empty()
-        ? LLBC_Directory::ModuleFilePath() + ".pid"
-        : exclusiveInfoFilePath;
+    LLBC_String nmlExclusiveInfoFilePath = exclusiveInfoFilePath;
+    if (nmlExclusiveInfoFilePath.empty())
+    {
+        nmlExclusiveInfoFilePath = LLBC_Directory::Join(selfExeFilePath, LLBC_Directory::ModuleFileName());
+        nmlExclusiveInfoFilePath.append(".pid");
+    }
 
     // Open exclusive info file and read pid.
     int exclusiveInfoFd = open(nmlExclusiveInfoFilePath.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
     LLBC_SetErrAndReturnIf(exclusiveInfoFd < 0, LLBC_ERROR_OSAPI, LLBC_FAILED);
-    LLBC_Defer(
-        LLBC_SetErrAndReturnIf(close(exclusiveInfoFd) == -1, LLBC_ERROR_OSAPI, )
-    );
-    LLBC_Defer();
+    LLBC_Defer(close(exclusiveInfoFd););
 
     int readRet = read(exclusiveInfoFd, exclusiveInfoBuf, MAX_INPUT);
     LLBC_SetErrAndReturnIf(readRet == -1, LLBC_ERROR_OSAPI, LLBC_FAILED);
     exclusiveInfoBuf[readRet] = '\0';
 
     // Deal with exclusive info.
-    long exclusiveInfoPid = LLBC_Str2Long(exclusiveInfoBuf);
-    LLBC_ReturnIf(exclusiveInfoPid == getpid(), LLBC_OK);
-
-	// Get executable file by pid.
+    long exclusiveInfoPid = atoi(exclusiveInfoBuf);
+    if (strlen(exclusiveInfoBuf) != 0 && exclusiveInfoPid != getpid())
+    {
+        // Get executable file by pid.
 #if LLBC_TARGET_PLATFORM_MAC
-	int pidPathRet = proc_pidpath(exclusiveInfoPid, runningExeFilePath, PATH_MAX);
-	LLBC_DoIf(pidPathRet != -1, runningExeFilePath[pidPathRet] = '\0');
+        int pidPathRet = proc_pidpath(exclusiveInfoPid, runningExeFilePath, PATH_MAX);
+        LLBC_DoIf(pidPathRet != -1, runningExeFilePath[pidPathRet] = '\0');
 #else
-	llbc::LLBC_String runingExe;
-	runingExe.format("/proc/%d/exe", exclusiveInfoPid);
-	ssize_t readLinkRet = readlink(runingExe.c_str(), runningExeFilePath, PATH_MAX);
-	LLBC_DoIf(readLinkRet != -1, runningExeFilePath[readLinkRet] = '\0');
+        llbc::LLBC_String runingExe;
+        runingExe.format("/proc/%d/exe", exclusiveInfoPid);
+        ssize_t readLinkRet = readlink(runingExe.c_str(), runningExeFilePath, PATH_MAX);
+        LLBC_DoIf(readLinkRet != -1, runningExeFilePath[readLinkRet] = '\0');
 #endif
 
-    LLBC_ReturnIf(selfExeFilePath == runningExeFilePath, LLBC_FAILED);
+        // Compare self name and running process path.
+        LLBC_ReturnIf(selfExeFilePath == runningExeFilePath, LLBC_FAILED);
+    }
 
     // Try to lock exclusive info file.
     struct flock fl;

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -566,7 +566,7 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     ssize_t readLinkRet = readlink(runingExe.c_str(), runningExeFilePath, PATH_MAX);
     LLBC_DoIf(readLinkRet != -1, runningExeFilePath[readLinkRet] = '\0');
 #endif
-    LLBC_ReturnIf(selfExeFilePath == runningExeFilePath, LLBC_FAILED);
+    LLBC_ReturnIf(strcmp(selfExeFilePath.c_str(), runningExeFilePath) == 0, LLBC_FAILED);
 
     // Try to lock pid file
     struct flock fl;

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -566,7 +566,7 @@ int LLBC_SetExclusive(const LLBC_String &pidFilePath)
     ssize_t readLinkRet = readlink(runingExe.c_str(), runningExeFilePath, PATH_MAX);
     LLBC_DoIf(readLinkRet != -1, runningExeFilePath[readLinkRet] = '\0');
 #endif
-    LLBC_ReturnIf(strcmp(selfExeFilePath.c_str(), runningExeFilePath) == 0, LLBC_FAILED);
+    LLBC_ReturnIf(selfExeFilePath.c_str() == runningExeFilePath, LLBC_FAILED);
 
     // Try to lock pid file
     struct flock fl;

--- a/testsuite/app/AppCfgTest.cfg
+++ b/testsuite/app/AppCfgTest.cfg
@@ -8,6 +8,7 @@ x.y.k = hey judy
 
 # App Fps
 Fps = 2
+Exclusive = 0
 
 # Service: TestSvc1 config.
 TestSvc1.Fps = 88

--- a/testsuite/app/AppCfgTest.ini
+++ b/testsuite/app/AppCfgTest.ini
@@ -1,5 +1,6 @@
 [App]
 fps = 44
+exclusive = 0
 
 [section_a]
 a = 3

--- a/testsuite/app/AppCfgTest.properties
+++ b/testsuite/app/AppCfgTest.properties
@@ -7,6 +7,7 @@ x.y.j = 6
 x.y.k = hey judy
 
 Fps = 2
+Exclusive = 0
 
 TestSvc1.TestCompA.a = 3
 TestSvc1.TestCompA.bb = 4

--- a/testsuite/app/AppCfgTest.xml
+++ b/testsuite/app/AppCfgTest.xml
@@ -2,6 +2,7 @@
 <b b_attr1 = "5" b_attr2 = "6" />
 
 <Fps>33</Fps>
+<Exclusive>0</Exclusive>
 
 <Service Name = "TestSvc1">
     <FPS>88</FPS>

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -26,6 +26,10 @@ int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
 {
     std::cout <<"core/os/process test:" <<std::endl;
 
+    // Test set exclusive
+    if (TestSetExclusive() != LLBC_OK)
+        return LLBC_FAILED;
+
     // Test crash hook.
     if (TestCrash() != LLBC_OK)
         return LLBC_FAILED;
@@ -83,4 +87,46 @@ void TestCase_Core_OS_Process::TestCrash_InvalidPtrRead()
     int *invalidPtr4Write = nullptr;
     std::cout << *invalidPtr4Write << std::endl;
 }
- 
+
+int TestCase_Core_OS_Process::TestSetExclusive()
+{
+    std::cout << "Set exclusive test:" << std::endl;
+
+#if LLBC_SUPPORT_SET_EXCLUSIVE
+    // Set exclusive
+    std::cout << "Set exclusive..." << std::endl;
+    if (LLBC_SetExclusive() != LLBC_OK)
+    {
+        std::cerr << "Set exclusive failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+
+#if LLBC_TARGET_PLATFORM_WIN32
+    if (LLBC_SetExclusive() == LLBC_OK)
+    {
+        std::cerr << "Another Process Set exclusive success, err:"
+                  << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+#else
+    if (fork() != -1)
+    {
+        if (LLBC_SetExclusive() == LLBC_OK)
+        {
+            std::cerr << "Another Process Set exclusive success, err:"
+                      << LLBC_FormatLastError() << std::endl;
+            exit(-1);
+        }
+    }
+    else
+    {
+        std::cout << "Fork failed!" << std::endl;
+        return LLBC_FAILED;
+    }
+#endif
+    return LLBC_OK;
+#else
+    // Unsupported set exclusive.
+    return LLBC_OK;
+#endif
+}

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -95,14 +95,14 @@ int TestCase_Core_OS_Process::TestSetExclusive()
 #if LLBC_SUPPORT_SET_EXCLUSIVE
     // Set exclusive
     std::cout << "Set exclusive..." << std::endl;
-    if (LLBC_SetExclusive() != LLBC_OK)
+    if (LLBC_SetProcessExclusive() != LLBC_OK)
     {
         std::cerr << "Set exclusive failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
 
 #if LLBC_TARGET_PLATFORM_WIN32
-    if (LLBC_SetExclusive() == LLBC_OK)
+    if (LLBC_SetProcessExclusive() == LLBC_OK)
     {
         std::cerr << "Another Process Set exclusive success, err:"
                   << LLBC_FormatLastError() << std::endl;
@@ -111,7 +111,7 @@ int TestCase_Core_OS_Process::TestSetExclusive()
 #else
     if (fork() != -1)
     {
-        if (LLBC_SetExclusive() == LLBC_OK)
+        if (LLBC_SetProcessExclusive() == LLBC_OK)
         {
             std::cerr << "Another Process Set exclusive success, err:"
                       << LLBC_FormatLastError() << std::endl;

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -92,7 +92,7 @@ int TestCase_Core_OS_Process::TestSetExclusive()
 {
     std::cout << "Set exclusive test:" << std::endl;
 
-#if LLBC_SUPPORT_SET_EXCLUSIVE
+#if LLBC_SUPPORT_SET_PROCESS_EXCLUSIVE
     // Set exclusive
     std::cout << "Set exclusive..." << std::endl;
     if (LLBC_SetProcessExclusive() != LLBC_OK)

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -101,29 +101,12 @@ int TestCase_Core_OS_Process::TestSetExclusive()
         return LLBC_FAILED;
     }
 
-#if LLBC_TARGET_PLATFORM_WIN32
     if (LLBC_SetProcessExclusive() == LLBC_OK)
     {
         std::cerr << "Another Process Set exclusive success, err:"
                   << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
-#else
-    if (fork() != -1)
-    {
-        if (LLBC_SetProcessExclusive() == LLBC_OK)
-        {
-            std::cerr << "Another Process Set exclusive success, err:"
-                      << LLBC_FormatLastError() << std::endl;
-            exit(-1);
-        }
-    }
-    else
-    {
-        std::cout << "Fork failed!" << std::endl;
-        return LLBC_FAILED;
-    }
-#endif
     return LLBC_OK;
 #else
     // Unsupported set exclusive.

--- a/testsuite/core/os/TestCase_Core_OS_Process.h
+++ b/testsuite/core/os/TestCase_Core_OS_Process.h
@@ -39,5 +39,7 @@ private:
     void TestCrash_DivisionByZero();
     void TestCrash_InvalidPtrWrite();
     void TestCrash_InvalidPtrRead();
+    
+    int TestSetExclusive();
 };
 


### PR DESCRIPTION
## 可选方案
1、文件锁
优点：
标准化实现，可拓展
tip:目录+pid保证原子性，检查/proc/<PID>/exe来保证进程指向验证
缺点：
crash之后需要额外处理(llbc不做处理，在进程启动的时候会检查并清理文件内容)
2、POSIX named semaphores
优点：
实现简单，原子性保证
缺点：
具有内核生命周期，系统重启前都无法被清理
3、bind a port
优点：
进程关闭后内核会自动关闭文件描述符，简单
如果进程本身就已经绑定了一个port，那完全无需改动
缺点：
对于不需要绑定port的进程也需要绑定port
port是系统资源，对于运行多个程序的系统，依赖单一的port不太可控
文件描述符会传递给子进程
依赖网络功能
4、mutex in shared memory
优点：
基于共享内存，原子性保证
缺点：
crash之后需要额外处理

## 方案选取
方案2，4在crash之后都会有数据残留且难以清除的问题。
接下来是在方案1和3里面选，两个方案其实都是操作系统提供的支持，一个是文件模块，一个是网络模块。
考虑到网络模块是对外模块，采用使用文件模块的方案一更稳定一些，最终决定使用方案一

## 功能实现
在Mac和Linux下：
1、判断.pid文件是否存在，存在就读取pid判断是否同名进程运行中。不存在则创建文件并直接进入下一步
2、设置.pid文件锁，写入当前进程pid到.pid文件中，释放文件锁
在Win平台下，步骤2中的设置文件锁，可以通过设置CreateFileA接口参数中的dwShareMode参数为共享读FILE_SHARE_READ只来实现。