### PR TITLE
【llbc】crash handle支持数组

### DIFF
--- a/llbc/include/llbc/comm/ServiceImpl.h
+++ b/llbc/include/llbc/comm/ServiceImpl.h
@@ -149,6 +149,12 @@ public:
 
 public:
     /**
+     * Get service thread id
+     * @return LLBC_ThreadId - the service native thread id.
+     */
+    LLBC_ThreadId GetSvcThreadId() const;
+public:
+    /**
      * Create a session and listening.
      * Note:
      *      If service not start when call this method, connection operation will

--- a/llbc/include/llbc/comm/ServiceImpl.h
+++ b/llbc/include/llbc/comm/ServiceImpl.h
@@ -147,12 +147,12 @@ public:
      */
     int GetFrameInterval() const override;
 
-public:
     /**
      * Get service thread id
-     * @return LLBC_ThreadId - the service native thread id.
+     * @return LLBC_ThreadId - the service thread id.
      */
-    LLBC_ThreadId GetSvcThreadId() const;
+    LLBC_ThreadId GetServiceThreadId() const;
+    
 public:
     /**
      * Create a session and listening.
@@ -598,7 +598,7 @@ private:
     int _id; // Service Id.
     LLBC_String _name; // Service Name.
     LLBC_ServiceDriveMode::ENUM _driveMode; // Drive mode(ExternalDrive or InternalDrive).
-    LLBC_ThreadId _svcThreadId; // Service thread Id(which thread drive this service).
+    volatile LLBC_ThreadId _svcThreadId; // Service thread Id(which thread drive this service).
     volatile bool _inCleaning; // Cleaning flag.
     volatile bool _sinkIntoOnSvcLoop; // Sink into OnSvc() loop flag.
     LLBC_ServiceMgr &_svcMgr; // Owned service manager.

--- a/llbc/include/llbc/comm/ServiceImplInl.h
+++ b/llbc/include/llbc/comm/ServiceImplInl.h
@@ -69,6 +69,11 @@ inline int LLBC_ServiceImpl::GetFrameInterval() const
     return fps != static_cast<int>(LLBC_INFINITE) ? 1000 / fps : 0;
 }
 
+inline LLBC_ThreadId LLBC_ServiceImpl::GetSvcThreadId() const
+{
+    return _svcThreadId;
+}
+
 inline LLBC_EventMgr &LLBC_ServiceImpl::GetEventManager()
 {
     return _evManager;

--- a/llbc/include/llbc/comm/ServiceImplInl.h
+++ b/llbc/include/llbc/comm/ServiceImplInl.h
@@ -69,7 +69,7 @@ inline int LLBC_ServiceImpl::GetFrameInterval() const
     return fps != static_cast<int>(LLBC_INFINITE) ? 1000 / fps : 0;
 }
 
-inline LLBC_ThreadId LLBC_ServiceImpl::GetSvcThreadId() const
+inline LLBC_ThreadId LLBC_ServiceImpl::GetServiceThreadId() const
 {
     return _svcThreadId;
 }

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -41,21 +41,32 @@ LLBC_EXPORT int LLBC_GetCurrentProcessId();
 #if LLBC_SUPPORT_HANDLE_CRASH
 
 /**
- * Handle process crash(and set user-defined dump file path and additional crash callback).
+ * Set user-defined dump file path.
  * @param[in] dumpFilePath  - the dump file path.
  *                            in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
  *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
- * @param[in] crashCallback - the crash callback delegate.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetHandleCrash(const LLBC_String &dumpFilePath = "",
-    const LLBC_Delegate<void(const char* stackBacktrace,
-        int sig)>& crashCallback = nullptr, const LLBC_String &hookName = "");
+LLBC_EXPORT int LLBC_SetCrashDumpPath(const LLBC_String &dumpFilePath = "");
+
+/**
+ * Set process crash handle
+ * @param[in] crashCallback - the crash callback delegate.
+ * @param[in] hookName - set hook name.
+ * @return int - return 0 if success, otherwise return -1.
+ */
+LLBC_EXPORT int LLBC_SetCrashHandle(const LLBC_String &hookName = "",
+                                    const LLBC_Delegate<void(const char *stackBacktrace,
+                                                             int sig)> &crashCallback = nullptr);
+/**
+ * Open handle crash.
+ */
+LLBC_EXPORT int LLBC_OpenCrashHandle();
 
 /**
  * Cancel handle crash.
  */
