### PR TITLE
feat: crash handle支持数组 

### DIFF
--- a/llbc/include/llbc/comm/ServiceImpl.h
+++ b/llbc/include/llbc/comm/ServiceImpl.h
@@ -147,6 +147,12 @@ public:
      */
     int GetFrameInterval() const override;
 
+    /**
+     * Get service thread id.
+     * @return LLBC_ThreadId - the service thread id.
+     */
+    LLBC_ThreadId GetServiceThreadId() const;
+    
 public:
     /**
      * Create a session and listening.
@@ -592,7 +598,7 @@ private:
     int _id; // Service Id.
     LLBC_String _name; // Service Name.
     LLBC_ServiceDriveMode::ENUM _driveMode; // Drive mode(ExternalDrive or InternalDrive).
-    LLBC_ThreadId _svcThreadId; // Service thread Id(which thread drive this service).
+    volatile LLBC_ThreadId _svcThreadId; // Service thread Id(which thread drive this service).
     volatile bool _inCleaning; // Cleaning flag.
     volatile bool _sinkIntoOnSvcLoop; // Sink into OnSvc() loop flag.
     LLBC_ServiceMgr &_svcMgr; // Owned service manager.

--- a/llbc/include/llbc/comm/ServiceImplInl.h
+++ b/llbc/include/llbc/comm/ServiceImplInl.h
@@ -69,6 +69,11 @@ inline int LLBC_ServiceImpl::GetFrameInterval() const
     return fps != static_cast<int>(LLBC_INFINITE) ? 1000 / fps : 0;
 }
 
+inline LLBC_ThreadId LLBC_ServiceImpl::GetServiceThreadId() const
+{
+    return _svcThreadId;
+}
+
 inline LLBC_EventMgr &LLBC_ServiceImpl::GetEventManager()
 {
     return _evManager;

--- a/llbc/include/llbc/core/os/OS_Process.h
+++ b/llbc/include/llbc/core/os/OS_Process.h
@@ -41,21 +41,50 @@ LLBC_EXPORT int LLBC_GetCurrentProcessId();
 #if LLBC_SUPPORT_HANDLE_CRASH
 
 /**
- * Handle process crash(and set user-defined dump file path and additional crash callback).
- * @param[in] dumpFilePath  - the dump file path.
- *                            in Windows platform, is a dump file path, if is empty, dump file path is <your_app_path>.dmp.
- *                            in Non-Windows platform, is a core pattern, if is empty, will use system default config.
- * @param[in] crashCallback - the crash callback delegate.
+ * Prepare crash handle env. Include：
+ * 1) allocate crash handle lock and crash handler infos container;
+ * 2) set default dump file path:
+ *      -in Windows platform, set default dump file path is <your_app_path>.dmp.
+ *      -in Non-Windows platform, default dump file path use system default config.
  * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT int LLBC_HandleCrash(const LLBC_String &dumpFilePath = "",
-                                 const LLBC_Delegate<void(const char *stackBacktrace,
-                                                          int sig)> &crashCallback = nullptr);
+LLBC_HIDDEN int __LLBC_PrepareCrashHandleEnv();
 
 /**
- * Cancel handle crash.
+ * Clean up crash handle env. Include:
+ * 1) free crash handle lock and crash handler infos container;
+ * 2) reset default dump file path:
+ * @return int - return 0 if success, otherwise return -1.
  */
-LLBC_EXPORT void LLBC_CancelHandleCrash();
+LLBC_HIDDEN int __LLBC_CleanUpCrashHandleEnv();
+
+/**
+ * Set user-defined crash dump file path.
+ * @param[in] dumpFilePath  - the dump file path.
+ *                            in Windows platform, is a dump file path, fobid empty file path.
+ *                            in Non-Windows platform, is a core pattern, fobid empty file path.
+ * @return int - return 0 if success, otherwise return -1.
+ */
+LLBC_EXPORT int LLBC_SetCrashDumpFilePath(const LLBC_CString &dumpFilePath = "");
+
+/**
+ * Set process crash handler
+ * @param[in] crashHandlerName - set crash handler name.
+ * @param[in] crashHandler     - the crash callback delegate.
+ * @return int - return 0 if success, otherwise return -1.
+ */
+LLBC_EXPORT int LLBC_SetCrashHandler(const LLBC_CString &crashHandlerName = "",
+                                     const LLBC_Delegate<void(const char *stackBacktrace,
+                                                              int sig)> &crashHandler = nullptr);
+/**
+ * Enable crash handle.
+ */
+LLBC_EXPORT int LLBC_EnableCrashHandle();
+
+/**
+ * Disable crash handle.
+ */
+LLBC_EXPORT void LLBC_DisableCrashHandle();
 
 #endif // LLBC_SUPPORT_HANDLE_CRASH
 

