### PR TITLE
【llbc】crash handle支持数组 

### DIFF
--- a/llbc/include/llbc/comm/ServiceImpl.h
+++ b/llbc/include/llbc/comm/ServiceImpl.h
@@ -149,6 +149,12 @@ public:
 
 public:
     /**
+     * Get service thread id
+     * @return LLBC_ThreadId - the service native thread id.
+     */
+    LLBC_ThreadId GetSvcThreadId() const;
+public:
+    /**
      * Create a session and listening.
      * Note:
      *      If service not start when call this method, connection operation will

--- a/llbc/include/llbc/comm/ServiceImplInl.h
+++ b/llbc/include/llbc/comm/ServiceImplInl.h
@@ -69,6 +69,11 @@ inline int LLBC_ServiceImpl::GetFrameInterval() const
     return fps != static_cast<int>(LLBC_INFINITE) ? 1000 / fps : 0;
 }
 
+inline LLBC_ThreadId LLBC_ServiceImpl::GetSvcThreadId() const
+{
+    return _svcThreadId;
+}
+
 inline LLBC_EventMgr &LLBC_ServiceImpl::GetEventManager()
 {
     return _evManager;

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -47,26 +47,26 @@ LLBC_EXPORT int LLBC_GetCurrentProcessId();
  *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetCrashDumpPath(const LLBC_String &dumpFilePath = "");
+LLBC_EXPORT int LLBC_SetCrashDumpFilePath(const LLBC_CString &dumpFilePath = "");
 
 /**
- * Set process crash handle
- * @param[in] crashCallback - the crash callback delegate.
- * @param[in] hookName - set hook name.
+ * Set process crash handler
+ * @param[in] crashHandlerName - set crash handler name.
+ * @param[in] crashHandler - the crash callback delegate.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetCrashHandle(const LLBC_String &hookName = "",
+LLBC_EXPORT int LLBC_SetCrashHandler(const LLBC_String &crashHandlerName = "",
                                     const LLBC_Delegate<void(const char *stackBacktrace,
-                                                             int sig)> &crashCallback = nullptr);
+                                                             int sig)> &crashHandler = nullptr);
 /**
- * Open handle crash.
+ * Enable crash handle.
  */
-LLBC_EXPORT int LLBC_OpenCrashHandle();
+LLBC_EXPORT int LLBC_EnableCrashHandle();
 
 /**
- * Cancel handle crash.
+ * Disable crash handle.
  */
-LLBC_EXPORT void LLBC_CancelCrashHandle();
+LLBC_EXPORT void LLBC_DisableCrashHandle();
 
 #endif // LLBC_SUPPORT_HANDLE_CRASH
 

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -41,21 +41,32 @@ LLBC_EXPORT int LLBC_GetCurrentProcessId();
 #if LLBC_SUPPORT_HANDLE_CRASH
 
 /**
- * Handle process crash(and set user-defined dump file path and additional crash callback).
+ * Set user-defined dump file path.
  * @param[in] dumpFilePath  - the dump file path.
  *                            in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
  *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
- * @param[in] crashCallback - the crash callback delegate.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetHandleCrash(const LLBC_String &dumpFilePath = "",
-    const LLBC_Delegate<void(const char* stackBacktrace,
-        int sig)>& crashCallback = nullptr, const LLBC_String &hookName = "");
+LLBC_EXPORT int LLBC_SetCrashDumpPath(const LLBC_String &dumpFilePath = "");
+
+/**
+ * Set process crash handle
+ * @param[in] crashCallback - the crash callback delegate.
+ * @param[in] hookName - set hook name.
+ * @return int - return 0 if success, otherwise return -1.
+ */
+LLBC_EXPORT int LLBC_SetCrashHandle(const LLBC_String &hookName = "",
+                                    const LLBC_Delegate<void(const char *stackBacktrace,
+                                                             int sig)> &crashCallback = nullptr);
+/**
+ * Open handle crash.
+ */
+LLBC_EXPORT int LLBC_OpenCrashHandle();
 
 /**
  * Cancel handle crash.
  */
-LLBC_EXPORT void LLBC_CancelHandleCrash();
+LLBC_EXPORT void LLBC_CancelCrashHandle();
 
 #endif // LLBC_SUPPORT_HANDLE_CRASH
 

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -48,9 +48,9 @@ LLBC_EXPORT int LLBC_GetCurrentProcessId();
  * @param[in] crashCallback - the crash callback delegate.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