-LLBC_EXPORT void LLBC_CancelHandleCrash();
+LLBC_EXPORT void LLBC_CancelCrashHandle();
 
 #endif // LLBC_SUPPORT_HANDLE_CRASH
 

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -48,9 +48,9 @@ LLBC_EXPORT int LLBC_GetCurrentProcessId();
  * @param[in] crashCallback - the crash callback delegate.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
-                                 const LLBC_Delegate<void(const char *stackBacktrace,
-                                                          int sig)> &crashCallback = nullptr);
+LLBC_EXPORT int LLBC_SetHandleCrash(const LLBC_String &dumpFilePath = "",
+    const LLBC_Delegate<void(const char* stackBacktrace,
+        int sig)>& crashCallback = nullptr, const LLBC_String &hookName = "");
 
 /**
  * Cancel handle crash.

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -47,26 +47,26 @@ LLBC_EXPORT int LLBC_GetCurrentProcessId();
  *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetCrashDumpPath(const LLBC_String &dumpFilePath = "");
+LLBC_EXPORT int LLBC_SetCrashDumpFilePath(const LLBC_CString &dumpFilePath = "");
 
 /**
- * Set process crash handle
- * @param[in] crashCallback - the crash callback delegate.
- * @param[in] hookName - set hook name.
+ * Set process crash handler
+ * @param[in] crashHandlerName - set crash handler name.
+ * @param[in] crashHandler - the crash callback delegate.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_SetCrashHandle(const LLBC_String &hookName = "",
-                                    const LLBC_Delegate<void(const char *stackBacktrace,
-                                                             int sig)> &crashCallback = nullptr);
+LLBC_EXPORT int LLBC_SetCrashHandler(const LLBC_CString &crashHandlerName = "",
+                                     const LLBC_Delegate<void(const char *stackBacktrace,
+                                                             int sig)> &crashHandler = nullptr);
 /**
- * Open handle crash.
+ * Enable crash handle.
  */
-LLBC_EXPORT int LLBC_OpenCrashHandle();
+LLBC_EXPORT int LLBC_EnableCrashHandle();
 
 /**
- * Cancel handle crash.
+ * Disable crash handle.
  */
-LLBC_EXPORT void LLBC_CancelCrashHandle();
+LLBC_EXPORT void LLBC_DisableCrashHandle();
 
 #endif // LLBC_SUPPORT_HANDLE_CRASH
 

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -245,7 +245,7 @@ int LLBC_App::Start(int argc, char *argv[], const LLBC_String &name)
     LLBC_ReturnIf(_cfgType != LLBC_AppConfigType::End && ReloadImpl(false, false) != LLBC_OK, LLBC_FAILED);
 
     // Handle progress crash.
-    LLBC_ReturnIf(LLBC_HandleCrash() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_SetHandleCrash() != LLBC_OK, LLBC_FAILED);
 
     // Install required signal handlers.
     // - App stop signals.

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -245,7 +245,7 @@ int LLBC_App::Start(int argc, char *argv[], const LLBC_String &name)
     LLBC_ReturnIf(_cfgType != LLBC_AppConfigType::End && ReloadImpl(false, false) != LLBC_OK, LLBC_FAILED);
 
     // Handle progress crash.
-    LLBC_ReturnIf(LLBC_SetHandleCrash() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
 
     // Install required signal handlers.
     // - App stop signals.
@@ -422,7 +422,7 @@ void LLBC_App::Stop()
 #endif // Non-Win32
 
     // Cancel handle crash.
-    LLBC_CancelHandleCrash();
+    LLBC_CancelCrashHandle();
 
     // Cleanup members.
     _cfgPath.clear();

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -245,7 +245,7 @@ int LLBC_App::Start(int argc, char *argv[], const LLBC_String &name)
     LLBC_ReturnIf(_cfgType != LLBC_AppConfigType::End && ReloadImpl(false, false) != LLBC_OK, LLBC_FAILED);
 
     // Handle progress crash.
-    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_EnableCrashHandle() != LLBC_OK || LLBC_SetCrashDumpFilePath() != LLBC_OK, LLBC_FAILED);
 
     // Install required signal handlers.
     // - App stop signals.
@@ -422,7 +422,7 @@ void LLBC_App::Stop()
 #endif // Non-Win32
 
     // Cancel handle crash.
