### PR TITLE
feat: LLBC_Time 移除 operator+(LLBC_Time) & 修复 clang 21 -Wnontrivial-me…

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   macos-build:
-    if: false
     name: MacOS build job
     runs-on: macOS-latest
     steps:

--- a/llbc/include/llbc/common/BasicCString.h
+++ b/llbc/include/llbc/common/BasicCString.h
@@ -296,7 +296,8 @@ public:
      */
     LLBC_BasicCString &operator=(const LLBC_BasicCString &other)
     {
-        memcpy(this, &other, sizeof(other));
+        _cstr = other._cstr;
+        _size = other._size;
         return *this;
     }
 

--- a/llbc/include/llbc/core/time/Time.h
+++ b/llbc/include/llbc/core/time/Time.h
@@ -384,7 +384,6 @@ public:
      * Time span operations.
      */
     LLBC_TimeSpan operator-(const LLBC_Time &time) const;
-    LLBC_TimeSpan operator+(const LLBC_Time &time) const;
 
     LLBC_Time operator+(const LLBC_TimeSpan &span) const;
     LLBC_Time operator-(const LLBC_TimeSpan &span) const;

--- a/llbc/src/common/SocketDataType.cpp
+++ b/llbc/src/common/SocketDataType.cpp
@@ -66,7 +66,10 @@ LLBC_SockAddr_IN::LLBC_SockAddr_IN(const char *ip, uint16 port)
 
 LLBC_SockAddr_IN::LLBC_SockAddr_IN(const LLBC_SockAddr_IN &right)
 {
-    memcpy(this, &right, sizeof(LLBC_SockAddr_IN));
+    _addrFamily = right._addrFamily;
+    _port = right._port;
+    _ip = right._ip;
+    memcpy(_zero, right._zero, sizeof(_zero));
 }
 
 LLBC_SockAddr_IN::~LLBC_SockAddr_IN()
@@ -262,7 +265,13 @@ LLBC_String LLBC_SockAddr_IN::ToString() const
 
 LLBC_SockAddr_IN &LLBC_SockAddr_IN::operator=(const LLBC_SockAddr_IN &right)
 {
-    memcpy(this, &right, sizeof(LLBC_SockAddr_IN));
+    if (this == &right)
+        return *this;
+
+    _addrFamily = right._addrFamily;
+    _port = right._port;
+    _ip = right._ip;
+    memcpy(_zero, right._zero, sizeof(_zero));
     return *this;
 }
 

--- a/llbc/src/core/time/Time.cpp
+++ b/llbc/src/core/time/Time.cpp
@@ -267,11 +267,6 @@ LLBC_TimeSpan LLBC_Time::operator-(const LLBC_Time &time) const
     return LLBC_TimeSpan(_time - time._time);
 }
 
-LLBC_TimeSpan LLBC_Time::operator+(const LLBC_Time &time) const
-{
-    return LLBC_TimeSpan(_time - time._time);
-}
-
 LLBC_Time LLBC_Time::operator+(const LLBC_TimeSpan &span) const
 {
     return LLBC_Time(_time + span.GetTotalMicros());


### PR DESCRIPTION
…mcall 导致的编译错误 #531

-Wnontrivial-memcall 告警会拒绝对带有用户自定义
 特殊成员函数的类型使用 memcpy(this, ...)，在 -Wall -Werror 下被升级
 为编译错误，导致 macOS clang 21 无法编译 core_lib。

 将三处 memcpy(this, &other, sizeof(...)) 反模式改为逐字段赋值：
 - LLBC_BasicCString::operator=(const LLBC_BasicCString &)
 - LLBC_SockAddr_IN 拷贝构造
 - LLBC_SockAddr_IN::operator=（顺带补 self-assign guard）

 LLBC_SockAddr_IN 中的 _zero[8] 仍用 memcpy 按数组首址拷贝（合法）。