-                                 const LLBC_Delegate<void(const char *stackBacktrace,
-                                                          int sig)> &crashCallback = nullptr);
+LLBC_EXPORT int LLBC_SetHandleCrash(const LLBC_String &dumpFilePath = "",
+    const LLBC_Delegate<void(const char* stackBacktrace,
+        int sig)>& crashCallback = nullptr, const LLBC_String &hookName = "");
 
 /**
  * Cancel handle crash.

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -245,7 +245,7 @@ int LLBC_App::Start(int argc, char *argv[], const LLBC_String &name)
     LLBC_ReturnIf(_cfgType != LLBC_AppConfigType::End && ReloadImpl(false, false) != LLBC_OK, LLBC_FAILED);
 
     // Handle progress crash.
-    LLBC_ReturnIf(LLBC_HandleCrash() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_SetHandleCrash() != LLBC_OK, LLBC_FAILED);
 
     // Install required signal handlers.
     // - App stop signals.

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -245,7 +245,7 @@ int LLBC_App::Start(int argc, char *argv[], const LLBC_String &name)
     LLBC_ReturnIf(_cfgType != LLBC_AppConfigType::End && ReloadImpl(false, false) != LLBC_OK, LLBC_FAILED);
 
     // Handle progress crash.
-    LLBC_ReturnIf(LLBC_SetHandleCrash() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
 
     // Install required signal handlers.
     // - App stop signals.
@@ -422,7 +422,7 @@ void LLBC_App::Stop()
 #endif // Non-Win32
 
     // Cancel handle crash.
-    LLBC_CancelHandleCrash();
+    LLBC_CancelCrashHandle();
 
     // Cleanup members.
     _cfgPath.clear();

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -245,7 +245,7 @@ int LLBC_App::Start(int argc, char *argv[], const LLBC_String &name)
     LLBC_ReturnIf(_cfgType != LLBC_AppConfigType::End && ReloadImpl(false, false) != LLBC_OK, LLBC_FAILED);
 
     // Handle progress crash.
-    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_EnableCrashHandle() != LLBC_OK || LLBC_SetCrashDumpFilePath() != LLBC_OK, LLBC_FAILED);
 
     // Install required signal handlers.
     // - App stop signals.
@@ -422,7 +422,7 @@ void LLBC_App::Stop()
 #endif // Non-Win32
 
     // Cancel handle crash.
-    LLBC_CancelCrashHandle();
+    LLBC_DisableCrashHandle();
 
     // Cleanup members.
     _cfgPath.clear();

--- a/llbc/src/core/Core.cpp
+++ b/llbc/src/core/Core.cpp
@@ -113,7 +113,7 @@ void __LLBC_CoreCleanup()
 
     // Cancel handle crash.
     #if LLBC_SUPPORT_HANDLE_CRASH
-    LLBC_CancelCrashHandle();
+    LLBC_DisableCrashHandle();
     #endif // LLBC_SUPPORT_HANDLE_CRASH
 }
 

--- a/llbc/src/core/Core.cpp
+++ b/llbc/src/core/Core.cpp
@@ -113,7 +113,7 @@ void __LLBC_CoreCleanup()
 
     // Cancel handle crash.
     #if LLBC_SUPPORT_HANDLE_CRASH
-    LLBC_CancelHandleCrash();
+    LLBC_CancelCrashHandle();
     #endif // LLBC_SUPPORT_HANDLE_CRASH
 }
 

--- a/testsuite/TestSuite.cpp
+++ b/testsuite/TestSuite.cpp
@@ -49,7 +49,7 @@
 int TestSuite_Main(int argc, char* argv[])
 {
     LLBC_Startup();
-    LLBC_HandleCrash();
+    LLBC_SetHandleCrash();
     __TraitsLoop<__TEST_CASE_COUNT>::Generate();
 
     while (true)

--- a/testsuite/TestSuite.cpp
+++ b/testsuite/TestSuite.cpp
@@ -50,7 +50,7 @@ int TestSuite_Main(int argc, char* argv[])
 {
     LLBC_Startup();
 
-    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_EnableCrashHandle() != LLBC_OK || LLBC_SetCrashDumpFilePath() != LLBC_OK, LLBC_FAILED);
 
     __TraitsLoop<__TEST_CASE_COUNT>::Generate();
 

--- a/testsuite/TestSuite.cpp
+++ b/testsuite/TestSuite.cpp
@@ -49,7 +49,9 @@
 int TestSuite_Main(int argc, char* argv[])
 {
     LLBC_Startup();
-    LLBC_SetHandleCrash();
+
+    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
+
     __TraitsLoop<__TEST_CASE_COUNT>::Generate();
 
     while (true)

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -51,13 +51,34 @@ int TestCase_Core_OS_Process::TestCrash()
 #if LLBC_SUPPORT_HANDLE_CRASH
     // Set crash hook handle array
     std::cout << "Handle crash..." << std::endl;
-    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test") != LLBC_OK)
+    // open crash handle
+    if(LLBC_OpenCrashHandle() != LLBC_OK)
+    {
+        std::cerr << "Open handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+
+    //set crash dump path
+    if (LLBC_SetCrashDumpPath() != LLBC_OK)
+    {
+        std::cerr << "Set dump file path failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+    
+    //set crash hook1
+    if (LLBC_SetCrashHandle("hook_test", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 1 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
-
-    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test2") != LLBC_OK)
+    //set crash hook2
+    if (LLBC_SetCrashHandle("hook_test2", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    {
+        std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+    //set crash hook3
+    if (LLBC_SetCrashHandle("hook_test3", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -22,6 +22,8 @@
 
 #include "core/os/TestCase_Core_OS_Process.h"
 
+static int __Test_Os_Process_Hook_Times = 0;
+
 int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
 {
     std::cout <<"core/os/process test:" <<std::endl;
@@ -36,16 +38,28 @@ int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
     return 0;
 }
 
+static void TestCase_Core_OS_Process_Crash_Hook_test(const char* traceback, int sig)
+{
+    std::cout << std::endl;
+    std::cout << "TestCase_Core_OS_Process_Crash_Hook_test success. times:" << __Test_Os_Process_Hook_Times++ << std::endl;
+}
+
 int TestCase_Core_OS_Process::TestCrash()
 {
     std::cout << "Crash hook test:" << std::endl;
 
 #if LLBC_SUPPORT_HANDLE_CRASH
-    // Set crash hook.
+    // Set crash hook handle array
     std::cout << "Handle crash..." << std::endl;
-    if (LLBC_HandleCrash() != LLBC_OK)
+    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test") != LLBC_OK)
     {
-        std::cerr << "Handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
+        std::cerr << "Handle crash 1 failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+
+    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test2") != LLBC_OK)
+    {
+        std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
 

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -38,7 +38,7 @@ int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
     return 0;
 }
 
-static void TestCase_Core_OS_Process_Crash_Hook_test(const char* traceback, int sig)
+static void TestCase_Core_OS_Process_Crash_Hook_test(const char *traceback, int sig)
 {
     std::cout << std::endl;
     std::cout << "TestCase_Core_OS_Process_Crash_Hook_test success. times:" << __Test_Os_Process_Hook_Times++ << std::endl;
@@ -49,36 +49,36 @@ int TestCase_Core_OS_Process::TestCrash()
     std::cout << "Crash hook test:" << std::endl;
 
 #if LLBC_SUPPORT_HANDLE_CRASH
-    // Set crash hook handle array
+    // Set crash hook handle list
     std::cout << "Handle crash..." << std::endl;
-    // open crash handle
-    if(LLBC_OpenCrashHandle() != LLBC_OK)
+    // enable crash handle
+    if(LLBC_EnableCrashHandle() != LLBC_OK)
     {
         std::cerr << "Open handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
 
-    //set crash dump path
-    if (LLBC_SetCrashDumpPath() != LLBC_OK)
+    //set crash dump filepath
+    if (LLBC_SetCrashDumpFilePath() != LLBC_OK)
     {
         std::cerr << "Set dump file path failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
     
     //set crash hook1
-    if (LLBC_SetCrashHandle("hook_test", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    if (LLBC_SetCrashHandler("hook_test", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 1 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
     //set crash hook2
-    if (LLBC_SetCrashHandle("hook_test2", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    if (LLBC_SetCrashHandler("hook_test2", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
     //set crash hook3
-    if (LLBC_SetCrashHandle("hook_test3", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    if (LLBC_SetCrashHandler("hook_test3", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;

--- a/wrap/pyllbc/src/app/_App.h
+++ b/wrap/pyllbc/src/app/_App.h
@@ -29,7 +29,7 @@ LLBC_EXTERN_C PyObject *_pyllbc_HandleCrash(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &dumpFile))
         return nullptr;
 
-    if (LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath(dumpFile) != LLBC_OK)
+    if (LLBC_EnableCrashHandle() != LLBC_OK || LLBC_SetCrashDumpFilePath(dumpFile) != LLBC_OK)
     {
         pyllbc_TransferLLBCError(__FILE__, __LINE__, "When set dump file");
         return nullptr;

--- a/wrap/pyllbc/src/app/_App.h
+++ b/wrap/pyllbc/src/app/_App.h
@@ -29,7 +29,7 @@ LLBC_EXTERN_C PyObject *_pyllbc_HandleCrash(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &dumpFile))
         return nullptr;
 
-    if (LLBC_HandleCrash(dumpFile) != LLBC_OK)
+    if (LLBC_SetHandleCrash(dumpFile) != LLBC_OK)
     {
         pyllbc_TransferLLBCError(__FILE__, __LINE__, "When set dump file");
         return nullptr;

--- a/wrap/pyllbc/src/app/_App.h
+++ b/wrap/pyllbc/src/app/_App.h
@@ -29,7 +29,7 @@ LLBC_EXTERN_C PyObject *_pyllbc_HandleCrash(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &dumpFile))
         return nullptr;
 
-    if (LLBC_SetHandleCrash(dumpFile) != LLBC_OK)
+    if (LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath(dumpFile) != LLBC_OK)
     {
         pyllbc_TransferLLBCError(__FILE__, __LINE__, "When set dump file");
         return nullptr;


### PR DESCRIPTION
如题，改动如下：
1.修改crash时候hook函数为数组，支持不同业务模块Set CrashHook函数
2.增加TestCase_Core_OS_Process set多crash hook函数用例
2.增加ServiceImpl::GetSvcThreadId接口
3.其他细节优化