-    LLBC_CancelCrashHandle();
+    LLBC_DisableCrashHandle();
 
     // Cleanup members.
     _cfgPath.clear();

--- a/llbc/src/core/Core.cpp
+++ b/llbc/src/core/Core.cpp
@@ -113,7 +113,7 @@ void __LLBC_CoreCleanup()
 
     // Cancel handle crash.
     #if LLBC_SUPPORT_HANDLE_CRASH
-    LLBC_CancelCrashHandle();
+    LLBC_DisableCrashHandle();
     #endif // LLBC_SUPPORT_HANDLE_CRASH
 }
 

--- a/llbc/src/core/Core.cpp
+++ b/llbc/src/core/Core.cpp
@@ -113,7 +113,7 @@ void __LLBC_CoreCleanup()
 
     // Cancel handle crash.
     #if LLBC_SUPPORT_HANDLE_CRASH
-    LLBC_CancelHandleCrash();
+    LLBC_CancelCrashHandle();
     #endif // LLBC_SUPPORT_HANDLE_CRASH
 }
 

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -55,17 +55,10 @@ __LLBC_INTERNAL_NS_BEGIN
 static bool __hookedCrashSignals = false;
 static char __stackBacktrace[128 * 1024 + 1] {'\0'};
 
-struct OS_ProcessCrashHook
-{
-    LLBC_NS LLBC_String hookName_ = "";
-    LLBC_NS LLBC_Delegate<void(const char* stackBacktrace, int sig)> crashCallback_ = nullptr;
-};
-
-#define MAX_CRASH_CALLBACK_ARRAY_LENGTH 3
-static int __crashCallbackCount = 0;
-static OS_ProcessCrashHook __crashCallbacks[MAX_CRASH_CALLBACK_ARRAY_LENGTH];
-
-static LLBC_NS LLBC_SpinLock __CrashHandleLock;
+static LLBC_NS LLBC_SpinLock __crashInfoLock;
+typedef std::pair<LLBC_NS LLBC_String, 
+                  LLBC_NS LLBC_Delegate<void(const char *stackBacktrace, int sig)>> CrashHandlerInfo;
+std::list<CrashHandlerInfo> __crashHandlerInfos;
 
 __LLBC_INTERNAL_NS_END
 
@@ -209,14 +202,11 @@ static LONG WINAPI __Win32CrashHandler(::EXCEPTION_POINTERS *exception)
     mbTitle.format("Unhandled Exception(%s)", LLBC_NS LLBC_Directory::ModuleFileName().c_str());
     ::MessageBoxA(nullptr, errMsg.c_str(), mbTitle.c_str(), MB_ICONERROR | MB_OK);
 
-    for(size_t i = 0; i < static_cast<size_t>(LLBC_INL_NS __crashCallbackCount) && i < MAX_CRASH_CALLBACK_ARRAY_LENGTH; i++)
+    for (auto &crashHanlderInfo : LLBC_INL_NS __crashHandlerInfos)
     {
-        if (LLBC_INL_NS __crashCallbacks[i].crashCallback_)
-        {
-            LLBC_INL_NS __crashCallbacks[i].crashCallback_(__stackBacktrace, 0);
-        }
+        crashHanlderInfo.second(__stackBacktrace, 0);
     }
-
+    
     LLBC_LoggerMgrSingleton->Finalize();
 
     return EXCEPTION_EXECUTE_HANDLER;
@@ -405,7 +395,7 @@ static void __NonWin32CrashHandler(int sig)
     }
 
     // Call callback delegate.
-    if (LLBC_INL_NS __crashCallbackCount > 0)
+    if (LLBC_INL_NS __crashHandlerInfos.size() > 0)
     {
         if (lseek(coreDescFileFd, 0, SEEK_SET) == -1)
         {
@@ -419,12 +409,9 @@ static void __NonWin32CrashHandler(int sig)
 
         close(coreDescFileFd);
 
-        for(size_t i = 0; i < static_cast<size_t>(LLBC_INL_NS __crashCallbackCount) && i < MAX_CRASH_CALLBACK_ARRAY_LENGTH; i++)
+        for (auto &crashHanlderInfo : LLBC_INL_NS __crashHandlerInfos)
         {
-            if (LLBC_INL_NS __crashCallbacks[i].crashCallback_)
-            {
-                LLBC_INL_NS __crashCallbacks[i].crashCallback_(__stackBacktrace, sig);
-            }
+            crashHanlderInfo.second(__stackBacktrace, sig);
         }
     }
     else
@@ -444,9 +431,9 @@ __LLBC_INTERNAL_NS_END
 
 __LLBC_NS_BEGIN
 
-int LLBC_SetCrashDumpPath(const LLBC_String& dumpFilePath)
+int LLBC_SetCrashDumpFilePath(const LLBC_CString &dumpFilePath)
 {
-    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __CrashHandleLock);
+    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __crashInfoLock);
     
 #if LLBC_TARGET_PLATFORM_WIN32
     LLBC_String nmlDumpFilePath = dumpFilePath;
