### PR TITLE
feat:【llbc】LLBC_STREAM_BEGIN_READ简化

### DIFF
--- a/llbc/include/llbc/common/Stream.h
+++ b/llbc/include/llbc/common/Stream.h
@@ -28,66 +28,66 @@
 /** Some stream helper macros define **/
 /*  Deserialize/Read about macros define  */
 // Begin read macro define, use to simple begin read object.
-#define LLBC_STREAM_BEGIN_READ(stream, failRetType, failRetVal) \
-    do {                                                        \
-        failRetType __r_failRet = (failRetVal);                 \
-        LLBC_NS LLBC_Stream &__r_stream = (stream)              \
+#define LLBC_STREAM_BEGIN_READ(stream, failRetVal)       \
+    do {                                                 \
+        decltype(failRetVal) __r_failRet = (failRetVal); \
+        LLBC_NS LLBC_Stream &__r_stream = (stream)       \
 
 // Deserialize macro define.
-#define LLBC_STREAM_READ(field)                                 \
-    if (!__r_stream.Read(field)) {                              \
-        return __r_failRet;                                     \
-    }                                                           \
+#define LLBC_STREAM_READ(field)                          \
+    if (!__r_stream.Read(field)) {                       \
+        return __r_failRet;                              \
+    }                                                    \
 
-#define LLBC_STREAM_READ_BUF(buf, len)                          \
-    if (!__r_stream.Read(buf, len)) {                           \
-        return __r_failRet;                                     \
-    }                                                           \
+#define LLBC_STREAM_READ_BUF(buf, len)                   \
+    if (!__r_stream.Read(buf, len)) {                    \
+        return __r_failRet;                              \
+    }                                                    \
 
 // Peek macro define.
-#define LLBC_STREAM_PEEK(field)                                 \
-    if (!__r_stream.Peek(field)) {                              \
-        return __r_failRet;                                     \
-    }                                                           \
+#define LLBC_STREAM_PEEK(field)                          \
+    if (!__r_stream.Peek(field)) {                       \
+        return __r_failRet;                              \
+    }                                                    \
 
 // Skip macro define, use to skip stream.
-#define LLBC_STREAM_SKIP(size)                                  \
-    if (!__r_stream.Skip(size)) {                               \
-        return __r_failRet;                                     \
-    }                                                           \
+#define LLBC_STREAM_SKIP(size)                           \
+    if (!__r_stream.Skip(size)) {                        \
+        return __r_failRet;                              \
+    }                                                    \
 
 // End read macro define, use to stop stream read.
-#define LLBC_STREAM_END_READ()                                  \
-    } while(0)                                                  \
+#define LLBC_STREAM_END_READ()                           \
+    } while(0)                                           \
 
 // End read macro define, like with previous, but this
 // macro will return given value to stop function call.
-#define LLBC_STREAM_END_READ_RET(retVal)                        \
-    } while(0);                                                 \
-    return (retVal)                                             \
+#define LLBC_STREAM_END_READ_RET(retVal)                 \
+    } while(0);                                          \
+    return (retVal)                                      \
 
 /*  Serialize/Write about macros define  */
 // Begin write macro define, use to simple begin write object.
-#define LLBC_STREAM_BEGIN_WRITE(stream)                         \
-    do {                                                        \
-        LLBC_NS LLBC_Stream &__w_stream = (stream)              \
+#define LLBC_STREAM_BEGIN_WRITE(stream)                  \
+    do {                                                 \
+        LLBC_NS LLBC_Stream &__w_stream = (stream)       \
 
 // Serialize macro define.
-#define LLBC_STREAM_WRITE(field)                                \
-    __w_stream.Write(field)                                     \
+#define LLBC_STREAM_WRITE(field)                         \
+    __w_stream.Write(field)                              \
 
-#define LLBC_STREAM_WRITE_BUF(buf, len)                         \
-    __w_stream.Write(buf, len)                                  \
+#define LLBC_STREAM_WRITE_BUF(buf, len)                  \
+    __w_stream.Write(buf, len)                           \
 
 // End write macro define, use to stop stream write.
-#define LLBC_STREAM_END_WRITE()                                 \
-    } while(0)                                                  \
+#define LLBC_STREAM_END_WRITE()                          \
+    } while(0)                                           \
 
 // End write macro define, like with previous, but this
 // macro will return given value to stop function call.
-#define LLBC_STREAM_END_WRITE_RET(retVal)                       \
-    } while(0);                                                 \
-    return (retVal)                                             \
+#define LLBC_STREAM_END_WRITE_RET(retVal)                \
+    } while(0);                                          \
+    return (retVal)                                      \
 
 
 __LLBC_NS_BEGIN

--- a/llbc/src/core/objbase/Array.cpp
+++ b/llbc/src/core/objbase/Array.cpp
@@ -469,7 +469,7 @@ bool LLBC_Array::Deserialize(LLBC_Stream &s)
     if (UNLIKELY(!_objFactory))
         return false;
 
-    LLBC_STREAM_BEGIN_READ(s, bool, false);
+    LLBC_STREAM_BEGIN_READ(s, false);
 
     uint32 size = 0;
     LLBC_STREAM_READ(size);

--- a/llbc/src/core/objbase/Dictionary.cpp
+++ b/llbc/src/core/objbase/Dictionary.cpp
@@ -469,7 +469,7 @@ bool LLBC_Dictionary::Deserialize(LLBC_Stream &s)
     if (!_objFactory)
         return false;
 
-    LLBC_STREAM_BEGIN_READ(s, bool, false);
+    LLBC_STREAM_BEGIN_READ(s, false);
 
     uint32 bucketSize = 0;
     LLBC_STREAM_READ(bucketSize);

--- a/testsuite/common/TestCase_Com_Stream.cpp
+++ b/testsuite/common/TestCase_Com_Stream.cpp
@@ -103,7 +103,7 @@ struct SerializableCls
 
     bool Deserialize(LLBC_Stream &stream)
     {
-        LLBC_STREAM_BEGIN_READ(stream, bool, false);
+        LLBC_STREAM_BEGIN_READ(stream, false);
 
         LLBC_STREAM_READ(bVal);
         LLBC_STREAM_READ(intVal);


### PR DESCRIPTION
将#define LLBC_STREAM_BEGIN_READ(stream, failRetType, failRetVal) 从三参数版本修改为二参数版本，代码中所有使用到LLBC_STREAM_BEGIN_READ的地方都需要修改

--编译通过
--单元测试通过