### PR TITLE
fix: 修复嵌套fire event时，postFire只会执行一次问题

### DIFF
--- a/llbc/src/core/event/EventMgr.cpp
+++ b/llbc/src/core/event/EventMgr.cpp
@@ -338,7 +338,15 @@ void LLBC_EventMgr::AfterFireEvent(LLBC_Event *ev)
     #endif // LLBC_CFG_CORE_ENABLE_EVENT_FIRE_DEAD_LOOP_DETECTION
 
     // Decrease firing flag.
-    if (--_firing != 0)
+    --_firing;
+
+    // The event hook manager do post-fire.
+    #if LLBC_CFG_CORE_ENABLE_EVENT_HOOK
+    if (_eventHookMgr)
+        _eventHookMgr->PostFire(ev);
+    #endif // LLBC_CFG_CORE_ENABLE_EVENT_HOOK
+
+    if (_firing != 0)
         return;
 
     // Assert: make sure _firing >= 0.
@@ -349,13 +357,6 @@ void LLBC_EventMgr::AfterFireEvent(LLBC_Event *ev)
     llbc_assert(_firingEventIds.empty() &&
                 "llbc framework internal error: LLBC_EventMgr._firingEventIds is not empty!");
     #endif // LLBC_CFG_CORE_ENABLE_EVENT_FIRE_DEAD_LOOP_DETECTION
-
-    // The event hook manager do post-fire.
-    #if LLBC_CFG_CORE_ENABLE_EVENT_HOOK
-    if (_eventHookMgr)
-        _eventHookMgr->PostFire(ev);
-    #endif // LLBC_CFG_CORE_ENABLE_EVENT_HOOK
-
 
     // Process pending event ops(add/remove).
     for (auto &pendingEventOp : _pendingEventOps)


### PR DESCRIPTION
之前逻辑是在嵌套fire事件中，postFire根据_firing次数，只会执行一次，这会跟BeforeFireEvent中PreFire执行次数不一致。
PostFilre()跟PreFIre()应该是对称的才对，包括顺序、次数。