@@ -455,8 +442,8 @@ int LLBC_SetCrashDumpPath(const LLBC_String& dumpFilePath)
         const auto now = LLBC_Time::Now();
         nmlDumpFilePath = LLBC_Directory::SplitExt(LLBC_Directory::ModuleFilePath())[0];
         nmlDumpFilePath.append_format("_%d_%s.dmp",
-            LLBC_GetCurrentProcessId(),
-            now.Format("%Y%m%d_%H%M%S").c_str());
+                                      LLBC_GetCurrentProcessId(),
+                                      now.Format("%Y%m%d_%H%M%S").c_str());
     }
 
     if (nmlDumpFilePath.size() >= sizeof(LLBC_INL_NS __dumpFilePath))
@@ -505,48 +492,32 @@ int LLBC_SetCrashDumpPath(const LLBC_String& dumpFilePath)
 #endif // Win32
 }
 
-int LLBC_SetCrashHandle(const LLBC_String &hookName,
-                        const LLBC_Delegate<void(const char *stackBacktrace, int sig)> &crashCallback)
+int LLBC_SetCrashHandler(const LLBC_CString &crashHandlerName,
+                         const LLBC_Delegate<void(const char *stackBacktrace, int sig)> &crashHandler)
 {
 
 #if LLBC_TARGET_PLATFORM_WIN32 || LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
+    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __crashInfoLock);
 
-    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __CrashHandleLock);
+    auto foundIt = std::find_if(LLBC_INL_NS __crashHandlerInfos.begin(),
+                                LLBC_INL_NS __crashHandlerInfos.end(),
+                                [&crashHandlerName](const LLBC_INL_NS CrashHandlerInfo &info) {
+                                    return info.first == crashHandlerName;
+                                });
 
-    size_t needDeleteIdx = SIZE_MAX;
-    bool found = false;
-    for (size_t i = 0; i < static_cast<size_t>(LLBC_INL_NS __crashCallbackCount) && i < MAX_CRASH_CALLBACK_ARRAY_LENGTH; i++)
+    if (foundIt == LLBC_INL_NS __crashHandlerInfos.end())
     {
-        if (LLBC_INL_NS __crashCallbacks[i].hookName_ == hookName)
-        {
-            if (crashCallback)
-                LLBC_INL_NS __crashCallbacks[i].crashCallback_ = crashCallback;
-            else
-                needDeleteIdx = i;
-            
-            found = true;
-            break;
-        }
-    }
-
-    if (!found)
-    {
-        if (LLBC_INL_NS __crashCallbackCount >= MAX_CRASH_CALLBACK_ARRAY_LENGTH)
-        {
-            LLBC_SetLastError(LLBC_ERROR_LIMIT);
-            return LLBC_FAILED;
-        }
-        LLBC_INL_NS __crashCallbacks[LLBC_INL_NS __crashCallbackCount].hookName_ = hookName;
-        LLBC_INL_NS __crashCallbacks[LLBC_INL_NS __crashCallbackCount].crashCallback_ = crashCallback;
-        LLBC_INL_NS __crashCallbackCount++;
+        LLBC_INL_NS __crashHandlerInfos.emplace_back(crashHandlerName, crashHandler);
         return LLBC_OK;
     }
 
-    if (needDeleteIdx != SIZE_MAX)
+    if(crashHandler == nullptr)
     {
-        LLBC_INL_NS __crashCallbacks[needDeleteIdx] = LLBC_INL_NS __crashCallbacks[LLBC_INL_NS __crashCallbackCount - 1];
-        LLBC_INL_NS __crashCallbackCount--;
+        LLBC_INL_NS __crashHandlerInfos.erase(foundIt);
+        return LLBC_OK;
     }
+
+    (*foundIt).second = crashHandler;
 
     return LLBC_OK;
 
