### PR TITLE
fix: LLBC_Stream的Clear()接口重置endian字段 #437

### DIFF
--- a/llbc/include/llbc/common/StreamInl.h
+++ b/llbc/include/llbc/common/StreamInl.h
@@ -1264,6 +1264,7 @@ LLBC_FORCE_INLINE void LLBC_Stream::Clear()
     {
         _readPos = _writePos = 0;
     }
+    _endian = LLBC_DefaultEndian;
 }
 
 LLBC_FORCE_INLINE LLBC_TypedObjPool<LLBC_Stream> *LLBC_Stream::GetTypedObjPool() const

--- a/testsuite/common/TestCase_Com_Stream.cpp
+++ b/testsuite/common/TestCase_Com_Stream.cpp
@@ -238,6 +238,7 @@ int TestCase_Com_Stream::Run(int argc, char *argv[])
     LLBC_ReturnIf(NonTrivialClsSerTest() != LLBC_OK, LLBC_FAILED);
     LLBC_ReturnIf(SerializableClsSerTest() != LLBC_OK, LLBC_FAILED);
     LLBC_ReturnIf(MovableReadTest() != LLBC_OK, LLBC_FAILED);
+    LLBC_ReturnIf(EndianThreadSpecObjPoolTest() != LLBC_OK, LLBC_FAILED);
 
     return LLBC_OK;
 }
@@ -759,6 +760,32 @@ int TestCase_Com_Stream::MovableReadTest()
     LLBC_PrintLn("- After called Read<MovableCls>():");
     LLBC_PrintLn("  - stream:%s", stream.ToString().c_str());
     LLBC_PrintLn("  - movableObj2:%d %s", movableObj2.intVal, movableObj2.strVal.c_str());
+
+    return LLBC_OK;
+}
+
+int TestCase_Com_Stream::EndianThreadSpecObjPoolTest()
+{
+    // Stream obj pool test: reallocate stream obj and check whether the endian field of the stream is reset.
+    LLBC_PrintLn("EndianThreadSpecObjPoolTest test:");
+    LLBC_PrintLn("- Default endian:%s", LLBC_Endian::Type2Str(LLBC_DefaultEndian));
+
+    auto allocateStreamAndChangeEndian = []()
+    {
+        auto stream = LLBC_ThreadSpecObjPool::GuardedUnsafeAcquire<LLBC_Stream>();
+        int initEndian = stream->GetEndian();
+        if (initEndian == LLBC_Endian::BigEndian)
+            stream->SetEndian(LLBC_Endian::LittleEndian);
+        else
+            stream->SetEndian(LLBC_Endian::BigEndian);
+        LLBC_PrintLn("- Change obj pool stream obj endian field. Field init value:%s, change to value:%s, obj ptr:%p.",
+                     LLBC_Endian::Type2Str(initEndian), LLBC_Endian::Type2Str(stream->GetEndian()), stream.Get());
+    };
+
+    allocateStreamAndChangeEndian();
+    auto stream = LLBC_ThreadSpecObjPool::GuardedUnsafeAcquire<LLBC_Stream>();
+    LLBC_PrintLn("- Reallocation stream obj. Obj endian field init value:%s, obj ptr:%p.",
+                 LLBC_Endian::Type2Str(stream->GetEndian()), stream.Get());
 
     return LLBC_OK;
 }

--- a/testsuite/common/TestCase_Com_Stream.h
+++ b/testsuite/common/TestCase_Com_Stream.h
@@ -43,6 +43,7 @@ private:
     int NonTrivialClsSerTest();
     int SerializableClsSerTest();
     int MovableReadTest();
+    int EndianThreadSpecObjPoolTest();
 
 private:
     static void GenRandStr(LLBC_String &str,


### PR DESCRIPTION
如提，修复LLBC_Stream大小端字段clear接口未清除问题。
新增测试用例：
1.从对象池中分配LLBC_Stream对象，记录初试大小端，并改变大小端；
2.待1对象回收后，重新从对象池中分配对象，打印初试大小端；
3.检查1 2中是否是同一个对象，以及检查大小端字段是否符合预期。