--- a/llbc/src/app/App.cpp
+++ b/llbc/src/app/App.cpp
@@ -245,7 +245,7 @@ int LLBC_App::Start(int argc, char *argv[], const LLBC_String &name)
     LLBC_ReturnIf(_cfgType != LLBC_AppConfigType::End && ReloadImpl(false, false) != LLBC_OK, LLBC_FAILED);
 
     // Handle progress crash.
-    LLBC_ReturnIf(LLBC_HandleCrash() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(LLBC_EnableCrashHandle() != LLBC_OK, LLBC_FAILED);
 
     // Install required signal handlers.
     // - App stop signals.
@@ -421,8 +421,8 @@ void LLBC_App::Stop()
         sigaction(cfgReloadSig, &sa, nullptr);
 #endif // Non-Win32
 
-    // Cancel handle crash.
-    LLBC_CancelHandleCrash();
+    // Disable handle crash.
+    LLBC_DisableCrashHandle();
 
     // Cleanup members.
     _cfgPath.clear();

--- a/llbc/src/core/Core.cpp
+++ b/llbc/src/core/Core.cpp
@@ -66,6 +66,12 @@ int __LLBC_CoreStartup()
     if (LLBC_ThreadSpecObjPool::Initialize() != LLBC_OK)
         return LLBC_FAILED;
 
+    //Prepare crash handle environment.
+    #if LLBC_SUPPORT_HANDLE_CRASH
+    if (__LLBC_PrepareCrashHandleEnv() != LLBC_OK)
+        return LLBC_FAILED;
+    #endif // LLBC_SUPPORT_HANDLE_CRASH
+  
     return LLBC_OK;
 }
 
@@ -111,9 +117,10 @@ void __LLBC_CoreCleanup()
     (void)LLBC_CleanupSymbol();
     #endif // LLBC_CFG_OS_IMPL_SYMBOL
 
-    // Cancel handle crash.
+    // Disable handle crash.
     #if LLBC_SUPPORT_HANDLE_CRASH
-    LLBC_CancelHandleCrash();
+    LLBC_DisableCrashHandle();
+    __LLBC_CleanUpCrashHandleEnv();
     #endif // LLBC_SUPPORT_HANDLE_CRASH
 }
 

--- a/llbc/src/core/os/OS_Process.cpp
+++ b/llbc/src/core/os/OS_Process.cpp
@@ -54,7 +54,11 @@ __LLBC_INTERNAL_NS_BEGIN
 
 static bool __hookedCrashSignals = false;
 static char __stackBacktrace[128 * 1024 + 1] {'\0'};
-static LLBC_NS LLBC_Delegate<void(const char *stackBacktrace, int sig)> __crashCallback = nullptr;
+
+static LLBC_NS LLBC_SpinLock *__crashInfoLock = nullptr;
+typedef std::pair<LLBC_NS LLBC_String, 
+                  LLBC_NS LLBC_Delegate<void(const char *stackBacktrace, int sig)>> __CrashHandlerInfo;
+static std::list<__CrashHandlerInfo> *__crashHandlerInfos = nullptr;
 
 __LLBC_INTERNAL_NS_END
 
@@ -198,8 +202,8 @@ static LONG WINAPI __Win32CrashHandler(::EXCEPTION_POINTERS *exception)
     mbTitle.format("Unhandled Exception(%s)", LLBC_NS LLBC_Directory::ModuleFileName().c_str());
     ::MessageBoxA(nullptr, errMsg.c_str(), mbTitle.c_str(), MB_ICONERROR | MB_OK);
 
-    if (__crashCallback)
-        __crashCallback(__stackBacktrace, 0);
+    for (auto &crashHanlderInfo : *LLBC_INL_NS __crashHandlerInfos)
+        crashHanlderInfo.second(__stackBacktrace, 0);
 
     LLBC_LoggerMgrSingleton->Finalize();
 
@@ -389,7 +393,7 @@ static void __NonWin32CrashHandler(int sig)
     }
 
     // Call callback delegate.