@@ -556,9 +527,9 @@ int LLBC_SetCrashHandle(const LLBC_String &hookName,
 #endif // Win32
 }
 
-int LLBC_OpenCrashHandle()
+int LLBC_EnableCrashHandle()
 {
-    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __CrashHandleLock);
+    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __crashInfoLock);
 
 #if LLBC_TARGET_PLATFORM_WIN32
     if (!LLBC_INL_NS __hookedCrashSignals)
@@ -581,7 +552,7 @@ int LLBC_OpenCrashHandle()
         struct sigaction sa;
         memset(&sa, 0, sizeof(sa));
         sa.sa_handler = LLBC_INL_NS __NonWin32CrashHandler;
-        for (auto& sig : LLBC_INL_NS __crashSignals)
+        for (auto &sig : LLBC_INL_NS __crashSignals)
         {
             sigaddset(&ss, sig);
             sigaction(sig, &sa, nullptr);
@@ -600,9 +571,9 @@ int LLBC_OpenCrashHandle()
 #endif // Win32
 }
 
-void LLBC_CancelCrashHandle()
+void LLBC_DisableCrashHandle()
 {
-    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __CrashHandleLock);
+    LLBC_NS LLBC_LockGuard guard(LLBC_INL_NS __crashInfoLock);
 
     if (!LLBC_INL_NS __hookedCrashSignals)
         return;