-    if (__crashCallback)
+    if (LLBC_INL_NS __crashHandlerInfos->size() > 0)
     {
         if (lseek(coreDescFileFd, 0, SEEK_SET) == -1)
         {
@@ -403,7 +407,8 @@ static void __NonWin32CrashHandler(int sig)
 
         close(coreDescFileFd);
 
-        __crashCallback(__stackBacktrace, sig);
+        for (auto &crashHanlderInfo : *LLBC_INL_NS __crashHandlerInfos)
+            crashHanlderInfo.second(__stackBacktrace, sig);
     }
     else
     {
@@ -422,20 +427,18 @@ __LLBC_INTERNAL_NS_END
 
 __LLBC_NS_BEGIN
 
-int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
-                     const LLBC_Delegate<void(const char *stackBacktrace,
-                                              int sig)> &crashCallback)
+int __LLBC_PrepareCrashHandleEnv()
 {
+    //Init crash handle lock and infos container.
+    LLBC_INL_NS __crashInfoLock = new LLBC_NS LLBC_SpinLock;
+    LLBC_INL_NS __crashHandlerInfos = new std::list<LLBC_INL_NS __CrashHandlerInfo>;
+
+    // Set default crash dump file path.
 #if LLBC_TARGET_PLATFORM_WIN32
-    LLBC_String nmlDumpFilePath = dumpFilePath;
-    if (nmlDumpFilePath.empty())
-    {
-        const auto now = LLBC_Time::Now();
-        nmlDumpFilePath = LLBC_Directory::SplitExt(LLBC_Directory::ModuleFilePath())[0];
-        nmlDumpFilePath.append_format("_%d_%s.dmp",
-                                      LLBC_GetCurrentProcessId(),
-                                      now.Format("%Y%m%d_%H%M%S").c_str());
-    }
+    LLBC_String nmlDumpFilePath(LLBC_Directory::SplitExt(LLBC_Directory::ModuleFilePath())[0]);
+    nmlDumpFilePath.append_format("_%d_%s.dmp",
+                                  LLBC_GetCurrentProcessId(),
+                                  LLBC_Time::Now().Format("%Y%m%d_%H%M%S").c_str());
 
     if (nmlDumpFilePath.size() >= sizeof(LLBC_INL_NS __dumpFilePath))
     {
@@ -446,18 +449,48 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
     memcpy(LLBC_INL_NS __dumpFilePath, nmlDumpFilePath.c_str(), nmlDumpFilePath.size());
     LLBC_INL_NS __dumpFilePath[nmlDumpFilePath.size()] = '\0';
 
-    if (!LLBC_INL_NS __hookedCrashSignals)
-    {
-        ::SetUnhandledExceptionFilter(LLBC_INL_NS __Win32CrashHandler);
-        #ifdef LLBC_RELEASE
-        LLBC_INL_NS __PreventSetUnhandledExceptionFilter();
-        #endif
+#elif LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
+    // No-win32 not support set default crash dump file path. will use system default config.
+#else 
+    // Unsupported platforms.
+#endif // Win32
+    
+    return LLBC_OK;
+}
 
-        LLBC_INL_NS __hookedCrashSignals = true;
+int __LLBC_CleanUpCrashHandleEnv()
+{
+#if LLBC_TARGET_PLATFORM_WIN32
+    memset(&LLBC_INL_NS __dumpFilePath, 0, sizeof(LLBC_INL_NS __dumpFilePath));
+#endif
+    LLBC_XDelete(LLBC_INL_NS __crashInfoLock);
+    LLBC_INL_NS __crashInfoLock = nullptr;
+
+    LLBC_XDelete(LLBC_INL_NS __crashHandlerInfos);
+    LLBC_INL_NS __crashHandlerInfos = nullptr;
+
+    return LLBC_OK;
+}
+
+int LLBC_SetCrashDumpFilePath(const LLBC_CString &dumpFilePath)
+{
+    LLBC_NS LLBC_LockGuard guard(*LLBC_INL_NS __crashInfoLock);
+    
+    if(dumpFilePath.empty())
+    {
+        LLBC_SetLastError(LLBC_ERROR_ARG);
+        return LLBC_FAILED;
     }
 
-    // Set crash callback.
-    LLBC_INL_NS __crashCallback = crashCallback;
+#if LLBC_TARGET_PLATFORM_WIN32
+    if (dumpFilePath.size() >= sizeof(LLBC_INL_NS __dumpFilePath))
+    {
+        LLBC_SetLastError(LLBC_ERROR_ARG);
+        return LLBC_FAILED;
+    }
+
+    memcpy(LLBC_INL_NS __dumpFilePath, dumpFilePath.c_str(), dumpFilePath.size());
+    LLBC_INL_NS __dumpFilePath[dumpFilePath.size()] = '\0';
 
     return LLBC_OK;
 #elif LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
@@ -465,28 +498,94 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
     // if (dumpFilePath.empty())
     //    return LLBC_OK;
 
-    if (!dumpFilePath.empty())
+    // Save old core pattern.
+    const auto oldCorePattern = LLBC_File::ReadToEnd(LLBC_INL_NS __corePatternPath);
+    if (LLBC_GetLastError() != LLBC_ERROR_SUCCESS)
+        return LLBC_FAILED;
+
+    // Write new core pattern(may not have permission to open core_pattern file, ignore error).
+    LLBC_File corePatternFile;
+    if (corePatternFile.Open(LLBC_INL_NS __corePatternPath, LLBC_FileMode::Write) == LLBC_OK)
     {
-        // Save old core pattern.
-        const auto oldCorePattern = LLBC_File::ReadToEnd(LLBC_INL_NS __corePatternPath);
-        if (LLBC_GetLastError() != LLBC_ERROR_SUCCESS)
-            return LLBC_FAILED;
-
-        // Write new core pattern(may not have permission to open core_pattern file, ignore error).
-        LLBC_File corePatternFile;
-        if (corePatternFile.Open(LLBC_INL_NS __corePatternPath, LLBC_FileMode::Write) == LLBC_OK)
+        // If failed, try write old core pattern.
+        if (corePatternFile.Write(dumpFilePath) != LLBC_OK)
         {
-            // If failed, try write old core pattern.
-            if (corePatternFile.Write(dumpFilePath) != LLBC_OK)
-            {
-                corePatternFile.Seek(LLBC_FileSeekOrigin::Begin, 0);
-                corePatternFile.Write(oldCorePattern);
+            corePatternFile.Seek(LLBC_FileSeekOrigin::Begin, 0);
+            corePatternFile.Write(oldCorePattern);
 
-                return LLBC_FAILED;
-            }
+            return LLBC_FAILED;
         }
     }
+    else
+    {
+        return LLBC_FAILED;
+    }
 
+    return LLBC_OK;
+
+#else // Unsupported platforms
+    LLBC_SetLastError(LLBC_ERROR_NOT_IMPL);
+    return LLBC_FAILED;
+#endif // Win32
+}
+
+int LLBC_SetCrashHandler(const LLBC_CString &crashHandlerName,
+                         const LLBC_Delegate<void(const char *stackBacktrace, int sig)> &crashHandler)
+{
+
+#if LLBC_TARGET_PLATFORM_WIN32 || LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
+    LLBC_NS LLBC_LockGuard guard(*LLBC_INL_NS __crashInfoLock);
+
+    if (crashHandlerName.empty())
+    {
+        LLBC_SetLastError(LLBC_ERROR_ARG);
+        return LLBC_FAILED;
+    }
+
+    auto foundIt = std::find_if(LLBC_INL_NS __crashHandlerInfos->begin(),
+                                LLBC_INL_NS __crashHandlerInfos->end(),
+                                [&crashHandlerName](const LLBC_INL_NS __CrashHandlerInfo &info) {
+                                    return info.first == crashHandlerName;
+                                });
+
+    if (foundIt == LLBC_INL_NS __crashHandlerInfos->end())
+    {
+        if (!crashHandler)
+            return LLBC_OK;
+        
+        LLBC_INL_NS __crashHandlerInfos->emplace_back(crashHandlerName, crashHandler);
+        return LLBC_OK;
+    }
+
+    if (!crashHandler)
+        LLBC_INL_NS __crashHandlerInfos->erase(foundIt);
+    else
+        (*foundIt).second = crashHandler;
+
+    return LLBC_OK;
+
+#else // Unsupported platforms
+    LLBC_SetLastError(LLBC_ERROR_NOT_IMPL);
+    return LLBC_FAILED;
+#endif // Win32
+}
+
+int LLBC_EnableCrashHandle()
+{
+    LLBC_NS LLBC_LockGuard guard(*LLBC_INL_NS __crashInfoLock);
+
+#if LLBC_TARGET_PLATFORM_WIN32
+    if (!LLBC_INL_NS __hookedCrashSignals)
+    {
+        ::SetUnhandledExceptionFilter(LLBC_INL_NS __Win32CrashHandler);
+#ifdef LLBC_RELEASE
+        LLBC_INL_NS __PreventSetUnhandledExceptionFilter();
+#endif
+        LLBC_INL_NS __hookedCrashSignals = true;
+    }
+
+    return LLBC_OK;
+#elif LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_MAC
     // Set signals handler.
     if (!LLBC_INL_NS __hookedCrashSignals)
     {
@@ -508,9 +607,6 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
         LLBC_INL_NS __hookedCrashSignals = true;
     }
 
-    // Set crash callback.
-    LLBC_INL_NS __crashCallback = crashCallback;
-
     return LLBC_OK;
 #else // Unsupported platforms
     LLBC_SetLastError(LLBC_ERROR_NOT_IMPL);
@@ -518,8 +614,10 @@ int LLBC_HandleCrash(const LLBC_String &dumpFilePath,
 #endif // Win32
 }
 
-void LLBC_CancelHandleCrash()
+void LLBC_DisableCrashHandle()
 {
+    LLBC_NS LLBC_LockGuard guard(*LLBC_INL_NS __crashInfoLock);
+
     if (!LLBC_INL_NS __hookedCrashSignals)
         return;
 

--- a/testsuite/TestSuite.cpp
+++ b/testsuite/TestSuite.cpp
@@ -49,7 +49,9 @@
 int TestSuite_Main(int argc, char* argv[])
 {
     LLBC_Startup();
-    LLBC_HandleCrash();
+
+    LLBC_ReturnIf(LLBC_EnableCrashHandle() != LLBC_OK, LLBC_FAILED);
+
     __TraitsLoop<__TEST_CASE_COUNT>::Generate();
 
     while (true)

--- a/testsuite/core/os/TestCase_Core_OS_Process.cpp
+++ b/testsuite/core/os/TestCase_Core_OS_Process.cpp
@@ -22,6 +22,8 @@
 
 #include "core/os/TestCase_Core_OS_Process.h"
 
+static int __Test_Os_Process_Hook_Times = 0;
+
 int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
 {
     std::cout <<"core/os/process test:" <<std::endl;
@@ -36,16 +38,42 @@ int TestCase_Core_OS_Process::Run(int argc, char *argvp[])
     return 0;
 }
 
+static void TestCase_Core_OS_Process_Crash_Hook_test(const char *traceback, int sig)
+{
+    std::cout << std::endl;
+    std::cout << "TestCase_Core_OS_Process_Crash_Hook_test success. times:" << __Test_Os_Process_Hook_Times++ << std::endl;
+}
+
 int TestCase_Core_OS_Process::TestCrash()
 {
     std::cout << "Crash hook test:" << std::endl;
 
 #if LLBC_SUPPORT_HANDLE_CRASH
-    // Set crash hook.
+    // Set crash hook handle list.
     std::cout << "Handle crash..." << std::endl;
-    if (LLBC_HandleCrash() != LLBC_OK)
+    // Enable crash handle.
+    if(LLBC_EnableCrashHandle() != LLBC_OK)
     {
-        std::cerr << "Handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
+        std::cerr << "Open handle crash failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+
+    //Set crash hook1.
+    if (LLBC_SetCrashHandler("hook_test", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    {
+        std::cerr << "Handle crash 1 failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+    //Set crash hook2.
+    if (LLBC_SetCrashHandler("hook_test2", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    {
+        std::cerr << "Handle crash 2 failed, err:" << LLBC_FormatLastError() << std::endl;
+        return LLBC_FAILED;
+    }
+    //Set crash hook3.
+    if (LLBC_SetCrashHandler("hook_test3", TestCase_Core_OS_Process_Crash_Hook_test) != LLBC_OK)
+    {
+        std::cerr << "Handle crash 3 failed, err:" << LLBC_FormatLastError() << std::endl;
         return LLBC_FAILED;
     }
 

--- a/wrap/pyllbc/src/app/_App.h
+++ b/wrap/pyllbc/src/app/_App.h
@@ -29,7 +29,7 @@ LLBC_EXTERN_C PyObject *_pyllbc_HandleCrash(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "s", &dumpFile))
         return nullptr;
 
-    if (LLBC_HandleCrash(dumpFile) != LLBC_OK)
+    if (LLBC_EnableCrashHandle() != LLBC_OK || LLBC_SetCrashDumpFilePath(dumpFile) != LLBC_OK)
     {
         pyllbc_TransferLLBCError(__FILE__, __LINE__, "When set dump file");
         return nullptr;


### PR DESCRIPTION
如题，改动如下：
1.crash handle支持多个handler。
2.将SetCrashHandle函数拆分为：
-1）LLBC_SetCrashHandler 设置crash处理函数
- 2）LLBC_SetCrashDumpFilePath 设置crash dump文件路径
- 3）LLBC_EnableCrashHandle 设置打开crash handle开关
3.增加__LLBC_PrepareCrashHandleEnv接口，进行crash handle管理数据初始化，设置win-32默认crash dump file path。
4.增加TestCase_Core_OS_Process set多crash handle函数用例。
5.增加ServiceImpl::GetServiceThreadId接口。
6.其他细节优化.