--- a/testsuite/TestSuite.cpp
+++ b/testsuite/TestSuite.cpp
@@ -49,7 +49,7 @@
 int TestSuite_Main(int argc, char* argv[])
 {
     LLBC_Startup();
-    LLBC_HandleCrash();
+    LLBC_SetHandleCrash();
     __TraitsLoop<__TEST_CASE_COUNT>::Generate();
 
     while (true)

--- a/testsuite/TestSuite.cpp
+++ b/testsuite/TestSuite.cpp
@@ -50,7 +50,7 @@ int TestSuite_Main(int argc, char* argv[])
 {
     LLBC_Startup();
 
-    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_EnableCrashHandle() != LLBC_OK || LLBC_SetCrashDumpFilePath() != LLBC_OK, LLBC_FAILED);
 
     __TraitsLoop<__TEST_CASE_COUNT>::Generate();
 

--- a/testsuite/TestSuite.cpp
+++ b/testsuite/TestSuite.cpp
@@ -49,7 +49,9 @@
 int TestSuite_Main(int argc, char* argv[])
 {
     LLBC_Startup();
-    LLBC_SetHandleCrash();
+
+    LLBC_ReturnIf(LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath() != LLBC_OK, LLBC_FAILED);
+
     __TraitsLoop<__TEST_CASE_COUNT>::Generate();
 
     while (true)

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -51,13 +51,34 @@ int TestCase_Core_OS_Process::TestCrash()
 #if LLBC_SUPPORT_HANDLE_CRASH
     // Set crash hook handle array
     std::cout << "Handle crash..." << std::endl;
-    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test") != LLBC_OK)
+    // open crash handle
+    if(LLBC_OpenCrashHandle() != LLBC_OK)
+    {
+        std::cerr << "Open handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+
+    //set crash dump path
+    if (LLBC_SetCrashDumpPath() != LLBC_OK)
+    {
+        std::cerr << "Set dump file path failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+    
+    //set crash hook1
+    if (LLBC_SetCrashHandle("hook_test", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 1 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
-
-    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test2") != LLBC_OK)
+    //set crash hook2
+    if (LLBC_SetCrashHandle("hook_test2", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    {
+        std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+    //set crash hook3
+    if (LLBC_SetCrashHandle("hook_test3", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -22,6 +22,8 @@
 
 #include "core/os/TestCase_Core_OS_Process.h"
 
+static int __Test_Os_Process_Hook_Times = 0;
+
 int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
 {
     std::cout <<"core/os/process test:" <<std::endl;
@@ -36,16 +38,28 @@ int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
     return 0;
 }
 
+static void TestCase_Core_OS_Process_Crash_Hook_test(const char* traceback, int sig)
+{
+    std::cout << std::endl;
+    std::cout << "TestCase_Core_OS_Process_Crash_Hook_test success. times:" << __Test_Os_Process_Hook_Times++ << std::endl;
+}
+
 int TestCase_Core_OS_Process::TestCrash()
 {
     std::cout << "Crash hook test:" << std::endl;
 
 #if LLBC_SUPPORT_HANDLE_CRASH
-    // Set crash hook.
+    // Set crash hook handle array
     std::cout << "Handle crash..." << std::endl;
-    if (LLBC_HandleCrash() != LLBC_OK)
+    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test") != LLBC_OK)
     {
-        std::cerr << "Handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
+        std::cerr << "Handle crash 1 failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+
+    if (LLBC_SetHandleCrash("", TestCase_Core_OS_Process_Crash_Hook_test, "hook_test2") != LLBC_OK)
+    {
+        std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
 

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -38,7 +38,7 @@ int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
     return 0;
 }
 
-static void TestCase_Core_OS_Process_Crash_Hook_test(const char* traceback, int sig)
+static void TestCase_Core_OS_Process_Crash_Hook_test(const char *traceback, int sig)
 {
     std::cout << std::endl;
     std::cout << "TestCase_Core_OS_Process_Crash_Hook_test success. times:" << __Test_Os_Process_Hook_Times++ << std::endl;
@@ -49,36 +49,36 @@ int TestCase_Core_OS_Process::TestCrash()
     std::cout << "Crash hook test:" << std::endl;
 
 #if LLBC_SUPPORT_HANDLE_CRASH
-    // Set crash hook handle array
+    // Set crash hook handle list
     std::cout << "Handle crash..." << std::endl;
-    // open crash handle
-    if(LLBC_OpenCrashHandle() != LLBC_OK)
+    // enable crash handle
+    if(LLBC_EnableCrashHandle() != LLBC_OK)
     {
         std::cerr << "Open handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
 
-    //set crash dump path
-    if (LLBC_SetCrashDumpPath() != LLBC_OK)
+    //set crash dump filepath
+    if (LLBC_SetCrashDumpFilePath() != LLBC_OK)
     {
         std::cerr << "Set dump file path failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
     
     //set crash hook1
-    if (LLBC_SetCrashHandle("hook_test", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    if (LLBC_SetCrashHandler("hook_test", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 1 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
     //set crash hook2
-    if (LLBC_SetCrashHandle("hook_test2", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    if (LLBC_SetCrashHandler("hook_test2", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
     //set crash hook3
-    if (LLBC_SetCrashHandle("hook_test3", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    if (LLBC_SetCrashHandler("hook_test3", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
     {
         std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;

--- a/wrap/pyllbc/src/app/_App.h
+++ b/wrap/pyllbc/src/app/_App.h
@@ -29,7 +29,7 @@ LLBC_EXTERN_C PyObject *_pyllbc_HandleCrash(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &dumpFile))
         return nullptr;
 
-    if (LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath(dumpFile) != LLBC_OK)
+    if (LLBC_EnableCrashHandle() != LLBC_OK || LLBC_SetCrashDumpFilePath(dumpFile) != LLBC_OK)
     {
         pyllbc_TransferLLBCError(__FILE__, __LINE__, "When set dump file");
         return nullptr;

--- a/wrap/pyllbc/src/app/_App.h
+++ b/wrap/pyllbc/src/app/_App.h
@@ -29,7 +29,7 @@ LLBC_EXTERN_C PyObject *_pyllbc_HandleCrash(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &dumpFile))
         return nullptr;
 
-    if (LLBC_HandleCrash(dumpFile) != LLBC_OK)
+    if (LLBC_SetHandleCrash(dumpFile) != LLBC_OK)
     {
         pyllbc_TransferLLBCError(__FILE__, __LINE__, "When set dump file");
         return nullptr;

--- a/wrap/pyllbc/src/app/_App.h
+++ b/wrap/pyllbc/src/app/_App.h
@@ -29,7 +29,7 @@ LLBC_EXTERN_C PyObject *_pyllbc_HandleCrash(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &dumpFile))
         return nullptr;
 
-    if (LLBC_SetHandleCrash(dumpFile) != LLBC_OK)
+    if (LLBC_OpenCrashHandle() != LLBC_OK || LLBC_SetCrashDumpPath(dumpFile) != LLBC_OK)
     {
         pyllbc_TransferLLBCError(__FILE__, __LINE__, "When set dump file");
         return nullptr;


### PR DESCRIPTION
如题，改动如下：
1.修改crash时候hook函数为数组，支持不同业务模块Set CrashHook函数
2.增加TestCase_Core_OS_Process set多crash hook函数用例
2.增加ServiceImpl::GetSvcThreadId接口
3.其他细节优化