### PR TITLE
feat: 【llbc】设计及实现一套标准化、高性能、可扩展的日志控制机制 #535

### DIFF
--- a/doc/log_control.md
+++ b/doc/log_control.md
@@ -1,544 +1,200 @@
 # Log Output Control Items（日志输出控制项）
 
-`llbc` 日志库提供了一套**统一的、按 appender 串行应用的日志输出控制机制**，
-用以替代历史上的 `LLBC_LogMuteFilter`。每个 logger 持有一个有序的控制项列表
-（`std::vector<LLBC_LogControlItem>`），在 `Logger::OutputLogData()`
-内部、对每个 appender 独立、按声明顺序应用。
+每个 logger 持有一个有序的 `std::vector<LLBC_LogControlItem>`；`Logger::OutputLogData()` 里对每个 appender 独立、按声明顺序应用。控制项**只从配置装载**（`Initialize` / `Reload`）。
 
-控制机制由两个设施组成：
+实现分三层，源码见 `llbc/core/log/`：
 
-- **数据模型**：`LLBC_LogControlItem`（见 `llbc/core/log/LogControl.h`）。
-- **执行器**：`LLBC_LogControlMgr`（见 `llbc/core/log/LogControlMgr.h`）。
-
----
-
-## 1. 控制项三段式结构
-
-每个 `LLBC_LogControlItem` 由三块组成：
-
-### a) Match Rules（匹配规则）
-
-控制项内**已启用**的维度之间为 **AND**（all-of，必须同时命中）；每条规则**自身的取值集合**（如 `file.lineRanges` / `func.values` / `threadId.values` / `level.values`）则为 **OR**（one-of，任一取值命中即视该条规则命中）。
-
-> 设计取舍：规则间 AND 与 iptables / log4j filter / SQL `WHERE` / Prometheus matcher 的多字段语义一致，符合"过滤器即交集"的工程直觉；如需在多个维度上做 OR，**追加多条控制项**即可。
-
-| 字段 | 标志 | 备注 |
-| ---- | ---- | ---- |
-| `matchFile` + `matchLineRanges` | `haveFile` | 文件 basename + 行号集合。`matchLineRanges` 是若干 **半开区间** `[begin, end)` 段的并集（与 `LLBC_Stream::Erase / Replace` 等 llbc 范围 API 风格一致）：单行 `N` 内部存为 `[N, N+1)`；为空表示通配整文件。每段必须满足 `0 <= begin && end > begin` |
-| `matchFuncs`              | `haveFunc` | 完整函数名列表（不支持通配）；记录的函数名等于其中**任意一个**即命中 |
-| `matchThreadIds`          | `haveThreadId` | 原生线程 id 列表；记录的 tid 等于其中**任意一个**即命中 |
-| `matchLevels`             | `haveLevel` | 日志级别列表；记录的 level 等于其中**任意一个**即命中。每个元素必须在 `LLBC_LogLevel::Begin..<End` 内 |
-
-`HasAnyMatch()` 校验至少一个维度被启用，否则视为非法控制项（`AddControl` 会
-拒绝；配置解析时会静默跳过）。
-
-### b) Appender Scope（应用 appender 集合）
-
-`appenderTypes` 为 `std::vector<int>`，元素为 `LLBC_LogAppenderType::Console / File
-/ Network` 之一。**留空 = 对所有 appender 生效**。
-
-### c) Action（生效规则）
-
-| 取值 | 语义 |
-| ---- | ---- |
-| `LLBC_LogControlAction::Mute`     | 在当前 appender 上丢弃此条记录，并对 `suppressedCount` +1 |
-| `LLBC_LogControlAction::SetLevel` | 把记录在当前 appender 链中的 effective level 改写为 `newLevel` |
+| 层 | 类型 | 职责 |
+| --- | --- | --- |
+| 配置项 | `LLBC_LogControlItem`（`LogControl.h`） | 纯数据结构，描述一条控制项：一组 match 规则 + appender scope + 一个 action |
+| 执行器 | `LLBC_LogControlExecutor`（`LogControlExecutor.h`） | 一条配置项编译后的"匹配 + 动作"最小单元；`SetLogControls` 时**一次性**编译为不可变形态，热路径不再做校验 |
+| 管理器 | `LLBC_LogControlMgr`（`LogControlMgr.h`） | 持有 `shared_ptr<const ExecutorList>` 快照，对外提供 `Apply`；`Initialize` / `Reload` 时原子发布新快照，`Apply` 拷指针后**出锁遍历** |
 
 ---
 
-## 2. 应用顺序与作用域
+## 1. 控制项结构
 
-对 **(record, appender)** 这一对：
+结构定义位于 `llbc/core/log/LogControl.h`：
 
-1. 控制项按声明顺序遍历。
-2. `ScopeAllows` 先过 appender 范围（空 = all），不命中则跳过该项。
-3. `MatchOne` 在当前 effective level 上做匹配（**已启用规则之间 AND**，每条规则**自身取值集合 OR**）；不命中则跳过该项。
-4. 命中后：
-   - `Mute`：立刻丢弃该 appender 上的本条记录，`suppressedCount` 原子 +1，
-     **停止**遍历当前 appender。
-   - `SetLevel`：把 effective level 改写为 `newLevel`；**继续**遍历后续控
-     制项（后续控制项可基于改写后的 level 再次匹配，例如先 SetLevel 到
-     warn，再用 `level==warn` 的 Mute 项二次过滤）。
+```cpp
+template <typename T>
+struct LLBC_LogMatchSet
+{
+    bool enabled;
+    std::vector<T> values;
+};
 
-> ⚠️ **SetLevel 的改写不会跨 appender 泄漏**。每个 appender 都从
-> 记录的原始 level 开始遍历，因此 console 上的 SetLevel 不会影响 file
-> appender 看到的 level。
+struct LLBC_LogFileMatch
+{
+    bool enabled;
+    LLBC_String file;                             // file basename
+    std::vector<std::pair<int, int>> lineRanges;  // half-open [begin, end)
+};
+
+struct LLBC_LogControlItem
+{
+    // a) match rules; AND-combined when enabled, each rule's values OR-combined.
+    LLBC_LogFileMatch               file;
+    LLBC_LogMatchSet<LLBC_String>   func;         // exact function names, no wildcard
+    LLBC_LogMatchSet<LLBC_ThreadId> threadId;
+    LLBC_LogMatchSet<int>           level;        // matched against effective level
+
+    // b) appender scope; empty == all appenders.
+    std::vector<int> appenderTypes;               // LLBC_LogAppenderType::{Console, File, Network}
+
+    // c) action; default Unset -> must be assigned explicitly.
+    int action;                                   // LLBC_LogControlAction::Mute / SetLevel
+    int newLevel;                                 // valid when action == SetLevel
+
+    bool HasAnyMatch() const;                     // 至少一个维度启用，否则非法
+};
+```
+
+三点关键语义（源码 doc-comment 已述，此处强调）：
+
+- **AND/OR**：已启用的 match 维度之间是 AND；单维度内 `values` / `lineRanges` 是 OR。跨维度 OR 请写多条 `<logControl>`。
+- **`file.lineRanges`** 是半开区间 `[begin, end)` 的并集：单行 `N` 存为 `[N, N+1)`，空 = 通配整文件。每段须满足 `0 <= begin < end`。
+- **`level` 匹配的是"当前 effective level"**（可与前面 executor 的 `SetLevel` 链式组合），不是 `data.level`。
+- **`action` 必须显式赋值**：默认哨兵 `Unset` 会被 `SetLogControls` 拒绝，避免漏写 action 静默变成破坏性 Mute。`Mute` 命中即链遍历终止；`SetLevel` 只改写 level，遍历继续。
 
 ---
 
-## 3. 配置驱动：`logControls`
+## 2. 应用顺序
 
-每个 logger 配置中可以提供一个名为 `logControls` 的**嵌套 XML 子树**，子树
-下每个 `<item>` 描述一个控制项。
+```cpp
+LLBC_LogControlApplyResult Apply(int appenderType,
+                                 const LLBC_LogData &data,
+                                 int originalLevel) const;
+// LLBC_LogControlApplyResult { bool muted; int effectiveLevel; }
+```
 
-> **配置载体限制**：`logControls` **仅 XML 格式 (`.xml`) 支持**。`.cfg`
-> (property-style) 是扁平的 `key=value` 格式，无法承载 `item -> match ->
-> file/func/threadId/level/...` 这种嵌套结构；若在 `.cfg` 中写
-> `myLogger.logControls=...` 会被 LoggerConfigurator 检测到并触发 stderr
-> 警告，然后整段忽略。
+对 `(record, appender)` 这一对：
 
-### XML schema
+1. 拷贝 `shared_ptr<const ExecutorList>` 快照后**出锁遍历**；executor 按声明顺序推进。
+2. 每个 executor：先过 appender scope（空 == all），再对所有已启用维度 `Match(data, currentLevel)`；任一失败即跳过。level 规则读的是 `currentLevel`，不是 `data.level`。
+3. 命中后：`Mute` → `muted = true`，**立即返回**；`SetLevel` → 更新 `currentLevel`，**继续**遍历。
 
-本 schema 刻意**只用子元素、不用 XML 属性**：所有 payload 一律走内联文本或
-子元素，多值规则（OR）用同名重复子元素承载。这样 XML 与未来的 YAML/JSON
-loader 结构完全对齐（每个元素 == map 条目；重复子元素 == list），无需在
-"该字段做 attribute 还是做 key"上分裂。`<action>` 作为 sum type（mute 无操
-作数；setLevel 携带 `<newLevel>` 操作数），其判别 tag 也作为 `<type>` 子元素
-承载——保持"操作数与判别 tag 都在 `<action>` 子序列里"的一致性，也便于将来
-扩展更多 action 变体。
+---
+
+## 3. XML 配置：`logControls`
+
+`logControls` 是每个 logger 配置下的**嵌套子树**，每个 `<logControl>` 描述一个控制项。**仅 `.xml` 支持**——`.cfg` 是扁平 `key=value`，无法承载嵌套；若在 `.cfg` 里写 `myLogger.logControls=...` 会 stderr 告警并整段忽略。
 
 ```xml
 <logControls>
-  <item>
+  <logControl>
     <match>
-      <!-- 文件名 + 行号 (多个 <file> 同一 item 内只取第一个) -->
-      <file><name>Foo.cpp</name></file>                     <!-- 通配整文件 -->
-      <file>
-        <name>Foo.cpp</name>
-        <line>42</line>                                     <!-- 单行 -->
-      </file>
-      <file>
-        <name>Foo.cpp</name>
-        <line>10-12</line>                                  <!-- 半开区间 [10, 12) -->
-      </file>
-      <file>
-        <name>Foo.cpp</name>
-        <line>100</line>                                    <!-- 多段: 重复 <line> -->
-        <line>102-112</line>
-      </file>
+      <!-- file: 每个 <logControl> 至多一个 <file>；多文件请写多条 <logControl>。
+           `name` 必填，`lines` 可选：
+             缺省 / 空       -> 整文件通配
+             "N"             -> 单行, 内部存为 [N, N+1)
+             "N-M"           -> 半开区间 [N, M), 需 M > N
+             "s1, s2, ..."   -> 多段 OR, 以逗号 ',' 分隔, 段两侧允许空白 -->
+      <file name="Foo.cpp" lines="42, 60-65, 100-110"/>
 
-      <!-- 函数名 (重复多次以表达 OR) -->
+      <!-- 多值 OR：重复子元素 -->
       <func>DoBar</func>
       <func>DoBaz</func>
-
-      <!-- 线程 id (重复多次以表达 OR) -->
       <threadId>12345</threadId>
-      <threadId>23456</threadId>
-
-      <!-- 日志级别 (重复多次以表达 OR; 字符串大小写不敏感, 或整型) -->
       <level>warn</level>
       <level>error</level>
     </match>
 
-    <appenders>                                             <!-- 可选; 缺省 == 全部 appender -->
+    <appenders>                    <!-- 可选；缺省 / 为空 == 全部 appender -->
       <appender>console</appender>
       <appender>file</appender>
     </appenders>
 
-    <action>                                                <!-- 变体 1: 静音, 无操作数 -->
+    <action>                       <!-- mute 无操作数 -->
       <type>mute</type>
     </action>
-  </item>
+  </logControl>
 
-  <item>
-    <match><file><name>perf.cpp</name></file></match>
-    <action>                                                <!-- 变体 2: 提级, 操作数为 <newLevel> -->
+  <logControl>
+    <match><file name="perf.cpp"/></match>
+    <action>                       <!-- setLevel 携带 <newLevel> -->
       <type>setLevel</type>
       <newLevel>warn</newLevel>
     </action>
-  </item>
+  </logControl>
 </logControls>
 ```
 
-> 行号语法采用**左闭右开** `[begin, end)`——`begin` 包含、`end` 不包含——
-> 这与 llbc 内 `LLBC_Stream::Erase / Replace` 等使用 `[n0, n1)` 半开区间的
-> 风格保持一致。例如 `<line>10-12</line>` 命中第 10、11 行，**不**命中第
-> 12 行；多段写法 `<line>100</line><line>102-112</line>` 命中第 100 行 与
-> 第 102..111 行，**不**命中 101 / 112。
+### 字段解析规则（对照 `ParseLogControls`）
 
-### 解析规则（`ParseLogControls`）
+| 字段 | 允许形态 | 值语义 |
+| --- | --- | --- |
+| `<file name="..." lines="..."/>` | attr 形式；`name` 必填非空；`lines` 可选字符串 | `name` 是 basename；`lines` 段间以 `,` 分隔，段两侧空白 strip 后忽略；单段 `N` 存为 `[N, N+1)`，`N-M` 存为 `[N, M)`（要求 `0 <= N < M < INT_MAX`） |
+| `<func>` | 单个或重复子元素 | 每项 strip 后非空即收；OR |
+| `<threadId>` | 单个或重复子元素 | 十进制整数，允许前导 `+` / `-`；范围 `LLBC_ThreadId`；OR |
+| `<level>` | 单个或重复子元素 | 名称（`Debug` / `Info` / … 大小写不敏感）**或**十进制整数；必须落在 `LLBC_LogLevel::Begin..End` 内；OR |
+| `<appenders><appender>` | 容器 + 重复子元素 | 名称：`console` / `file` / `network`，大小写不敏感；未知名**静默丢弃**（不拒 item）；容器缺失 / 全部无效 == 全部 appender |
+| `<action><type>` | 必填 | 大小写不敏感；仅 `mute` / `setlevel` |
+| `<action><newLevel>` | 仅 `setLevel` 时读取 | 同 `<level>` 值语义 |
 
-下文给出 `LoggerConfigInfo::ParseLogControls` 把上述 XML 子树物化为
-`std::vector<LLBC_LogControlItem>` 的**逐字段、逐分支**的精确规则。它是
-schema 的执行级补充——schema 描述"长什么样"，本节描述"按什么顺序解析、
-谁先谁后、哪些情况静默跳过、哪些情况拒掉整个 `<item>`"。
+### 错误处理速查
 
-#### 遍历框架
+`ParseLogControls` 的三条原则：**未知即静默丢弃、可降级维度自动禁用、结构性错误拒整条 logControl**。
 
-1. 仅当 `cfg` 是 Dict、且其 `Children` 是 Seq 时才会进入遍历；否则视为
-   "没有配置任何控制项"，**静默返回**——这覆盖了 `.cfg` 扁平配置、XML 中
-   缺 `<logControls>` 节点等所有"无控制项"形态。
-2. 遍历 `<logControls>` 的直接子序列，仅识别 tag 名等于 `"item"` 的子元素；
-   其他 tag（含偶然写入的 `<foo/>`）**静默跳过**。
-3. 对每个 `<item>`，按 **match → appenders → action** 的顺序解析，并按
-   "解析到非法形态即 `continue` 整 item"的策略保持 all-or-nothing 单元语义。
-   只有走完全部三段、未被任何分支 `continue` 的 item 才会 `push_back` 到
-   输出列表。声明顺序在输出列表中被**完整保留**（后续 `LogControlMgr` 按
-   顺序应用，链式语义依赖该顺序）。
+| 触发条件 | 处理 |
+| --- | --- |
+| `<logControls>` 缺失 / 非 Dict / 出现在 `.cfg` 中 | 静默忽略整段（`.cfg` 会额外发一条 stderr 告警） |
+| `<logControl>` 下的未知 tag、多余的 `<match>` / `<file>` / `<appenders>` / `<action>` | 静默忽略；同名标量子元素只取第一次出现的值 |
+| `<func>` / `<threadId>` / `<level>` 个别项非法或为空 | 只丢该项；若该维度最终无有效值，则该维度自动不启用；item 保留 |
+| `<appender>` 未知名 | 静默丢弃；若全部无效，等价于 appenders 缺失（== 全部 appender） |
+| `<file>` 存在但 `name` 空 **或** `lines` 任一段非法 | **拒整条 logControl** |
+| `<action>` 缺失 / 非 Dict、`<type>` 未知、`setLevel` 缺 `<newLevel>` 或 `<newLevel>` 非法 | **拒整条 logControl** |
+| 所有 match 维度均未启用（`HasAnyMatch()` 失败） | **拒整条 logControl** |
 
-#### 1) match 段
+被拒的 logControl 不影响同一 `<logControls>` 里其它 logControl 的解析。
 
-- 在 `<item>` 的直接子序列里查找第一个 tag 为 `"match"` 的子元素，**只取
-  第一个**，其余 `<match>` 兄弟静默忽略。`<match>` 缺失或非 Dict 时，
-  match 段什么都不解析，最终在 `HasAnyMatch()` 校验处被丢弃。
-- match 内部按 `file → func → threadId → level` 的顺序解析；它们彼此独立，
-  解析顺序仅影响**错误检出顺序**，不影响最终语义。
-
-  | 维度 | 子元素形态 | 多值/单值 | 规则 |
-  | ---- | ---- | ---- | ---- |
-  | `file` | `<file><name>...</name>[<line>...</line>...]</file>` | 同 item 内**只取第一个** | 多个 `<file>` 时只解析第一个；第一个若非法（`<name>` 缺失/为空、任一 `<line>` 非法等）→ **整 item `continue`**。要表达"多个文件"应当写多个 `<item>` |
-  | `func` | `<func>name</func>`，可重复 | 多值（OR） | 取 `tolower` 前的原始文本；空/全空白项**静默丢弃**；最终列表非空才启用该规则 |
-  | `threadId` | `<threadId>n</threadId>`，可重复 | 多值（OR） | 每项必须能被 `ParseThreadIdStr` 解析为合法 tid；非法项**静默丢弃**；最终列表非空才启用 |
-  | `level` | `<level>warn</level>`，可重复 | 多值（OR） | 接受字符串（不区分大小写）或整型；越界/非法项**静默丢弃**；最终列表非空才启用 |
-
-- `<file>` 的 `<line>` 子元素可 0 至多个：0 个表示整文件通配；每个 `<line>` 的内联文本是**一段** `N` 或 `N-M`（半开区间，详见 `ParseLineToken`），任一 `<line>` 非法整 item 被跳过。多段 OR 通过重复 `<line>` 表达，与 `<func>` / `<threadId>` / `<level>` 的多值语义完全对称。
-- 单个维度的取值集合**在去掉非法元素后为空**等价于"该维度未启用"，不会
-  让整 item 失败；但若所有维度都未启用，会在 match 段末尾的 `HasAnyMatch()`
-  处统一 `continue`。
-- 任何一个**已启用维度**自身仍然是 OR；维度之间是 AND——这一行为是
-  `LogControlMgr::MatchOne` 的运行时语义，`ParseLogControls` 只负责"启用
-  对应维度并写入取值列表"。
-
-#### 2) appenders 段
-
-- 可选；遍历 `<item>` 直接子序列，命中第一个 `<appenders>` 后**只解析它一个**。
-- `<appender>` 文本通过 `ParseAppenderTypeStr` 翻译为 `LLBC_LogAppenderType`
-  整型；未识别字符串**静默丢弃**，整个 item **不会被** `continue`——这是
-  schema 中"未知 appender 名静默忽略，控制项整体保留"的来源（与 match 段
-  对非法 `<file/>` 的强约束**刻意不一致**）。
-- `appenderTypes` 为空向量在运行时含义为"对所有 appender 生效"。
-
-#### 3) action 段
-
-- 必选；遍历 `<item>` 直接子序列，命中第一个 `<action>` 后**只解析它一个**，
-  其余 `<action>` 静默忽略。`<action>` 缺失 → 整 item `continue`。
-- `<action>` 内的 `<type>` 子元素文本通过 `tolower` 标准化，识别两种变体：
-  - `<type>mute</type>`：写入 `action = Mute`，不再读任何操作数子元素。
-  - `<type>setLevel</type>`：写入 `action = SetLevel`，并要求**`<action>` 自身**
-    的直接子序列里出现至少一个合法的 `<newLevel>`：
-    - 文本通过 `ParseLevelStr` 解析；
-    - **只取第一个**，无论其合法与否；
-    - 第一个合法 → 写入 `item.newLevel`；
-    - 第一个非法 或 完全没有 `<newLevel>` → 整 item `continue`。
-  - 其他 `<type>`（包括 `<type>` 缺失/空文本、未知字符串如 `"unknownaction"`）
-    → 整 item `continue`。
-
-#### 静默跳过 vs 整项拒绝（速查）
-
-下列情况**静默跳过单个控制项**，不影响同列表中的其他合法控制项：
-
-| 触发条件 | 说明 |
-| ---- | ---- |
-| 元素 tag 不是 `<item>` | 整段 schema 只接受 `<item>` 作为子元素 |
-| `HasAnyMatch()` 失败 | 包括 `<match/>` 空块，以及所有维度取值集合在丢弃非法项后变空 |
-| 第一个 `<file>` 非法 | `<name>` 缺失/为空、任一 `<line>` 非法（非数字、负数、区间空/翻转等） |
-| `<action>` 缺失 | item 必须显式声明 action |
-| `<action>` 内 `<type>` 不是已知变体 | 含 `<type>` 缺省、未知字符串 |
-| `<action>` 内 `<type>setLevel</type>` 缺 `<newLevel>` 或值非法 | setLevel 操作数硬要求 |
-
-下列情况**静默跳过单条子元素**，控制项**整体保留**：
-
-| 触发条件 | 影响 |
-| ---- | ---- |
-| `<func>` / `<threadId>` / `<level>` 个别项非法或为空 | 仅丢弃该项；若该维度因此空了，则该维度自动不启用 |
-| `<appender>` 文本未识别 | 仅丢弃该项；其余 appender 仍生效；空集合等价于"全部 appender" |
-| `<logControls>` / `<item>` 下出现未知 tag | 直接忽略，不会让宿主 item 失败 |
-
-整个 `<logControls>` 子树本身缺失 / 不是合法 Dict（如 `.cfg` 配置不支持
-该子树）也是**静默跳过**，等价于"未配置任何控制项"。
-
-#### 显式忽略策略（不是 bug）
-
-- 同 `<item>` 内出现多个 `<match>` / `<file>` / `<appenders>` / `<action>`
-  时**只取第一个**：这条规则统一了"标量字段在 XML 中误写多份"的歧义；想
-  表达"多文件 mute / 多 appender 限定"应当通过**多个 `<item>`** 或同名重
-  复子元素（`<func>` / `<threadId>` / `<level>`）来表达。
-- 解析阶段**不做去重**：完全相同的两条 `<item>` 会原样进入输出列表；这是
-  刻意保留的——`LogControlMgr` 按顺序应用，重复项会在统计层多算一次，但
-  语义上等价；强行去重反而会丢失"重复即压力测试"这类用例。
-- 解析阶段**不做跨 item 校验**：例如"link.cpp 先 SetLevel 到 warn、再用
-  level==warn Mute"这种链式构造完全合法，由顺序保证。
+解析阶段**不做去重、不做跨 item 校验**：`link.cpp` 先 `SetLevel` 再按 `level==warn` `Mute` 这种链式构造由声明顺序保证。
 
 ---
 
-## 4. 控制 API（`LLBC_Logger`）
+## 4. 典型用法
 
-控制项**只从配置安装**。生产代码不应直接调用控制 API；下列接口仅供以下
-两条内部路径以及测试代码使用：
+### 4.1 静音某函数（只在 console）
 
-- `Logger::Initialize`：从 `LoggerConfigInfo::GetLogControls()` 一次性装载。
-- `LoggerMgr::Reload`：重新解析配置文件后，对每个 logger 调用一次完整替换。
-
-```cpp
-int    SetLogControls(const std::vector<LLBC_LogControlItem> &items);
-size_t GetLogControlCount() const;
-void   GetLogControls(std::vector<LLBC_LogControlItem> &out) const;
-uint64 GetLogControlSuppressedCount() const;
-void   ResetLogControlSuppressedCount();
-```
-
-- `SetLogControls(items)`：**原子整体替换**当前控制项列表。先全量校验
-  `items`，任一项非法则整体失败 (`LLBC_ERROR_INVALID`)、当前快照保持不变；
-  校验通过后单次原子发布新快照——正在 `OutputLogData()` 中的并发记录要么
-  完整看到旧快照、要么完整看到新快照，**不会观察到中间空状态**。
-  - 传空向量会发布一个空快照，`IsEmpty()` 快路径会跳过整段控制逻辑。
-  - `SuppressedCount` 不会被该操作清零（如需归零请显式调用
-    `ResetLogControlSuppressedCount()`）。
-  - 失败原因 (`LLBC_GetLastError`) `LLBC_ERROR_INVALID`：`HasAnyMatch()` 失
-    败、`haveFile && matchFile.empty()`、`matchLineRanges` 中存在 `begin < 0`
-    或 `end <= begin` 的非法段、`haveFunc && matchFuncs.empty()`、
-    `matchFuncs` 中存在空字符串、`haveThreadId && matchThreadIds.empty()`、
-    `haveLevel && matchLevels.empty()`、`matchLevels` 中存在非法 level、
-    非法 `action`、`SetLevel` 但 `newLevel` 非法、`appenderTypes` 中含
-    无效类型。
-- `GetLogControlSuppressedCount()`：**按 (record, appender) 计数**——一条
-  记录被 N 个 appender 静音就计 N。
-
-设计注记：之所以**不**提供运行时的 `Add / Remove / Clear` 增量 API——
-log control 是**配置项**，"哪些日志应当被静音/提级"应当跟配置文件同步演
-进（包括代码审查、版本管理、reload）。开放运行时增量入口会诱导跳过这些
-约束，违背 "可观测性配置即代码" 的初衷。所有读路径接口 (`GetLogControls`,
-`GetLogControlCount`, `Get/ResetLogControlSuppressedCount`) 始终可用。
-
-`SetLogControls` 与 `Apply` 共用 `LLBC_SpinLock`（仅在写侧之间互斥，
-读侧 lock-free）；`IsEmpty()` 走 `volatile bool` fast-path，用于无控制项
-时完全跳过整段控制逻辑。
-
----
-
-## 5. 典型用法
-
-控制项的"正常"装载入口是**配置文件**。下面每个例子先给等价的 XML/JSON 片段，
-再附一段"手动用 `SetLogControls` 安装"的代码——后者主要面向单测、自检工具
-或诊断小程序，正式业务代码请优先走配置 + `LLBC_LoggerMgrSingleton->Reload()`。
-
-每次 `SetLogControls` 都是**整体替换**：要"在原列表上加一条"必须自行先
-`GetLogControls(...)` 取回当前列表、push 后整体回写。
-
-### 5.1 仅 console 上静音某个吵闹函数
-
-```xml
-<mylogger>
-  <logControls>
-    <item>
-      <match><func>NoisyFunc</func></match>
-      <appenders><appender>console</appender></appenders>
-      <action><type>mute</type></action>
-    </item>
-  </logControls>
-</mylogger>
-```
-
-```cpp
-LLBC_LogControlItem item;
-item.func.enabled = true;
-item.func.values.emplace_back("NoisyFunc");
-item.appenderTypes.push_back(LLBC_LogAppenderType::Console);
-item.action = LLBC_LogControlAction::Mute;
-logger->SetLogControls({item});
-```
-
-### 5.2 文件级"提级"——所有低于 warn 的日志都改写到 warn 落地
+用 `<func>` 精确命中 + `<appenders>` 收窄作用域：file appender 仍然照常记录。
 
 ```xml
 <logControls>
-  <item>
-    <match><file><name>perf_hot_path.cpp</name></file></match>
+  <logControl>
+    <match><func>NoisyFunc</func></match>
+    <appenders><appender>console</appender></appenders>
+    <action><type>mute</type></action>
+  </logControl>
+</logControls>
+```
+
+### 4.2 链式：先提级再按级别静音
+
+跨 logControl 交互：**声明顺序即应用顺序**，两条必须在同一份配置里。
+
+```xml
+<logControls>
+  <logControl>
+    <match><file name="link.cpp"/></match>
     <action><type>setLevel</type><newLevel>warn</newLevel></action>
-  </item>
-</logControls>
-```
-
-```cpp
-LLBC_LogControlItem item;
-item.file.enabled = true;
-item.file.file = "perf_hot_path.cpp";
-item.action = LLBC_LogControlAction::SetLevel;
-item.newLevel = LLBC_LogLevel::Warn;
-logger->SetLogControls({item});
-```
-
-### 5.3 行号范围 / 多段静音 —— 半开区间 `[begin, end)`
-
-```xml
-<!-- 单段: file=hot.cpp 上 [120, 160) -->
-<logControls>
-  <item>
-    <match>
-      <file>
-        <name>hot.cpp</name>
-        <line>120-160</line>
-      </file>
-    </match>
-    <action><type>mute</type></action>
-  </item>
-</logControls>
-<!-- 多段: 50, 60-65, 70 -->
-<logControls>
-  <item>
-    <match>
-      <file>
-        <name>hot.cpp</name>
-        <line>50</line>
-        <line>60-65</line>
-        <line>70</line>
-      </file>
-    </match>
-    <action><type>mute</type></action>
-  </item>
-</logControls>
-```
-
-```cpp
-LLBC_LogControlItem item;
-item.file.enabled = true;
-item.file.file    = "hot.cpp";
-item.file.lineRanges.emplace_back(50, 51);   // 单行 50
-item.file.lineRanges.emplace_back(60, 65);   // [60, 65)
-item.file.lineRanges.emplace_back(70, 71);   // 单行 70
-item.action       = LLBC_LogControlAction::Mute;
-logger->SetLogControls({item});
-```
-
-> 推荐统一通过 `file.lineRanges` 表达单行 / 范围 / 多段三种情况；单行 `N`
-> 用 `emplace_back(N, N+1)`；空 `file.lineRanges` 表示通配整个文件。
-
-### 5.4 多值 func / threadId —— 任一命中即匹配
-
-```xml
-<logControls>
-  <item>
-    <match>
-      <func>NoisyA</func>
-      <func>NoisyB</func>
-    </match>
-    <action><type>mute</type></action>
-  </item>
-  <item>
-    <match>
-      <threadId>12345</threadId>
-      <threadId>23456</threadId>
-    </match>
-    <action><type>mute</type></action>
-  </item>
-</logControls>
-```
-
-```cpp
-LLBC_LogControlItem byFunc;
-byFunc.func.enabled = true;
-byFunc.func.values.emplace_back("NoisyA");
-byFunc.func.values.emplace_back("NoisyB");
-byFunc.action = LLBC_LogControlAction::Mute;
-
-LLBC_LogControlItem byTid;
-byTid.threadId.enabled = true;
-byTid.threadId.values.push_back(12345);
-byTid.threadId.values.push_back(23456);
-byTid.action = LLBC_LogControlAction::Mute;
-
-logger->SetLogControls({byFunc, byTid});
-```
-
-### 5.5 链式：先提级再按级别静音
-
-链式两条规则必须 **在同一个 `SetLogControls` 调用里按声明序安装**，因为
-chain 顺序由列表顺序决定，`SetLogControls` 是原子整体替换。
-
-```xml
-<logControls>
-  <item>
-    <match><file><name>link.cpp</name></file></match>
-    <action><type>setLevel</type><newLevel>warn</newLevel></action>
-  </item>
-  <item>
+  </logControl>
+  <logControl>
     <match><level>warn</level></match>
     <action><type>mute</type></action>
-  </item>
+  </logControl>
 </logControls>
-```
-
-```cpp
-LLBC_LogControlItem setlvl;
-setlvl.file.enabled = true;
-setlvl.file.file    = "link.cpp";
-setlvl.action       = LLBC_LogControlAction::SetLevel;
-setlvl.newLevel     = LLBC_LogLevel::Warn;
-
-LLBC_LogControlItem mute;
-mute.level.enabled = true;
-mute.level.values.push_back(LLBC_LogLevel::Warn);
-mute.action        = LLBC_LogControlAction::Mute;
-
-logger->SetLogControls({setlvl, mute});
-// link.cpp 上的 INFO 记录: 先被改写为 WARN, 再被 level==WARN 的 mute 命中.
-```
-
-### 5.6 多级别 OR + 多维度 AND —— 仅静音特定函数的 warn / error
-
-```xml
-<logControls>
-  <item>
-    <match>
-      <func>Stub</func>
-      <level>warn</level>
-      <level>error</level>
-    </match>
-    <action><type>mute</type></action>
-  </item>
-</logControls>
-```
-
-```cpp
-LLBC_LogControlItem item;
-item.func.enabled = true;
-item.func.values.emplace_back("Stub");                // func 维度: 等于 "Stub"
-item.level.enabled = true;
-item.level.values.push_back(LLBC_LogLevel::Warn);     // level 维度: warn 或 error
-item.level.values.push_back(LLBC_LogLevel::Error);
-item.action = LLBC_LogControlAction::Mute;
-logger->SetLogControls({item});
-// 命中条件: 函数名 == "Stub" 且 (level == warn 或 level == error).
-// 同函数的 info / 其它函数的 warn / error 都不会被静音.
+<!-- link.cpp 上的 info 记录: 先被第 1 条改写为 warn, 再被第 2 条 level==warn 的 mute 命中 -->
 ```
 
 ---
 
-## 6. 配置 Reload
+## 5. Reload
 
-`LLBC_LoggerMgrSingleton->Reload(newCfgFilePath)` 会把已存在的 logger 配置
-（默认重新加载首次 `Initialize` 用的那份配置文件）应用到 live logger 上。
-对 `logControls` 而言：
+`LLBC_LoggerMgrSingleton->Reload(cfgPath)` 会重新解析配置并对每个 logger 调一次 `SetLogControls` **整体重建**列表（不增量、不合并）。
 
-- 配置文件解析仍走标准管线：非法元素静默丢弃，同 `Initialize` 完全一致。
-- 内部对每个 logger 调一次 `Logger::SetLogControls(...)`：**整体重建**控制项
-  列表。这是 reload 时 `logControls` 唯一的更新方式——既不增量打补丁，也不
-  跨快照合并；旧快照在新快照原子发布后被整体淘汰。
-- 某条 reload 失败（任一项非法）时，对应 logger 的旧 logControls 保持有效
-  （`SetLogControls` 的 all-or-nothing 语义），整个 `Reload()` 返回
-  `LLBC_FAILED` 并设置 `LastError`。
-- `SuppressedCount` 不会被 reload 清零。如需归零请在 reload 后显式调用
-  `ResetLogControlSuppressedCount()`。
-- 已知限制（继承自 `LoggerMgr::Reload`）：仅刷新已存在的 logger；`Reload`
-  期间新增的 logger 段不会被创建。
+- 某个 logger 的新配置非法 → 该 logger 保留旧 logControls，`Reload()` 返回 `LLBC_FAILED`。
 
 ```cpp
-// 改了配置文件，希望热生效:
 if (LLBC_LoggerMgrSingleton->Reload() != LLBC_OK)
     fprintf(stderr, "reload failed: %s\n", LLBC_FormatLastError());
-
-// 也可重新指向另一份配置文件:
-if (LLBC_LoggerMgrSingleton->Reload("/etc/myapp/log.alt.xml") != LLBC_OK)
-    fprintf(stderr, "reload failed: %s\n", LLBC_FormatLastError());
 ```
-
-> 控制项不提供"绕过配置文件、由程序内代码动态注入"的稳定入口；如确需在
-> 测试 / 诊断工具里手动装入一组规则，可直接调用 `Logger::SetLogControls`，
-> 但生产代码不应依赖此路径——它存在的目的是供 `Initialize` / `Reload` 复用，
-> 不属于对外稳定 API。
-
----
-
-## 7. 与旧 `LLBC_LogMuteFilter` 的差异
-
-| 维度 | 旧 LogMuteFilter | 新 LogControlMgr |
-| ---- | ---------------- | ------------------- |
-| 维度组合 | 三类 mute 规则平铺，互不交叉 | 单控制项内多维度 AND，每条规则的取值集合内部 OR；多控制项按声明顺序串联 |
-| 应用范围 | 整 logger（所有 appender 共享） | 按 appender 单独应用（可显式限定 appender） |
-| 动作 | 仅 Mute（含"提级到 minLevel 的隐式 Mute"） | Mute / SetLevel 显式分开；SetLevel 在链中可被后续匹配 |
-| 配置 | 三个独立字符串 key + 自定义分隔符（`.cfg` / `.xml` 都支持） | 单一嵌套 XML 子树（仅 `.xml` 支持） |
-| API 命名 | `*LogMute*` | `*LogControl*` |
-| 计数语义 | 每条 record 计 1 次 | 每条 record × 命中 appender 计 1 次 |
-
-旧 API 已**全部移除**，业务层若仍在使用旧 `*LogMute*` 系列接口，须按新 API
-重构。

--- a/doc/log_control.md
+++ b/doc/log_control.md
@@ -1,0 +1,544 @@
+# Log Output Control Items（日志输出控制项）
+
+`llbc` 日志库提供了一套**统一的、按 appender 串行应用的日志输出控制机制**，
+用以替代历史上的 `LLBC_LogMuteFilter`。每个 logger 持有一个有序的控制项列表
+（`std::vector<LLBC_LogControlItem>`），在 `Logger::OutputLogData()`
+内部、对每个 appender 独立、按声明顺序应用。
+
+控制机制由两个设施组成：
+
+- **数据模型**：`LLBC_LogControlItem`（见 `llbc/core/log/LogControl.h`）。
+- **执行器**：`LLBC_LogControlMgr`（见 `llbc/core/log/LogControlMgr.h`）。
+
+---
+
+## 1. 控制项三段式结构
+
+每个 `LLBC_LogControlItem` 由三块组成：
+
+### a) Match Rules（匹配规则）
+
+控制项内**已启用**的维度之间为 **AND**（all-of，必须同时命中）；每条规则**自身的取值集合**（如 `file.lineRanges` / `func.values` / `threadId.values` / `level.values`）则为 **OR**（one-of，任一取值命中即视该条规则命中）。
+
+> 设计取舍：规则间 AND 与 iptables / log4j filter / SQL `WHERE` / Prometheus matcher 的多字段语义一致，符合"过滤器即交集"的工程直觉；如需在多个维度上做 OR，**追加多条控制项**即可。
+
+| 字段 | 标志 | 备注 |
+| ---- | ---- | ---- |
+| `matchFile` + `matchLineRanges` | `haveFile` | 文件 basename + 行号集合。`matchLineRanges` 是若干 **半开区间** `[begin, end)` 段的并集（与 `LLBC_Stream::Erase / Replace` 等 llbc 范围 API 风格一致）：单行 `N` 内部存为 `[N, N+1)`；为空表示通配整文件。每段必须满足 `0 <= begin && end > begin` |
+| `matchFuncs`              | `haveFunc` | 完整函数名列表（不支持通配）；记录的函数名等于其中**任意一个**即命中 |
+| `matchThreadIds`          | `haveThreadId` | 原生线程 id 列表；记录的 tid 等于其中**任意一个**即命中 |
+| `matchLevels`             | `haveLevel` | 日志级别列表；记录的 level 等于其中**任意一个**即命中。每个元素必须在 `LLBC_LogLevel::Begin..<End` 内 |
+
+`HasAnyMatch()` 校验至少一个维度被启用，否则视为非法控制项（`AddControl` 会
+拒绝；配置解析时会静默跳过）。
+
+### b) Appender Scope（应用 appender 集合）
+
+`appenderTypes` 为 `std::vector<int>`，元素为 `LLBC_LogAppenderType::Console / File
+/ Network` 之一。**留空 = 对所有 appender 生效**。
+
+### c) Action（生效规则）
+
+| 取值 | 语义 |
+| ---- | ---- |
+| `LLBC_LogControlAction::Mute`     | 在当前 appender 上丢弃此条记录，并对 `suppressedCount` +1 |
+| `LLBC_LogControlAction::SetLevel` | 把记录在当前 appender 链中的 effective level 改写为 `newLevel` |
+
+---
+
+## 2. 应用顺序与作用域
+
+对 **(record, appender)** 这一对：
+
+1. 控制项按声明顺序遍历。
+2. `ScopeAllows` 先过 appender 范围（空 = all），不命中则跳过该项。
+3. `MatchOne` 在当前 effective level 上做匹配（**已启用规则之间 AND**，每条规则**自身取值集合 OR**）；不命中则跳过该项。
+4. 命中后：
+   - `Mute`：立刻丢弃该 appender 上的本条记录，`suppressedCount` 原子 +1，
+     **停止**遍历当前 appender。
+   - `SetLevel`：把 effective level 改写为 `newLevel`；**继续**遍历后续控
+     制项（后续控制项可基于改写后的 level 再次匹配，例如先 SetLevel 到
+     warn，再用 `level==warn` 的 Mute 项二次过滤）。
+
+> ⚠️ **SetLevel 的改写不会跨 appender 泄漏**。每个 appender 都从
+> 记录的原始 level 开始遍历，因此 console 上的 SetLevel 不会影响 file
+> appender 看到的 level。
+
+---
+
+## 3. 配置驱动：`logControls`
+
+每个 logger 配置中可以提供一个名为 `logControls` 的**嵌套 XML 子树**，子树
+下每个 `<item>` 描述一个控制项。
+
+> **配置载体限制**：`logControls` **仅 XML 格式 (`.xml`) 支持**。`.cfg`
+> (property-style) 是扁平的 `key=value` 格式，无法承载 `item -> match ->
+> file/func/threadId/level/...` 这种嵌套结构；若在 `.cfg` 中写
+> `myLogger.logControls=...` 会被 LoggerConfigurator 检测到并触发 stderr
+> 警告，然后整段忽略。
+
+### XML schema
+
+本 schema 刻意**只用子元素、不用 XML 属性**：所有 payload 一律走内联文本或
+子元素，多值规则（OR）用同名重复子元素承载。这样 XML 与未来的 YAML/JSON
+loader 结构完全对齐（每个元素 == map 条目；重复子元素 == list），无需在
+"该字段做 attribute 还是做 key"上分裂。`<action>` 作为 sum type（mute 无操
+作数；setLevel 携带 `<newLevel>` 操作数），其判别 tag 也作为 `<type>` 子元素
+承载——保持"操作数与判别 tag 都在 `<action>` 子序列里"的一致性，也便于将来
+扩展更多 action 变体。
+
+```xml
+<logControls>
+  <item>
+    <match>
+      <!-- 文件名 + 行号 (多个 <file> 同一 item 内只取第一个) -->
+      <file><name>Foo.cpp</name></file>                     <!-- 通配整文件 -->
+      <file>
+        <name>Foo.cpp</name>
+        <line>42</line>                                     <!-- 单行 -->
+      </file>
+      <file>
+        <name>Foo.cpp</name>
+        <line>10-12</line>                                  <!-- 半开区间 [10, 12) -->
+      </file>
+      <file>
+        <name>Foo.cpp</name>
+        <line>100</line>                                    <!-- 多段: 重复 <line> -->
+        <line>102-112</line>
+      </file>
+
+      <!-- 函数名 (重复多次以表达 OR) -->
+      <func>DoBar</func>
+      <func>DoBaz</func>
+
+      <!-- 线程 id (重复多次以表达 OR) -->
+      <threadId>12345</threadId>
+      <threadId>23456</threadId>
+
+      <!-- 日志级别 (重复多次以表达 OR; 字符串大小写不敏感, 或整型) -->
+      <level>warn</level>
+      <level>error</level>
+    </match>
+
+    <appenders>                                             <!-- 可选; 缺省 == 全部 appender -->
+      <appender>console</appender>
+      <appender>file</appender>
+    </appenders>
+
+    <action>                                                <!-- 变体 1: 静音, 无操作数 -->
+      <type>mute</type>
+    </action>
+  </item>
+
+  <item>
+    <match><file><name>perf.cpp</name></file></match>
+    <action>                                                <!-- 变体 2: 提级, 操作数为 <newLevel> -->
+      <type>setLevel</type>
+      <newLevel>warn</newLevel>
+    </action>
+  </item>
+</logControls>
+```
+
+> 行号语法采用**左闭右开** `[begin, end)`——`begin` 包含、`end` 不包含——
+> 这与 llbc 内 `LLBC_Stream::Erase / Replace` 等使用 `[n0, n1)` 半开区间的
+> 风格保持一致。例如 `<line>10-12</line>` 命中第 10、11 行，**不**命中第
+> 12 行；多段写法 `<line>100</line><line>102-112</line>` 命中第 100 行 与
+> 第 102..111 行，**不**命中 101 / 112。
+
+### 解析规则（`ParseLogControls`）
+
+下文给出 `LoggerConfigInfo::ParseLogControls` 把上述 XML 子树物化为
+`std::vector<LLBC_LogControlItem>` 的**逐字段、逐分支**的精确规则。它是
+schema 的执行级补充——schema 描述"长什么样"，本节描述"按什么顺序解析、
+谁先谁后、哪些情况静默跳过、哪些情况拒掉整个 `<item>`"。
+
+#### 遍历框架
+
+1. 仅当 `cfg` 是 Dict、且其 `Children` 是 Seq 时才会进入遍历；否则视为
+   "没有配置任何控制项"，**静默返回**——这覆盖了 `.cfg` 扁平配置、XML 中
+   缺 `<logControls>` 节点等所有"无控制项"形态。
+2. 遍历 `<logControls>` 的直接子序列，仅识别 tag 名等于 `"item"` 的子元素；
+   其他 tag（含偶然写入的 `<foo/>`）**静默跳过**。
+3. 对每个 `<item>`，按 **match → appenders → action** 的顺序解析，并按
+   "解析到非法形态即 `continue` 整 item"的策略保持 all-or-nothing 单元语义。
+   只有走完全部三段、未被任何分支 `continue` 的 item 才会 `push_back` 到
+   输出列表。声明顺序在输出列表中被**完整保留**（后续 `LogControlMgr` 按
+   顺序应用，链式语义依赖该顺序）。
+
+#### 1) match 段
+
+- 在 `<item>` 的直接子序列里查找第一个 tag 为 `"match"` 的子元素，**只取
+  第一个**，其余 `<match>` 兄弟静默忽略。`<match>` 缺失或非 Dict 时，
+  match 段什么都不解析，最终在 `HasAnyMatch()` 校验处被丢弃。
+- match 内部按 `file → func → threadId → level` 的顺序解析；它们彼此独立，
+  解析顺序仅影响**错误检出顺序**，不影响最终语义。
+
+  | 维度 | 子元素形态 | 多值/单值 | 规则 |
+  | ---- | ---- | ---- | ---- |
+  | `file` | `<file><name>...</name>[<line>...</line>...]</file>` | 同 item 内**只取第一个** | 多个 `<file>` 时只解析第一个；第一个若非法（`<name>` 缺失/为空、任一 `<line>` 非法等）→ **整 item `continue`**。要表达"多个文件"应当写多个 `<item>` |
+  | `func` | `<func>name</func>`，可重复 | 多值（OR） | 取 `tolower` 前的原始文本；空/全空白项**静默丢弃**；最终列表非空才启用该规则 |
+  | `threadId` | `<threadId>n</threadId>`，可重复 | 多值（OR） | 每项必须能被 `ParseThreadIdStr` 解析为合法 tid；非法项**静默丢弃**；最终列表非空才启用 |
+  | `level` | `<level>warn</level>`，可重复 | 多值（OR） | 接受字符串（不区分大小写）或整型；越界/非法项**静默丢弃**；最终列表非空才启用 |
+
+- `<file>` 的 `<line>` 子元素可 0 至多个：0 个表示整文件通配；每个 `<line>` 的内联文本是**一段** `N` 或 `N-M`（半开区间，详见 `ParseLineToken`），任一 `<line>` 非法整 item 被跳过。多段 OR 通过重复 `<line>` 表达，与 `<func>` / `<threadId>` / `<level>` 的多值语义完全对称。
+- 单个维度的取值集合**在去掉非法元素后为空**等价于"该维度未启用"，不会
+  让整 item 失败；但若所有维度都未启用，会在 match 段末尾的 `HasAnyMatch()`
+  处统一 `continue`。
+- 任何一个**已启用维度**自身仍然是 OR；维度之间是 AND——这一行为是
+  `LogControlMgr::MatchOne` 的运行时语义，`ParseLogControls` 只负责"启用
+  对应维度并写入取值列表"。
+
+#### 2) appenders 段
+
+- 可选；遍历 `<item>` 直接子序列，命中第一个 `<appenders>` 后**只解析它一个**。
+- `<appender>` 文本通过 `ParseAppenderTypeStr` 翻译为 `LLBC_LogAppenderType`
+  整型；未识别字符串**静默丢弃**，整个 item **不会被** `continue`——这是
+  schema 中"未知 appender 名静默忽略，控制项整体保留"的来源（与 match 段
+  对非法 `<file/>` 的强约束**刻意不一致**）。
+- `appenderTypes` 为空向量在运行时含义为"对所有 appender 生效"。
+
+#### 3) action 段
+
+- 必选；遍历 `<item>` 直接子序列，命中第一个 `<action>` 后**只解析它一个**，
+  其余 `<action>` 静默忽略。`<action>` 缺失 → 整 item `continue`。
+- `<action>` 内的 `<type>` 子元素文本通过 `tolower` 标准化，识别两种变体：
+  - `<type>mute</type>`：写入 `action = Mute`，不再读任何操作数子元素。
+  - `<type>setLevel</type>`：写入 `action = SetLevel`，并要求**`<action>` 自身**
+    的直接子序列里出现至少一个合法的 `<newLevel>`：
+    - 文本通过 `ParseLevelStr` 解析；
+    - **只取第一个**，无论其合法与否；
+    - 第一个合法 → 写入 `item.newLevel`；
+    - 第一个非法 或 完全没有 `<newLevel>` → 整 item `continue`。
+  - 其他 `<type>`（包括 `<type>` 缺失/空文本、未知字符串如 `"unknownaction"`）
+    → 整 item `continue`。
+
+#### 静默跳过 vs 整项拒绝（速查）
+
+下列情况**静默跳过单个控制项**，不影响同列表中的其他合法控制项：
+
+| 触发条件 | 说明 |
+| ---- | ---- |
+| 元素 tag 不是 `<item>` | 整段 schema 只接受 `<item>` 作为子元素 |
+| `HasAnyMatch()` 失败 | 包括 `<match/>` 空块，以及所有维度取值集合在丢弃非法项后变空 |
+| 第一个 `<file>` 非法 | `<name>` 缺失/为空、任一 `<line>` 非法（非数字、负数、区间空/翻转等） |
+| `<action>` 缺失 | item 必须显式声明 action |
+| `<action>` 内 `<type>` 不是已知变体 | 含 `<type>` 缺省、未知字符串 |
+| `<action>` 内 `<type>setLevel</type>` 缺 `<newLevel>` 或值非法 | setLevel 操作数硬要求 |
+
+下列情况**静默跳过单条子元素**，控制项**整体保留**：
+
+| 触发条件 | 影响 |
+| ---- | ---- |
+| `<func>` / `<threadId>` / `<level>` 个别项非法或为空 | 仅丢弃该项；若该维度因此空了，则该维度自动不启用 |
+| `<appender>` 文本未识别 | 仅丢弃该项；其余 appender 仍生效；空集合等价于"全部 appender" |
+| `<logControls>` / `<item>` 下出现未知 tag | 直接忽略，不会让宿主 item 失败 |
+
+整个 `<logControls>` 子树本身缺失 / 不是合法 Dict（如 `.cfg` 配置不支持
+该子树）也是**静默跳过**，等价于"未配置任何控制项"。
+
+#### 显式忽略策略（不是 bug）
+
+- 同 `<item>` 内出现多个 `<match>` / `<file>` / `<appenders>` / `<action>`
+  时**只取第一个**：这条规则统一了"标量字段在 XML 中误写多份"的歧义；想
+  表达"多文件 mute / 多 appender 限定"应当通过**多个 `<item>`** 或同名重
+  复子元素（`<func>` / `<threadId>` / `<level>`）来表达。
+- 解析阶段**不做去重**：完全相同的两条 `<item>` 会原样进入输出列表；这是
+  刻意保留的——`LogControlMgr` 按顺序应用，重复项会在统计层多算一次，但
+  语义上等价；强行去重反而会丢失"重复即压力测试"这类用例。
+- 解析阶段**不做跨 item 校验**：例如"link.cpp 先 SetLevel 到 warn、再用
+  level==warn Mute"这种链式构造完全合法，由顺序保证。
+
+---
+
+## 4. 控制 API（`LLBC_Logger`）
+
+控制项**只从配置安装**。生产代码不应直接调用控制 API；下列接口仅供以下
+两条内部路径以及测试代码使用：
+
+- `Logger::Initialize`：从 `LoggerConfigInfo::GetLogControls()` 一次性装载。
+- `LoggerMgr::Reload`：重新解析配置文件后，对每个 logger 调用一次完整替换。
+
+```cpp
+int    SetLogControls(const std::vector<LLBC_LogControlItem> &items);
+size_t GetLogControlCount() const;
+void   GetLogControls(std::vector<LLBC_LogControlItem> &out) const;
+uint64 GetLogControlSuppressedCount() const;
+void   ResetLogControlSuppressedCount();
+```
+
+- `SetLogControls(items)`：**原子整体替换**当前控制项列表。先全量校验
+  `items`，任一项非法则整体失败 (`LLBC_ERROR_INVALID`)、当前快照保持不变；
+  校验通过后单次原子发布新快照——正在 `OutputLogData()` 中的并发记录要么
+  完整看到旧快照、要么完整看到新快照，**不会观察到中间空状态**。
+  - 传空向量会发布一个空快照，`IsEmpty()` 快路径会跳过整段控制逻辑。
+  - `SuppressedCount` 不会被该操作清零（如需归零请显式调用
+    `ResetLogControlSuppressedCount()`）。
+  - 失败原因 (`LLBC_GetLastError`) `LLBC_ERROR_INVALID`：`HasAnyMatch()` 失
+    败、`haveFile && matchFile.empty()`、`matchLineRanges` 中存在 `begin < 0`
+    或 `end <= begin` 的非法段、`haveFunc && matchFuncs.empty()`、
+    `matchFuncs` 中存在空字符串、`haveThreadId && matchThreadIds.empty()`、
+    `haveLevel && matchLevels.empty()`、`matchLevels` 中存在非法 level、
+    非法 `action`、`SetLevel` 但 `newLevel` 非法、`appenderTypes` 中含
+    无效类型。
+- `GetLogControlSuppressedCount()`：**按 (record, appender) 计数**——一条
+  记录被 N 个 appender 静音就计 N。
+
+设计注记：之所以**不**提供运行时的 `Add / Remove / Clear` 增量 API——
+log control 是**配置项**，"哪些日志应当被静音/提级"应当跟配置文件同步演
+进（包括代码审查、版本管理、reload）。开放运行时增量入口会诱导跳过这些
+约束，违背 "可观测性配置即代码" 的初衷。所有读路径接口 (`GetLogControls`,
+`GetLogControlCount`, `Get/ResetLogControlSuppressedCount`) 始终可用。
+
+`SetLogControls` 与 `Apply` 共用 `LLBC_SpinLock`（仅在写侧之间互斥，
+读侧 lock-free）；`IsEmpty()` 走 `volatile bool` fast-path，用于无控制项
+时完全跳过整段控制逻辑。
+
+---
+
+## 5. 典型用法
+
+控制项的"正常"装载入口是**配置文件**。下面每个例子先给等价的 XML/JSON 片段，
+再附一段"手动用 `SetLogControls` 安装"的代码——后者主要面向单测、自检工具
+或诊断小程序，正式业务代码请优先走配置 + `LLBC_LoggerMgrSingleton->Reload()`。
+
+每次 `SetLogControls` 都是**整体替换**：要"在原列表上加一条"必须自行先
+`GetLogControls(...)` 取回当前列表、push 后整体回写。
+
+### 5.1 仅 console 上静音某个吵闹函数
+
+```xml
+<mylogger>
+  <logControls>
+    <item>
+      <match><func>NoisyFunc</func></match>
+      <appenders><appender>console</appender></appenders>
+      <action><type>mute</type></action>
+    </item>
+  </logControls>
+</mylogger>
+```
+
+```cpp
+LLBC_LogControlItem item;
+item.func.enabled = true;
+item.func.values.emplace_back("NoisyFunc");
+item.appenderTypes.push_back(LLBC_LogAppenderType::Console);
+item.action = LLBC_LogControlAction::Mute;
+logger->SetLogControls({item});
+```
+
+### 5.2 文件级"提级"——所有低于 warn 的日志都改写到 warn 落地
+
+```xml
+<logControls>
+  <item>
+    <match><file><name>perf_hot_path.cpp</name></file></match>
+    <action><type>setLevel</type><newLevel>warn</newLevel></action>
+  </item>
+</logControls>
+```
+
+```cpp
+LLBC_LogControlItem item;
+item.file.enabled = true;
+item.file.file = "perf_hot_path.cpp";
+item.action = LLBC_LogControlAction::SetLevel;
+item.newLevel = LLBC_LogLevel::Warn;
+logger->SetLogControls({item});
+```
+
+### 5.3 行号范围 / 多段静音 —— 半开区间 `[begin, end)`
+
+```xml
+<!-- 单段: file=hot.cpp 上 [120, 160) -->
+<logControls>
+  <item>
+    <match>
+      <file>
+        <name>hot.cpp</name>
+        <line>120-160</line>
+      </file>
+    </match>
+    <action><type>mute</type></action>
+  </item>
+</logControls>
+<!-- 多段: 50, 60-65, 70 -->
+<logControls>
+  <item>
+    <match>
+      <file>
+        <name>hot.cpp</name>
+        <line>50</line>
+        <line>60-65</line>
+        <line>70</line>
+      </file>
+    </match>
+    <action><type>mute</type></action>
+  </item>
+</logControls>
+```
+
+```cpp
+LLBC_LogControlItem item;
+item.file.enabled = true;
+item.file.file    = "hot.cpp";
+item.file.lineRanges.emplace_back(50, 51);   // 单行 50
+item.file.lineRanges.emplace_back(60, 65);   // [60, 65)
+item.file.lineRanges.emplace_back(70, 71);   // 单行 70
+item.action       = LLBC_LogControlAction::Mute;
+logger->SetLogControls({item});
+```
+
+> 推荐统一通过 `file.lineRanges` 表达单行 / 范围 / 多段三种情况；单行 `N`
+> 用 `emplace_back(N, N+1)`；空 `file.lineRanges` 表示通配整个文件。
+
+### 5.4 多值 func / threadId —— 任一命中即匹配
+
+```xml
+<logControls>
+  <item>
+    <match>
+      <func>NoisyA</func>
+      <func>NoisyB</func>
+    </match>
+    <action><type>mute</type></action>
+  </item>
+  <item>
+    <match>
+      <threadId>12345</threadId>
+      <threadId>23456</threadId>
+    </match>
+    <action><type>mute</type></action>
+  </item>
+</logControls>
+```
+
+```cpp
+LLBC_LogControlItem byFunc;
+byFunc.func.enabled = true;
+byFunc.func.values.emplace_back("NoisyA");
+byFunc.func.values.emplace_back("NoisyB");
+byFunc.action = LLBC_LogControlAction::Mute;
+
+LLBC_LogControlItem byTid;
+byTid.threadId.enabled = true;
+byTid.threadId.values.push_back(12345);
+byTid.threadId.values.push_back(23456);
+byTid.action = LLBC_LogControlAction::Mute;
+
+logger->SetLogControls({byFunc, byTid});
+```
+
+### 5.5 链式：先提级再按级别静音
+
+链式两条规则必须 **在同一个 `SetLogControls` 调用里按声明序安装**，因为
+chain 顺序由列表顺序决定，`SetLogControls` 是原子整体替换。
+
+```xml
+<logControls>
+  <item>
+    <match><file><name>link.cpp</name></file></match>
+    <action><type>setLevel</type><newLevel>warn</newLevel></action>
+  </item>
+  <item>
+    <match><level>warn</level></match>
+    <action><type>mute</type></action>
+  </item>
+</logControls>
+```
+
+```cpp
+LLBC_LogControlItem setlvl;
+setlvl.file.enabled = true;
+setlvl.file.file    = "link.cpp";
+setlvl.action       = LLBC_LogControlAction::SetLevel;
+setlvl.newLevel     = LLBC_LogLevel::Warn;
+
+LLBC_LogControlItem mute;
+mute.level.enabled = true;
+mute.level.values.push_back(LLBC_LogLevel::Warn);
+mute.action        = LLBC_LogControlAction::Mute;
+
+logger->SetLogControls({setlvl, mute});
+// link.cpp 上的 INFO 记录: 先被改写为 WARN, 再被 level==WARN 的 mute 命中.
+```
+
+### 5.6 多级别 OR + 多维度 AND —— 仅静音特定函数的 warn / error
+
+```xml
+<logControls>
+  <item>
+    <match>
+      <func>Stub</func>
+      <level>warn</level>
+      <level>error</level>
+    </match>
+    <action><type>mute</type></action>
+  </item>
+</logControls>
+```
+
+```cpp
+LLBC_LogControlItem item;
+item.func.enabled = true;
+item.func.values.emplace_back("Stub");                // func 维度: 等于 "Stub"
+item.level.enabled = true;
+item.level.values.push_back(LLBC_LogLevel::Warn);     // level 维度: warn 或 error
+item.level.values.push_back(LLBC_LogLevel::Error);
+item.action = LLBC_LogControlAction::Mute;
+logger->SetLogControls({item});
+// 命中条件: 函数名 == "Stub" 且 (level == warn 或 level == error).
+// 同函数的 info / 其它函数的 warn / error 都不会被静音.
+```
+
+---
+
+## 6. 配置 Reload
+
+`LLBC_LoggerMgrSingleton->Reload(newCfgFilePath)` 会把已存在的 logger 配置
+（默认重新加载首次 `Initialize` 用的那份配置文件）应用到 live logger 上。
+对 `logControls` 而言：
+
+- 配置文件解析仍走标准管线：非法元素静默丢弃，同 `Initialize` 完全一致。
+- 内部对每个 logger 调一次 `Logger::SetLogControls(...)`：**整体重建**控制项
+  列表。这是 reload 时 `logControls` 唯一的更新方式——既不增量打补丁，也不
+  跨快照合并；旧快照在新快照原子发布后被整体淘汰。
+- 某条 reload 失败（任一项非法）时，对应 logger 的旧 logControls 保持有效
+  （`SetLogControls` 的 all-or-nothing 语义），整个 `Reload()` 返回
+  `LLBC_FAILED` 并设置 `LastError`。
+- `SuppressedCount` 不会被 reload 清零。如需归零请在 reload 后显式调用
+  `ResetLogControlSuppressedCount()`。
+- 已知限制（继承自 `LoggerMgr::Reload`）：仅刷新已存在的 logger；`Reload`
+  期间新增的 logger 段不会被创建。
+
+```cpp
+// 改了配置文件，希望热生效:
+if (LLBC_LoggerMgrSingleton->Reload() != LLBC_OK)
+    fprintf(stderr, "reload failed: %s\n", LLBC_FormatLastError());
+
+// 也可重新指向另一份配置文件:
+if (LLBC_LoggerMgrSingleton->Reload("/etc/myapp/log.alt.xml") != LLBC_OK)
+    fprintf(stderr, "reload failed: %s\n", LLBC_FormatLastError());
+```
+
+> 控制项不提供"绕过配置文件、由程序内代码动态注入"的稳定入口；如确需在
+> 测试 / 诊断工具里手动装入一组规则，可直接调用 `Logger::SetLogControls`，
+> 但生产代码不应依赖此路径——它存在的目的是供 `Initialize` / `Reload` 复用，
+> 不属于对外稳定 API。
+
+---
+
+## 7. 与旧 `LLBC_LogMuteFilter` 的差异
+
+| 维度 | 旧 LogMuteFilter | 新 LogControlMgr |
+| ---- | ---------------- | ------------------- |
+| 维度组合 | 三类 mute 规则平铺，互不交叉 | 单控制项内多维度 AND，每条规则的取值集合内部 OR；多控制项按声明顺序串联 |
+| 应用范围 | 整 logger（所有 appender 共享） | 按 appender 单独应用（可显式限定 appender） |
+| 动作 | 仅 Mute（含"提级到 minLevel 的隐式 Mute"） | Mute / SetLevel 显式分开；SetLevel 在链中可被后续匹配 |
+| 配置 | 三个独立字符串 key + 自定义分隔符（`.cfg` / `.xml` 都支持） | 单一嵌套 XML 子树（仅 `.xml` 支持） |
+| API 命名 | `*LogMute*` | `*LogControl*` |
+| 计数语义 | 每条 record 计 1 次 | 每条 record × 命中 appender 计 1 次 |
+
+旧 API 已**全部移除**，业务层若仍在使用旧 `*LogMute*` 系列接口，须按新 API
+重构。

--- a/llbc/include/llbc/core/log/BaseLogAppender.h
+++ b/llbc/include/llbc/core/log/BaseLogAppender.h
@@ -39,7 +39,7 @@ __LLBC_NS_BEGIN
 /**
  * The log appender type class encapsulation.
  */
-class LLBC_LogAppenderType
+class LLBC_EXPORT LLBC_LogAppenderType
 {
 public:
     /**
@@ -61,6 +61,25 @@ public:
      * @return bool - reutrn true if valid, otherwise return false.
      */
     static constexpr bool IsValid(int appenderType) { return appenderType >= Begin && appenderType < End; }
+
+    /**
+     * Get specific appender type string representation.
+     * @param[in] appenderType - the appender type.
+     * @return const LLBC_CString & - the type string representation, lower-case
+     *                                ("console"/"file"/"network"); returns
+     *                                "unknown" when appenderType is invalid.
+     */
+    static const LLBC_CString &GetTypeStr(int appenderType);
+
+    /**
+     * Get specific appender type enum by type string representation.
+     * Comparison is case-insensitive; surrounding whitespace is NOT stripped
+     * (callers should pre-trim if needed).
+     * @param[in] typeStr - the type string representation.
+     * @return int - the appender type enum, returns LLBC_LogAppenderType::End
+     *               when typeStr is empty or unknown.
+     */
+    static int GetTypeEnum(const LLBC_CString &typeStr);
 };
 
 /**

--- a/llbc/include/llbc/core/log/LogConfigLoader.h
+++ b/llbc/include/llbc/core/log/LogConfigLoader.h
@@ -1,0 +1,72 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include "llbc/core/variant/Variant.h"
+
+__LLBC_NS_BEGIN
+
+/**
+ * \brief The log config loader.
+ *
+ * Load log config file into a Config Intermediate Representation (CIR):
+ * a plain map/seq/scalar LLBC_Variant tree, carrying no source-format
+ * metadata (XML attribute keys, comments, ...). Downstream layers
+ * (LoggerConfigurator / LoggerConfigInfo) consume CIR only and stay
+ * independent of the underlying config file format.
+ *
+ * Currently supports XML; kept as a dedicated (log-only) loader so it can
+ * be extended with additional formats (yaml/json/...) without touching
+ * the general-purpose LLBC config utilities.
+ *
+ * @note This class is for internal use of the log module only. It is
+ *       intentionally not part of the public LLBC config API.
+ */
+class LLBC_HIDDEN LLBC_LogConfigLoader
+{
+public:
+    /**
+     * Load XML config file and convert to CIR.
+     *
+     * Structural mapping rules (business-agnostic, driven only by XML shape):
+     *   - Leaf element (no attributes AND no children) -> Str(inline-text).
+     *   - Compound element                             -> Dict:
+     *       * every attribute becomes a scalar entry (Str), key = attr name;
+     *       * every child recursively converted, keyed by child tag name;
+     *       * when a tag name repeats (>=2 siblings under the same parent),
+     *         all such siblings are gathered into a Seq; a single occurrence
+     *         stays as a bare scalar/Dict.
+     *       * on rare attr/child key collision, child wins.
+     *   - Document root is treated as a container: its top-level element
+     *     (e.g. <Log>) is placed under `cir[<rootTag>]` as a Dict.
+     *
+     * @param[in]  filePath - the XML config file path.
+     * @param[out] cir      - the resulting CIR; on failure will be set to Nil.
+     * @return int - LLBC_OK on success, LLBC_FAILED otherwise. On failure a
+     *               human-readable detail is recorded via LLBC_SetLastError;
+     *               callers can retrieve it with LLBC_FormatLastError().
+     */
+    static int LoadXmlFromFile(const LLBC_String &filePath,
+                               LLBC_Variant &cir);
+};
+
+__LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogControl.h
+++ b/llbc/include/llbc/core/log/LogControl.h
@@ -1,0 +1,188 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include "llbc/common/Common.h"
+
+__LLBC_NS_BEGIN
+
+/**
+ * \brief Log control item match-rule kinds.
+ *
+ * Within one control item, enabled rules are AND-combined (all-of); each
+ * rule's own value-set (e.g. func.values, level.values, file.lineRanges)
+ * is OR-combined (one-of) internally. To express OR between top-level
+ * dimensions, install multiple control items.
+ */
+class LLBC_LogControlMatchType
+{
+public:
+    enum
+    {
+        Begin,
+
+        File = Begin,   // match by file (basename) + optional line(s).
+                        // file.lineRanges holds zero-or-more half-open ranges
+                        // [begin, end); a single line N is stored as [N, N+1).
+                        // Empty lineRanges means "any line of file.file"
+                        // (whole-file wildcard).
+        Func,           // match by function name; matches if record's function
+                        // equals ANY of func.values (exact, no wildcard).
+        ThreadId,       // match by native thread id; matches if record's tid
+                        // equals ANY of threadId.values.
+        Level,          // match by log level; matches if record's level equals
+                        // ANY of level.values.
+
+        End
+    };
+
+    /**
+     * @param[in] matchType - candidate match-rule kind.
+     * @return bool - true iff `matchType` is in [Begin, End).
+     */
+    static constexpr bool IsValid(int matchType)
+    {
+        return matchType >= Begin && matchType < End;
+    }
+};
+
+/**
+ * \brief Log control item action kinds.
+ *
+ * - Mute    : drop the matched log record (on the configured appenders;
+ *             if appenderTypes is empty, drop on every appender).
+ * - SetLevel: rewrite the matched log record's level to `newLevel`. The
+ *             rewrite is observable to subsequent control items in the
+ *             chain (so a later item can match against the new level).
+ */
+class LLBC_LogControlAction
+{
+public:
+    enum
+    {
+        Unset = 0,      // sentinel: action must be set explicitly. Items
+                        // default-construct `action` to Unset and are
+                        // rejected by SetControls() until overwritten,
+                        // so a missed assignment fails loudly rather than
+                        // silently defaulting to the destructive Mute.
+        Begin,
+
+        Mute = Begin,   // drop the matched record (on the configured appenders).
+        SetLevel,       // rewrite log level to <newLevel>.
+
+        End
+    };
+
+    /**
+     * @param[in] action - candidate action kind.
+     * @return bool - true iff `action` is in [Begin, End); Unset is invalid.
+     */
+    static constexpr bool IsValid(int action)
+    {
+        return action >= Begin && action < End;
+    }
+};
+
+/**
+ * \brief A single OR-combined value-set for a match rule.
+ *
+ * Pairs an enable flag with the rule's value-set. Values are OR-combined
+ * inside the rule (record matches iff its field equals ANY entry of
+ * `values`); different rules within an item are AND-combined at the
+ * executor level.
+ *
+ * Invariants when `enabled == true`:
+ *   - `values` is non-empty;
+ *   - per-rule payload constraints hold (e.g. each level entry must be a
+ *     valid LLBC_LogLevel; validated at executor construction).
+ */
+template <typename T>
+struct LLBC_LogMatchSet
+{
+    bool enabled;
+    std::vector<T> values;
+
+    LLBC_LogMatchSet(): enabled(false) {}
+};
+
+/**
+ * \brief Match clause for the File rule (file basename + line ranges).
+ *
+ * Each range is half-open [begin, end) with 0 <= begin < end; a single
+ * line N is stored as [N, N+1). An empty `lineRanges` means "any line
+ * of `file`" (whole-file wildcard). The record's line matches if it
+ * lies in ANY segment (OR-combined inside the rule).
+ */
+struct LLBC_LogFileMatch
+{
+    bool enabled;
+    LLBC_String file;                                  // file basename, valid when enabled.
+    std::vector<std::pair<int, int> > lineRanges;      // half-open [begin, end) segments.
+
+    LLBC_LogFileMatch(): enabled(false) {}
+};
+
+/**
+ * \brief A single log output control item.
+ *
+ * Three parts:
+ *   a) Match rules: zero-or-more of {File, Func, ThreadId, Level}. See
+ *      LLBC_LogControlMatchType for AND/OR combination semantics. An empty
+ *      rule set means "match everything" and is rejected on validation.
+ *   b) Appender scope: a set of LLBC_LogAppenderType values; empty == all.
+ *   c) Action: Mute or SetLevel(+newLevel). See LLBC_LogControlAction.
+ */
+struct LLBC_LogControlItem
+{
+public:
+    // a) match rules; AND-combined when enabled. Each rule carries its own
+    //    enable flag (file.enabled / func.enabled / threadId.enabled /
+    //    level.enabled).
+    LLBC_LogFileMatch                   file;       // File rule (basename + line ranges).
+    LLBC_LogMatchSet<LLBC_String>       func;       // Func rule; values: function names (exact).
+    LLBC_LogMatchSet<LLBC_ThreadId>     threadId;   // ThreadId rule; values: native tids.
+    LLBC_LogMatchSet<int>               level;      // Level rule; values: each in LLBC_LogLevel::Begin..<End.
+
+    // b) appender scope; empty == all appenders.
+    std::vector<int> appenderTypes;
+
+    // c) action; default-constructed to Unset (rejected by SetControls()
+    //    until set explicitly — see LLBC_LogControlAction::Unset).
+    int action;                // LLBC_LogControlAction::Mute / SetLevel.
+    int newLevel;              // valid when action == SetLevel.
+
+public:
+    LLBC_LogControlItem();
+
+    /**
+     * @return bool - true iff at least one match rule is enabled (i.e. a
+     *                non-empty match; empty match is a config error).
+     */
+    bool HasAnyMatch() const
+    {
+        return file.enabled || func.enabled || threadId.enabled || level.enabled;
+    }
+};
+
+__LLBC_NS_END
+
+#include "llbc/core/log/LogControlInl.h"

--- a/llbc/include/llbc/core/log/LogControlAction.h
+++ b/llbc/include/llbc/core/log/LogControlAction.h
@@ -1,0 +1,125 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include "llbc/common/Common.h"
+
+__LLBC_NS_BEGIN
+
+// Pre-declare.
+struct LLBC_LogControlApplyResult;
+struct LLBC_LogControlItem;
+
+/**
+ * \brief Log control action base class.
+ *
+ * Polymorphic counterpart of LLBC_LogControlItem::action. Immutable after
+ * Initialize(); Apply() is const and reentrant. Owned by the executor.
+ */
+class LLBC_HIDDEN LLBC_BaseLogControlAction
+{
+public:
+    using ApplyResult = LLBC_LogControlApplyResult;
+
+    virtual ~LLBC_BaseLogControlAction() = default;
+
+    /**
+     * Create & initialize the action for the given control item.
+     * @param[in] item - the source control item.
+     * @return LLBC_BaseLogControlAction * - the new action, or nullptr on
+     *                                       unknown/unset action or init
+     *                                       failure. Does NOT set LLBC_ERROR.
+     */
+    static LLBC_BaseLogControlAction *Create(const LLBC_LogControlItem &item);
+
+    /**
+     * Initialize from the control item (reads only the fields relevant to
+     * the concrete subclass).
+     * @param[in] item - the source control item.
+     * @return int - LLBC_OK / LLBC_FAILED.
+     */
+    virtual int Initialize(const LLBC_LogControlItem &item) = 0;
+
+    /**
+     * Apply this action onto `io`. Caller has already passed Match().
+     * @param[in,out] io - the cross-executor apply result to mutate
+     *                     (e.g. set `muted`, rewrite effective level).
+     */
+    virtual void Apply(ApplyResult &io) const = 0;
+
+protected:
+    LLBC_BaseLogControlAction() = default;
+
+    // Disable assignment.
+    LLBC_DISABLE_ASSIGNMENT(LLBC_BaseLogControlAction);
+};
+
+/**
+ * \brief Mute action: drop the matched record.
+ *
+ * Signals cut-off via `io.muted = true`; LLBC_LogControlMgr breaks the
+ * executor loop and bumps the suppression counter.
+ */
+class LLBC_HIDDEN LLBC_LogMuteAction final : public LLBC_BaseLogControlAction
+{
+public:
+    LLBC_LogMuteAction() = default;
+
+    /**
+     * No-op: mute action carries no payload.
+     * @param[in] item - unused.
+     * @return int - always LLBC_OK.
+     */
+    int Initialize(const LLBC_LogControlItem &item) override;
+
+    /**
+     * @param[in,out] io - sets `io.muted = true`.
+     */
+    void Apply(ApplyResult &io) const override;
+};
+
+/**
+ * \brief SetLevel action: rewrite the chain's effective level.
+ *
+ * Later executors in the same chain see the rewritten level.
+ */
+class LLBC_HIDDEN LLBC_LogSetLevelAction final : public LLBC_BaseLogControlAction
+{
+public:
+    LLBC_LogSetLevelAction();
+
+    /**
+     * @param[in] item - the source control item; only `newLevel` is read.
+     * @return int - LLBC_FAILED if `item.newLevel` is not a valid LLBC_LogLevel.
+     */
+    int Initialize(const LLBC_LogControlItem &item) override;
+
+    /**
+     * @param[in,out] io - rewrites `io.effectiveLevel` to the configured newLevel.
+     */
+    void Apply(ApplyResult &io) const override;
+
+private:
+    int _newLevel;
+};
+
+__LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogControlExecutor.h
+++ b/llbc/include/llbc/core/log/LogControlExecutor.h
@@ -1,0 +1,144 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include "llbc/common/Common.h"
+#include "llbc/core/log/LogControl.h"
+
+__LLBC_NS_BEGIN
+
+// Pre-declare.
+struct LLBC_LogData;
+class LLBC_BaseLogMatchRule;
+class LLBC_BaseLogControlAction;
+
+__LLBC_NS_END
+
+__LLBC_NS_BEGIN
+
+/**
+ * \brief Cross-executor apply result for one (record, appender) pair.
+ *
+ * - muted          : set to true by a Mute action; short-circuits the chain.
+ * - effectiveLevel : level after chained SetLevel actions; later executors
+ *                    evaluate against this, not against `data.level`.
+ */
+struct LLBC_LogControlApplyResult
+{
+    bool muted;
+    int effectiveLevel;
+};
+
+/**
+ * \brief Runtime executor of a single log control item.
+ *
+ * Compiles a configuration DTO (LLBC_LogControlItem) into its polymorphic
+ * runtime form: a set of AND-combined match rules plus one action.
+ * Immutable after construction; owned by LLBC_LogControlMgr's snapshot.
+ * Match() / Action() / GetItem() are const and reentrant.
+ */
+class LLBC_HIDDEN LLBC_LogControlExecutor
+{
+public:
+    using ApplyResult = LLBC_LogControlApplyResult;
+
+public:
+    /**
+     * Validate `item` and build an executor. Translates the DTO into its
+     * polymorphic form once so the hot path never re-validates.
+     *
+     * @param[in] item - the source control item (copied into the executor).
+     * @return LLBC_LogControlExecutor * - the new executor on success
+     *                                     (ownership transferred); nullptr
+     *                                     on validation failure with
+     *                                     LLBC_ERROR_INVALID set.
+     */
+    static LLBC_LogControlExecutor *Create(const LLBC_LogControlItem &item);
+
+    /**
+     * Destructor. Deletes every owned match rule and the action.
+     */
+    ~LLBC_LogControlExecutor();
+
+    // Executors live inside Mgr's immutable snapshot; identity matters,
+    // copies don't.
+    LLBC_DISABLE_ASSIGNMENT(LLBC_LogControlExecutor);
+
+public:
+    /**
+     * Test whether this executor is in-scope for and matches the given
+     * (record, appender) pair. Fuses two checks:
+     *   1) appender scope (item.appenderTypes empty == all);
+     *   2) all owned match rules return true (AND-combined; each rule's
+     *      own value-set is OR-combined internally).
+     *
+     * @param[in] appenderType - the appender currently being driven.
+     * @param[in] data         - the log record; `data.level` is ignored
+     *                           in favour of `currentLevel`.
+     * @param[in] currentLevel - chain-accumulated effective level (possibly
+     *                           rewritten by earlier SetLevel executors);
+     *                           the level rule evaluates against this.
+     * @return bool - true iff both appender scope and every rule match.
+     */
+    bool Match(int appenderType,
+               const LLBC_LogData &data,
+               int currentLevel) const;
+
+    /**
+     * Apply this executor's action onto `io`. Caller must have already
+     * passed Match() — Action() does no re-check.
+     * @param[in,out] io - cross-executor apply result to mutate.
+     */
+    void Action(ApplyResult &io) const;
+
+    /**
+     * @return const LLBC_LogControlItem & - the original configuration item.
+     */
+    const LLBC_LogControlItem &GetItem() const { return _item; }
+
+private:
+    // Adopts ownership of every rule in `rules` and of `action`. `rules`
+    // is passed by value (consumed) so the caller's builder vector is
+    // emptied on entry — preventing accidental double-delete.
+    LLBC_LogControlExecutor(
+        const LLBC_LogControlItem &item,
+        std::vector<LLBC_BaseLogMatchRule *> rules,
+        LLBC_BaseLogControlAction *action);
+
+    // Failure-path helper for Create(): deletes any already-built
+    // rules/action, sets LLBC_ERROR_INVALID, and returns nullptr.
+    static LLBC_LogControlExecutor *FailCreate(
+        std::vector<LLBC_BaseLogMatchRule *> &rules,
+        LLBC_BaseLogControlAction *&action);
+
+private:
+    // Original DTO, kept for GetItem() round-trip.
+    LLBC_LogControlItem _item;
+
+    // AND-combined match rules; never empty. Owned (deleted in dtor).
+    std::vector<LLBC_BaseLogMatchRule *> _rules;
+
+    // Exactly one action; never null. Owned (deleted in dtor).
+    LLBC_BaseLogControlAction *_action;
+};
+
+__LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogControlInl.h
+++ b/llbc/include/llbc/core/log/LogControlInl.h
@@ -21,42 +21,14 @@
 
 #pragma once
 
-#include "llbc.h"
-using namespace llbc;
+__LLBC_NS_BEGIN
 
-class FuncTest_Core_Log final : public LLBC_BaseTestCase
+inline LLBC_LogControlItem::LLBC_LogControlItem()
+: action(LLBC_LogControlAction::Unset)
+, newLevel(0)
 {
-public:
-    FuncTest_Core_Log();
-    ~FuncTest_Core_Log() override;
+    // file / func / threadId / level are default-constructed by their own
+    // ctors (enabled = false, values / lineRanges empty).
+}
 
-public:
-    int Run(int argc, char *argv[]) override;
-
-private:
-    void DoLogLevelSetTest();
-    void DoJsonLogTest();
-    void DoUninitLogTest();
-    void SyncLoggerMultiThreadTest();
-    void DoConditionMacroLogTest();
-    int DoLoggerMgrReloadTest();
-    void DoLogColorFilterTest();
-    void DoLogTraceEnableLevelTest();
-    int DoLogControlTest();
-    bool EmitAndCheckSuppressed(LLBC_Logger *logger,
-                                int level,
-                                const char *file,
-                                int line,
-                                const char *func,
-                                const char *msg,
-                                size_t expectedHits);
-
-    void DoLogTraceTest();
-    template <typename _KeyTy, typename _ContentTy>
-    void AddLogTrace(const _KeyTy &key, const _ContentTy &content);
-
-    void OnLogHook(const LLBC_LogData *logData);
-
-private:
-    LLBC_String _logCfgFilePath;
-};
+__LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogControlMgr.h
+++ b/llbc/include/llbc/core/log/LogControlMgr.h
@@ -1,0 +1,180 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include "llbc/common/Common.h"
+#include "llbc/core/thread/SpinLock.h"
+#include "llbc/core/log/LogControl.h"
+#include "llbc/core/log/LogControlExecutor.h"
+
+#include <memory>
+#include <vector>
+
+__LLBC_NS_BEGIN
+
+// Pre-declare.
+struct LLBC_LogData;
+
+__LLBC_NS_END
+
+__LLBC_NS_BEGIN
+
+/**
+ * \brief The log output control manager.
+ *
+ * Chain scheduler over an ordered list of LLBC_LogControlExecutor, driven
+ * per-appender at LLBC_Logger::OutputLogData(). Per-item match/action logic
+ * lives in the executor; Mgr only performs ordered traversal, snapshot
+ * publish, and global suppression accounting.
+ *
+ * Writer model: the control list is configuration-only. SetControls() is
+ * the only writer entry point (called at Logger::Initialize() and
+ * LoggerMgr::Reload()); every write replaces the whole list. Validation
+ * happens exactly once, at SetControls() time.
+ *
+ * Thread-safety: all public methods are safe to call from any thread. A
+ * single LLBC_SpinLock (`_lock`) guards `_execs` (the snapshot pointer) and
+ * `_suppressedCount`. Readers copy the shared_ptr under the lock and
+ * traverse the immutable snapshot outside it, so chain evaluation never
+ * blocks writers or other readers.
+ */
+class LLBC_HIDDEN LLBC_LogControlMgr
+{
+public:
+    // Re-export the namespace-scope ApplyResult so legacy callers can spell
+    // it as LLBC_LogControlMgr::ApplyResult.
+    using ApplyResult = LLBC_LogControlApplyResult;
+
+    // Immutable, ordered executor snapshot; each element is a unique_ptr so
+    // executor addresses are stable for the snapshot's lifetime.
+    using ExecutorList = std::vector<std::unique_ptr<LLBC_LogControlExecutor> >;
+
+public:
+    /**
+     * Constructor. Starts with no installed controls and suppressed count 0.
+     */
+    LLBC_LogControlMgr();
+    ~LLBC_LogControlMgr() = default;
+
+public:
+    /**
+     * Replace the entire installed control item list with `items`.
+     *
+     * All-or-nothing: every item is validated first (by building executors);
+     * if any fails, nothing is changed and LLBC_FAILED is returned with
+     * LLBC_ERROR_INVALID set. On success a new snapshot is published via a
+     * shared_ptr swap; in-flight Apply() callers keep using the previously
+     * captured snapshot until they return.
+     *
+     * Passing an empty vector publishes a null snapshot (IsEmpty() returns
+     * true). The suppressed count is preserved across calls; use
+     * ResetSuppressedCount() to start a fresh baseline.
+     *
+     * @param[in] items - the new full list of control items.
+     * @return int - LLBC_OK on success, LLBC_FAILED on any invalid item.
+     */
+    int SetControls(const std::vector<LLBC_LogControlItem> &items);
+
+    /**
+     * @return size_t - number of installed control items.
+     */
+    size_t GetControlCount() const;
+
+    /**
+     * Snapshot all installed control items (as configuration DTOs) in
+     * declaration order.
+     * @param[out] out - receives the items snapshot; cleared first.
+     */
+    void GetControls(std::vector<LLBC_LogControlItem> &out) const;
+
+    /**
+     * @return uint64 - total records dropped by mute action since
+     *                  construction or last reset, counted once per
+     *                  (record, appender) pair.
+     */
+    uint64 GetSuppressedCount() const;
+
+    /**
+     * Reset the suppressed count to zero.
+     */
+    void ResetSuppressedCount();
+
+    /**
+     * @return bool - true iff no control item is installed.
+     */
+    bool IsEmpty() const;
+
+    /**
+     * Apply the executor chain to one (log record, appender) pair and
+     * return the merged outcome.
+     *
+     * Chain-merge semantics (declaration order):
+     *   - SetLevel : overwrites `effectiveLevel`; the new level is visible
+     *                to subsequent executors' level rules, so chains like
+     *                    [SetLevel(Warn) -> match level==Warn -> Mute]
+     *                are observable and intentional.
+     *   - Mute     : sets `muted=true`, bumps the suppression counter once,
+     *                and short-circuits the chain.
+     *   - No match : `muted=false`, `effectiveLevel==originalLevel`.
+     *
+     * The rewrite does NOT leak across appenders: each Apply() call seeds
+     * `effectiveLevel` from `originalLevel`.
+     *
+     * @param[in] appenderType  - the appender type currently being driven,
+     *                            see LLBC_LogAppenderType.
+     * @param[in] data          - the log record; `data.level` is ignored
+     *                            in favour of `originalLevel` (so callers
+     *                            may safely rewrite `data.level` for
+     *                            per-appender output before calling Apply).
+     * @param[in] originalLevel - the record's original (pre-chain) level;
+     *                            seeds `effectiveLevel` and is the level
+     *                            input for the first executor.
+     * @return ApplyResult - merged {muted, effectiveLevel}.
+     */
+    ApplyResult Apply(int appenderType,
+                      const LLBC_LogData &data,
+                      int originalLevel) const;
+
+private:
+    // Non-copyable: owns a spinlock and a side-channel counter (see below);
+    // copying a Mgr would duplicate neither meaningfully.
+    LLBC_DISABLE_ASSIGNMENT(LLBC_LogControlMgr);
+
+private:
+    // Internal synchronization. Guards `_execs` (the snapshot pointer itself)
+    // and `_suppressedCount`. The vector pointed to by `_execs` is immutable,
+    // so once a reader has copied the `shared_ptr` under the lock it can
+    // traverse the snapshot freely after releasing.
+    mutable LLBC_SpinLock _lock;
+
+    // Immutable executor snapshot, published wholesale by SetControls(). The
+    // pointed vector is `const` — once published, it is never mutated. Each
+    // element is a unique_ptr<Executor> so executor addresses are stable for
+    // the lifetime of the snapshot.
+    std::shared_ptr<const ExecutorList> _execs;
+
+    // Total number of records dropped by mute action, counted per
+    // (record, appender).
+    mutable uint64 _suppressedCount;
+};
+
+__LLBC_NS_END

--- a/llbc/include/llbc/core/log/LogMatchRule.h
+++ b/llbc/include/llbc/core/log/LogMatchRule.h
@@ -1,0 +1,292 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include "llbc/common/Common.h"
+#include "llbc/core/log/LogControl.h"
+
+__LLBC_NS_BEGIN
+
+/**
+ * Pre-declare.
+ */
+struct LLBC_LogData;
+
+/**
+ * \brief One predicate over (LogData, currentLevel).
+ *
+ * Polymorphic counterpart of a single enabled match-rule inside a
+ * LLBC_LogControlItem; an executor owns one rule per enabled dimension
+ * (file / func / threadId / level) and AND-combines their Match() results.
+ * The whole hierarchy is `LLBC_HIDDEN`: only reachable from outside via
+ * LLBC_LogControlExecutor::Create.
+ *
+ * Two-phase construction: default-construct the subclass, then call
+ * Initialize(item) which reads only the rule's own slice of the DTO and
+ * validates it. Dispatch (matchType -> subclass) is centralized in the
+ * static Create() factory below so the executor never type-switches by hand.
+ *
+ * Immutable after a successful Initialize(); Match() is const and reentrant.
+ * Rules are owned as raw pointers by the executor, which deletes them in
+ * its destructor.
+ */
+class LLBC_HIDDEN LLBC_BaseLogMatchRule
+{
+public:
+    /**
+     * Virtual dtor for polymorphic deletion by the owning executor.
+     */
+    virtual ~LLBC_BaseLogMatchRule() = default;
+
+    /**
+     * Maps `matchType` to the corresponding per-dimension `.enabled` flag on
+     * `item` (File -> item.file.enabled, and so on). Lets the executor
+     * factory iterate LLBC_LogControlMatchType uniformly.
+     *
+     * @param[in] matchType - one of LLBC_LogControlMatchType::*.
+     * @param[in] item      - the source control item.
+     * @return bool - value of the corresponding `.enabled` flag; false for
+     *                unknown matchType.
+     */
+    static bool IsEnabled(int matchType, const LLBC_LogControlItem &item);
+
+    /**
+     * Build the polymorphic match-rule object for one dimension.
+     *
+     * A single switch on `matchType` picks the concrete subclass, which is
+     * then driven through Initialize(item) for payload validation.
+     *
+     * Pre-condition: `IsEnabled(matchType, item) == true` (the caller
+     * iterates enabled dimensions only); nullptr therefore unambiguously
+     * means "configured but invalid" at the call site.
+     *
+     * @param[in] matchType - one of LLBC_LogControlMatchType::*.
+     * @param[in] item      - the source control item.
+     * @return LLBC_BaseLogMatchRule * - a newly-allocated, fully-initialized
+     *                                   rule (ownership transferred to caller)
+     *                                   on success; nullptr on unknown
+     *                                   matchType or Initialize() failure (the
+     *                                   partially-constructed object is
+     *                                   deleted internally). Does NOT set
+     *                                   LLBC_ERROR; the executor factory
+     *                                   aggregates the failure.
+     */
+    static LLBC_BaseLogMatchRule *Create(int matchType, const LLBC_LogControlItem &item);
+
+    /**
+     * @return int - which match dimension this rule implements
+     *               (LLBC_LogControlMatchType::{File, Func, ThreadId, Level}).
+     *               On the base class so callers can identify a rule without
+     *               RTTI.
+     */
+    virtual int MatchType() const = 0;
+
+    /**
+     * Read the rule's own slice of the source control item and validate it.
+     * The corresponding `.enabled` flag is NOT re-checked — that's the
+     * factory's precondition (see Create()).
+     *
+     * @param[in] item - the source control item.
+     * @return int - LLBC_OK on success, LLBC_FAILED on payload validation
+     *               failure.
+     */
+    virtual int Initialize(const LLBC_LogControlItem &item) = 0;
+
+    /**
+     * Evaluate this rule against a record.
+     *
+     * @param[in] data         - the log record (file / func / line / threadId
+     *                           consumed by concrete rules).
+     * @param[in] currentLevel - effective level so far in the chain; the
+     *                           Level rule consumes this (NOT data.level),
+     *                           so "SetLevel then match by level" is
+     *                           composable — see LLBC_LogControlExecutor::Match.
+     * @return bool - true iff the rule matches.
+     */
+    virtual bool Match(const LLBC_LogData &data, int currentLevel) const = 0;
+
+protected:
+    /**
+     * Default ctor; subclass fields are filled by Initialize().
+     */
+    LLBC_BaseLogMatchRule() = default;
+
+    // Non-copyable: rules are owned as raw pointers by the executor;
+    // copying would bypass the factory contract and confuse ownership.
+    LLBC_DISABLE_ASSIGNMENT(LLBC_BaseLogMatchRule);
+};
+
+/**
+ * \brief Match by source file basename plus optional line-range set.
+ * See LLBC_LogFileMatch (LogControl.h) for the range/wildcard semantics.
+ */
+class LLBC_HIDDEN LLBC_LogFileMatchRule final : public LLBC_BaseLogMatchRule
+{
+public:
+    /**
+     * Default ctor; matched file + line-ranges are filled by Initialize().
+     */
+    LLBC_LogFileMatchRule() = default;
+
+    /**
+     * @return int - LLBC_LogControlMatchType::File.
+     */
+    int MatchType() const override { return LLBC_LogControlMatchType::File; }
+
+    /**
+     * Read `item.file` and validate it (non-empty file; each line-range is a
+     * valid half-open [begin, end) with 0 <= begin < end).
+     * @param[in] item - the source control item.
+     * @return int - LLBC_OK on success, LLBC_FAILED on payload validation
+     *               failure.
+     */
+    int Initialize(const LLBC_LogControlItem &item) override;
+
+    /**
+     * Match by source file basename (equal to `_matchFile`) plus optional
+     * line-ranges (if `_matchLineRanges` is non-empty, `data.line` must lie
+     * in ANY half-open [begin, end) segment).
+     * @param[in] data         - the log record; consumes `data.file` and `data.line`.
+     * @param[in] currentLevel - the chain-rewritten level (unused by this rule).
+     * @return bool - true iff the rule matches.
+     */
+    bool Match(const LLBC_LogData &data, int currentLevel) const override;
+
+private:
+    LLBC_String _matchFile;
+    std::vector<std::pair<int, int> > _matchLineRanges;
+};
+
+/**
+ * \brief Match by function name (exact, OR-set).
+ */
+class LLBC_HIDDEN LLBC_LogFuncMatchRule final : public LLBC_BaseLogMatchRule
+{
+public:
+    /**
+     * Default ctor; matched func names are filled by Initialize().
+     */
+    LLBC_LogFuncMatchRule() = default;
+
+    /**
+     * @return int - LLBC_LogControlMatchType::Func.
+     */
+    int MatchType() const override { return LLBC_LogControlMatchType::Func; }
+
+    /**
+     * Read `item.func` and validate it (non-empty value list; each entry
+     * non-empty).
+     * @param[in] item - the source control item.
+     * @return int - LLBC_OK on success, LLBC_FAILED on payload validation
+     *               failure.
+     */
+    int Initialize(const LLBC_LogControlItem &item) override;
+
+    /**
+     * Match iff `data.func` equals ANY entry of `_matchFuncs` (exact,
+     * case-sensitive).
+     * @param[in] data         - the log record; consumes `data.func`.
+     * @param[in] currentLevel - the chain-rewritten level (unused by this rule).
+     * @return bool - true iff the rule matches.
+     */
+    bool Match(const LLBC_LogData &data, int currentLevel) const override;
+
+private:
+    std::vector<LLBC_String> _matchFuncs;
+};
+
+/**
+ * \brief Match by native thread id (OR-set).
+ */
+class LLBC_HIDDEN LLBC_LogThreadIdMatchRule final : public LLBC_BaseLogMatchRule
+{
+public:
+    /**
+     * Default ctor; matched thread ids are filled by Initialize().
+     */
+    LLBC_LogThreadIdMatchRule() = default;
+
+    /**
+     * @return int - LLBC_LogControlMatchType::ThreadId.
+     */
+    int MatchType() const override { return LLBC_LogControlMatchType::ThreadId; }
+
+    /**
+     * Read `item.threadId` and validate it (non-empty value list).
+     * @param[in] item - the source control item.
+     * @return int - LLBC_OK on success, LLBC_FAILED on payload validation
+     *               failure.
+     */
+    int Initialize(const LLBC_LogControlItem &item) override;
+
+    /**
+     * Match iff `data.threadId` equals ANY entry of `_matchThreadIds`.
+     * @param[in] data         - the log record; consumes `data.threadId`.
+     * @param[in] currentLevel - the chain-rewritten level (unused by this rule).
+     * @return bool - true iff the rule matches.
+     */
+    bool Match(const LLBC_LogData &data, int currentLevel) const override;
+
+private:
+    std::vector<LLBC_ThreadId> _matchThreadIds;
+};
+
+/**
+ * \brief Match by current effective level (OR-set).
+ */
+class LLBC_HIDDEN LLBC_LogLevelMatchRule final : public LLBC_BaseLogMatchRule
+{
+public:
+    /**
+     * Default ctor; matched levels are filled by Initialize().
+     */
+    LLBC_LogLevelMatchRule() = default;
+
+    /**
+     * @return int - LLBC_LogControlMatchType::Level.
+     */
+    int MatchType() const override { return LLBC_LogControlMatchType::Level; }
+
+    /**
+     * Read `item.level` and validate it (non-empty value list; each entry
+     * a valid log level).
+     * @param[in] item - the source control item.
+     * @return int - LLBC_OK on success, LLBC_FAILED on payload validation
+     *               failure.
+     */
+    int Initialize(const LLBC_LogControlItem &item) override;
+
+    /**
+     * Match iff `currentLevel` equals ANY entry of `_matchLevels`. Evaluates
+     * against `currentLevel` (the chain-rewritten level), NOT `data.level`,
+     * so "SetLevel then match by level" composes.
+     * @param[in] data         - the log record (unused by this rule).
+     * @param[in] currentLevel - the chain-rewritten level; consumed here.
+     * @return bool - true iff the rule matches.
+     */
+    bool Match(const LLBC_LogData &data, int currentLevel) const override;
+
+private:
+    std::vector<int> _matchLevels;
+};
+
+__LLBC_NS_END

--- a/llbc/include/llbc/core/log/Logger.h
+++ b/llbc/include/llbc/core/log/Logger.h
@@ -27,6 +27,8 @@
 
 #include "llbc/core/log/LogLevel.h"
 #include "llbc/core/log/LogTrace.h"
+#include "llbc/core/log/LogControl.h"
+#include "llbc/core/log/LogControlMgr.h"
 
 __LLBC_NS_BEGIN
 
@@ -187,6 +189,49 @@ public:
      * @param[in] requireColorLogTraces - conf log traces.
      */
     void UpdateColorLogTraces(const LLBC_LogTraces &requireColorLogTraces);
+
+public:
+    /**
+     * Atomically replace the entire installed log control list with `items`.
+     *
+     * All-or-nothing: every item is validated first; on any invalid item
+     * nothing is changed. On success the new snapshot is published atomically
+     * — any in-flight log emit sees either the old list in full or the new
+     * list in full, never a transient state. Passing an empty vector
+     * publishes an empty snapshot. See LLBC_LogControlMgr for chain semantics
+     * and LLBC_LogControlItem for per-item invariants.
+     *
+     * The suppressed record count is preserved across calls; call
+     * ResetLogControlSuppressedCount() for a fresh baseline.
+     *
+     * @param[in] items - the new full list of control items.
+     * @return int - LLBC_OK on success, LLBC_FAILED on any invalid item
+     *               (LLBC_ERROR_INVALID).
+     */
+    int SetLogControls(const std::vector<LLBC_LogControlItem> &items);
+
+    /**
+     * @return size_t - number of installed log control items; 0 if not initialized.
+     */
+    size_t GetLogControlCount() const;
+
+    /**
+     * Snapshot all installed log control items in declaration order.
+     * @param[out] out - receives the items snapshot; cleared first.
+     */
+    void GetLogControls(std::vector<LLBC_LogControlItem> &out) const;
+
+    /**
+     * @return uint64 - total records dropped by Mute action since logger
+     *                  initialization or last ResetLogControlSuppressedCount();
+     *                  0 if not initialized.
+     */
+    uint64 GetLogControlSuppressedCount() const;
+
+    /**
+     * Reset the suppressed record count to zero.
+     */
+    void ResetLogControlSuppressedCount();
 
 public:
     /**
@@ -449,7 +494,7 @@ private:
     /**
      * Friend classs: LLBC_LogRunnable.
      * Asset method/data-members:
-     * - OutputLogData(const LLBC_LogData &data):int
+     * - OutputLogData(LLBC_LogData &data):int
      * - Flush(bool force, sint64 now):void
      */
     friend class LLBC_LogRunnable;
@@ -462,9 +507,16 @@ private:
 
     /**
      * Output log data.
-     * @param[in] data - log data.
+     * @param[in,out] data - log data. May be temporarily mutated (e.g. `level`
+     *                       rewritten by LLBC_LogControlMgr::SetLevel) per
+     *                       appender, but is always restored to the original
+     *                       state before this function returns. The caller
+     *                       (sole owner of `data` at this point: holding
+     *                       `_lock` in sync mode, or running on the unique
+     *                       LogRunnable thread in async mode) observes no
+     *                       net change.
      */
-    int OutputLogData(const LLBC_LogData &data);
+    int OutputLogData(LLBC_LogData &data);
 
     /**
     * Flush logger(for now, just only need flush all appenders).
@@ -500,6 +552,9 @@ private:
 
     // Log trace manager.
     LLBC_LogTraceMgr *_logTraceMgr;
+
+    // Log output control manager (Mute / SetLevel; per-appender, ordered).
+    LLBC_LogControlMgr *_logControlMgr;
 
     // Log runnable object.
     LLBC_LogRunnable *_logRunnable;

--- a/llbc/include/llbc/core/log/LoggerConfigInfo.h
+++ b/llbc/include/llbc/core/log/LoggerConfigInfo.h
@@ -272,9 +272,9 @@ public:
      * CIR schema for `logControls` (plain map/seq/scalar Variant tree; no
      * XML metadata such as [Name]/[Attrs]/[Children] is involved):
      *
-     *   logControls: Dict { "item": Dict | Seq<Dict> }   // XML container
-     *              | Seq<Dict>                           // loader-native
-     *              | Dict { ... }                        // single-item shortcut
+     *   logControls: Dict { "logControl": Dict | Seq<Dict> }   // XML container
+     *              | Seq<Dict>                                  // loader-native
+     *              | Dict { ... }                               // single-item shortcut
      *
      * Each item is a Dict:
      *   Dict {

--- a/llbc/include/llbc/core/log/LoggerConfigInfo.h
+++ b/llbc/include/llbc/core/log/LoggerConfigInfo.h
@@ -23,6 +23,7 @@
 
 #include "llbc/common/Common.h"
 #include "llbc/core/log/LogTrace.h"
+#include "llbc/core/log/LogControl.h"
 
 __LLBC_NS_BEGIN
 
@@ -261,6 +262,47 @@ public:
      */
     bool IsLazyCreateLogFile() const;
 
+public:
+    /**
+     * Get parsed log control items.
+     * Parsed from cfg key `logControls`, which the LoggerConfigurator layer
+     * hands over in a domain-neutral CIR (Config Intermediate Representation)
+     * shape regardless of the source format (XML today; YAML/JSON later).
+     *
+     * CIR schema for `logControls` (plain map/seq/scalar Variant tree; no
+     * XML metadata such as [Name]/[Attrs]/[Children] is involved):
+     *
+     *   logControls: Dict { "item": Dict | Seq<Dict> }   // XML container
+     *              | Seq<Dict>                           // loader-native
+     *              | Dict { ... }                        // single-item shortcut
+     *
+     * Each item is a Dict:
+     *   Dict {
+     *     "match": Dict {                          // optional; empty == no rule
+     *       "file": Dict { "name": Str,
+     *                      "lines"?: Str },        // "N" | "N-M" | "N,M-K,..."
+     *       "func":     Str | Seq<Str>,            // OR-combined
+     *       "threadId": Str | Seq<Str>,            // OR-combined
+     *       "level":    Str | Seq<Str>             // OR; name or decimal
+     *     },
+     *     "appenders": Dict { "appender": Str | Seq<Str> }
+     *                  | Str | Seq<Str>,           // optional; empty == all
+     *     "action":    Dict {
+     *       "type":     Str,                       // "mute" | "setLevel"
+     *       "newLevel"?: Str                       // required iff type=setLevel
+     *     }
+     *   }
+     *
+     * Within one item, enabled rules are AND-combined; each rule's value-set
+     * (file.lineRanges / func.values / threadId.values / level.values) is
+     * OR-combined. Declaration order is preserved across items.
+     *
+     * XML source binding is documented separately (see doc/log_control.md);
+     * this module is not aware of any XML tag/attribute name.
+     * @return const std::vector<LLBC_LogControlItem> & - the parsed items.
+     */
+    const std::vector<LLBC_LogControlItem> &GetLogControls() const;
+
 private:
     /**
      * Normalize the log file name.
@@ -276,6 +318,23 @@ private:
      * @return sint64 - the normalized size str.
      */
     sint64 NormalizeSizeStr(const LLBC_String &sizeStr, sint64 defaultSize, sint64 low, sint64 high);
+
+    /**
+     * Parse the CIR node for `logControls` (see schema in GetLogControls()
+     * doc above) into LLBC_LogControlItem list. Malformed input is ignored
+     * silently (consistent with other log cfg keys -- keep bootstrap robust).
+     * Per-item failures are also skipped silently; only well-formed items
+     * with at least one match rule, a known action and (when action==SetLevel)
+     * a valid newLevel are appended to `out`. Declaration order is preserved.
+     *
+     * `cfg` is a Seq<Dict> per the CIR schema. If `cfg` is not a Seq (i.e.
+     * the key was absent or the loader emitted a non-list shape), this is a
+     * silent no-op.
+     * @param[in]  cfg - the CIR node of `logControls`.
+     * @param[out] out - the parsed control items, appended.
+     */
+    static void ParseLogControls(const LLBC_Variant &cfg,
+                                 std::vector<LLBC_LogControlItem> &out);
 
 private:
     LLBC_String _loggerName;
@@ -313,6 +372,8 @@ private:
     bool _lazyCreateLogFile;
     LLBC_LogTraces _requireColorLogTraces;
     bool _takeOver;
+
+    std::vector<LLBC_LogControlItem> _logControls;
 };
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/log/LoggerConfigInfoInl.h
+++ b/llbc/include/llbc/core/log/LoggerConfigInfoInl.h
@@ -178,4 +178,9 @@ inline bool LLBC_LoggerConfigInfo::IsLazyCreateLogFile() const
     return _lazyCreateLogFile;
 }
 
+inline const std::vector<LLBC_LogControlItem> &LLBC_LoggerConfigInfo::GetLogControls() const
+{
+    return _logControls;
+}
+
 __LLBC_NS_END

--- a/llbc/src/core/log/BaseLogAppender.cpp
+++ b/llbc/src/core/log/BaseLogAppender.cpp
@@ -26,7 +26,49 @@
 #include "llbc/core/log/LogTokenChain.h"
 #include "llbc/core/log/BaseLogAppender.h"
 
+__LLBC_INTERNAL_NS_BEGIN
+
+// Lower-case type names; index aligned with LLBC_LogAppenderType enum.
+// Last slot is the "unknown" sentinel returned by GetTypeStr() on invalid input.
+static const LLBC_NS LLBC_CString __type2StrRepr[LLBC_NS LLBC_LogAppenderType::End + 1] =
+{
+    "console",
+    "file",
+    "network",
+
+    "unknown"
+};
+
+__LLBC_INTERNAL_NS_END
+
 __LLBC_NS_BEGIN
+
+const LLBC_CString &LLBC_LogAppenderType::GetTypeStr(int appenderType)
+{
+    auto &strReprs = LLBC_INTERNAL_NS __type2StrRepr;
+    return IsValid(appenderType) ? strReprs[appenderType] : strReprs[LLBC_LogAppenderType::End];
+}
+
+int LLBC_LogAppenderType::GetTypeEnum(const LLBC_CString &typeStr)
+{
+    if (UNLIKELY(typeStr.empty()))
+        return LLBC_LogAppenderType::End;
+
+    LLBC_String normalized(typeStr);
+    normalized.strip();
+    if (normalized.empty())
+        return LLBC_LogAppenderType::End;
+    normalized = normalized.tolower();
+
+    if (LLBC_INTERNAL_NS __type2StrRepr[LLBC_LogAppenderType::Console] == normalized)
+        return LLBC_LogAppenderType::Console;
+    else if (LLBC_INTERNAL_NS __type2StrRepr[LLBC_LogAppenderType::File] == normalized)
+        return LLBC_LogAppenderType::File;
+    else if (LLBC_INTERNAL_NS __type2StrRepr[LLBC_LogAppenderType::Network] == normalized)
+        return LLBC_LogAppenderType::Network;
+
+    return LLBC_LogAppenderType::End;
+}
 
 LLBC_BaseLogAppender::LLBC_BaseLogAppender()
 : _logLevel(LLBC_LogLevel::End)

--- a/llbc/src/core/log/LogConfigLoader.cpp
+++ b/llbc/src/core/log/LogConfigLoader.cpp
@@ -1,0 +1,156 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#include "llbc/common/Export.h"
+
+#include "llbc/core/tinyxml2/tinyxml2.h"
+
+#include "llbc/core/log/LogConfigLoader.h"
+
+__LLBC_NS_BEGIN
+
+namespace
+{
+
+// Forward decl for mutual recursion.
+static void __LLBC_XmlElementToCir(const LLBC_TINYXML2_NS XMLElement *elem,
+                                   LLBC_Variant &outCir);
+
+// Two-pass walk of `parent`'s child elements:
+//   pass 1: count occurrences per tag name -- the count decides whether
+//           the emitted CIR slot is a bare value (unique tag) or a Seq
+//           (repeated tag).
+//   pass 2: walk in document order, materialize each child's CIR and
+//           attach to the slot (Seq slots grow lazily).
+static void __LLBC_XmlChildrenToCir(const LLBC_TINYXML2_NS XMLElement *parent,
+                                    LLBC_Variant &outDict)
+{
+    // Pass 1: tag counts.
+    std::map<LLBC_String, int> tagCount;
+    for (auto child = parent->FirstChildElement();
+         child != nullptr;
+         child = child->NextSiblingElement())
+    {
+        const char *name = child->Name();
+        if (name == nullptr || *name == '\0')
+            continue;
+        ++tagCount[name];
+    }
+
+    // Pass 2: emit.
+    for (auto child = parent->FirstChildElement();
+         child != nullptr;
+         child = child->NextSiblingElement())
+    {
+        const char *name = child->Name();
+        if (name == nullptr || *name == '\0')
+            continue;
+
+        LLBC_Variant childCir;
+        __LLBC_XmlElementToCir(child, childCir);
+
+        const LLBC_String tag(name);
+        if (tagCount[tag] <= 1)
+        {
+            outDict[tag] = std::move(childCir);
+        }
+        else
+        {
+            auto &slot = outDict[tag];
+            if (!slot.Is<LLBC_Variant::Seq>())
+                slot.Become<LLBC_Variant::Seq>();
+            slot.SeqPushBack(std::move(childCir));
+        }
+    }
+}
+
+// Single-element dispatcher: leaf (no attrs & no children) -> Str scalar;
+// compound (has attrs and/or children) -> Dict.
+static void __LLBC_XmlElementToCir(const LLBC_TINYXML2_NS XMLElement *elem,
+                                   LLBC_Variant &outCir)
+{
+    const auto *firstAttr = elem->FirstAttribute();
+    const auto *firstChild = elem->FirstChildElement();
+
+    // Pure leaf: expose inline text as a Str scalar. Empty text becomes "".
+    if (firstAttr == nullptr && firstChild == nullptr)
+    {
+        const char *text = elem->GetText();
+        outCir = (text != nullptr) ? LLBC_String(text) : LLBC_String();
+        return;
+    }
+
+    // Compound: Dict; attrs written first, children second (child wins on
+    // rare key collision -- documented in the header).
+    outCir.Become<LLBC_Variant::Dict>();
+    for (auto attr = firstAttr; attr != nullptr; attr = attr->Next())
+    {
+        const char *attrName = attr->Name();
+        if (attrName == nullptr || *attrName == '\0')
+            continue;
+        const char *attrValue = attr->Value();
+        outCir[attrName] = (attrValue != nullptr) ? LLBC_String(attrValue)
+                                                  : LLBC_String();
+    }
+    if (firstChild != nullptr)
+        __LLBC_XmlChildrenToCir(elem, outCir);
+}
+
+}
+
+int LLBC_LogConfigLoader::LoadXmlFromFile(const LLBC_String &filePath,
+                                          LLBC_Variant &cir)
+{
+    cir.Become<void>();
+
+    LLBC_TINYXML2_NS XMLDocument xmlDoc;
+    const auto xmlLoadRet = xmlDoc.LoadFile(filePath.c_str());
+    if (xmlLoadRet != LLBC_TINYXML2_NS XML_SUCCESS)
+    {
+        LLBC_String detail;
+        detail.format("load log config file failed(xml format), "
+                      "file:%s, errno(tinyxml2:%d), error str:%s",
+                      filePath.c_str(),
+                      xmlLoadRet,
+                      xmlDoc.ErrorStr() != nullptr ? xmlDoc.ErrorStr() : "");
+        LLBC_SetLastError(LLBC_ERROR_FORMAT, detail.c_str());
+        return LLBC_FAILED;
+    }
+
+    // Walk top-level elements of the document. In practice log configs have
+    // a single <Log> root, but the loader stays structural: every top-level
+    // element is exposed under `cir[<tag>]`.
+    cir.Become<LLBC_Variant::Dict>();
+    for (auto elem = xmlDoc.FirstChildElement();
+         elem != nullptr;
+         elem = elem->NextSiblingElement())
+    {
+        const char *name = elem->Name();
+        if (name == nullptr || *name == '\0')
+            continue;
+        __LLBC_XmlElementToCir(elem, cir[LLBC_String(name)]);
+    }
+
+    return LLBC_OK;
+}
+
+__LLBC_NS_END

--- a/llbc/src/core/log/LogControlAction.cpp
+++ b/llbc/src/core/log/LogControlAction.cpp
@@ -1,0 +1,90 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#include "llbc/common/Export.h"
+
+#include "llbc/core/log/LogLevel.h"
+#include "llbc/core/log/LogControl.h"
+#include "llbc/core/log/LogControlExecutor.h"
+#include "llbc/core/log/LogControlAction.h"
+
+__LLBC_NS_BEGIN
+
+int LLBC_LogMuteAction::Initialize(const LLBC_LogControlItem &item)
+{
+    return LLBC_OK;
+}
+
+void LLBC_LogMuteAction::Apply(ApplyResult &io) const
+{
+    // Caller (LogControlMgr::Apply) breaks the chain and bumps the
+    // suppression counter on muted.
+    io.muted = true;
+}
+
+LLBC_LogSetLevelAction::LLBC_LogSetLevelAction()
+: _newLevel(LLBC_LogLevel::End)
+{
+}
+
+int LLBC_LogSetLevelAction::Initialize(const LLBC_LogControlItem &item)
+{
+    if (!LLBC_LogLevel::IsValid(item.newLevel))
+        return LLBC_FAILED;
+
+    _newLevel = item.newLevel;
+    return LLBC_OK;
+}
+
+void LLBC_LogSetLevelAction::Apply(ApplyResult &io) const
+{
+    io.effectiveLevel = _newLevel;
+}
+
+LLBC_BaseLogControlAction *LLBC_BaseLogControlAction::Create(const LLBC_LogControlItem &item)
+{
+    LLBC_BaseLogControlAction *action = nullptr;
+    switch (item.action)
+    {
+    case LLBC_LogControlAction::Mute:
+        action = new LLBC_LogMuteAction;
+        break;
+
+    case LLBC_LogControlAction::SetLevel:
+        action = new LLBC_LogSetLevelAction;
+        break;
+
+    default:
+        // Includes LLBC_LogControlAction::Unset and out-of-range values.
+        return nullptr;
+    }
+
+    if (action->Initialize(item) != LLBC_OK)
+    {
+        LLBC_XDelete(action);
+        return nullptr;
+    }
+
+    return action;
+}
+
+__LLBC_NS_END

--- a/llbc/src/core/log/LogControlExecutor.cpp
+++ b/llbc/src/core/log/LogControlExecutor.cpp
@@ -1,0 +1,145 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#include "llbc/common/Export.h"
+
+#include "llbc/core/log/LogData.h"
+#include "llbc/core/log/LogLevel.h"
+#include "llbc/core/log/BaseLogAppender.h"
+#include "llbc/core/log/LogMatchRule.h"
+#include "llbc/core/log/LogControlAction.h"
+#include "llbc/core/log/LogControlExecutor.h"
+
+__LLBC_NS_BEGIN
+
+LLBC_LogControlExecutor::LLBC_LogControlExecutor(
+    const LLBC_LogControlItem &item,
+    std::vector<LLBC_BaseLogMatchRule *> rules,
+    LLBC_BaseLogControlAction *action)
+: _item(item)
+, _rules(std::move(rules))
+, _action(action)
+{
+}
+
+LLBC_LogControlExecutor::~LLBC_LogControlExecutor()
+{
+    for (auto *rule : _rules)
+        delete rule;
+    _rules.clear();
+
+    LLBC_XDelete(_action);
+}
+
+LLBC_LogControlExecutor *LLBC_LogControlExecutor::FailCreate(
+    std::vector<LLBC_BaseLogMatchRule *> &rules,
+    LLBC_BaseLogControlAction *&action)
+{
+    for (auto *r : rules)
+        delete r;
+    rules.clear();
+    LLBC_XDelete(action);
+    LLBC_SetLastError(LLBC_ERROR_INVALID);
+    return nullptr;
+}
+
+LLBC_LogControlExecutor *LLBC_LogControlExecutor::Create(const LLBC_LogControlItem &item)
+{
+    // Single error-reporting boundary: rule/action factories return nullptr
+    // on failure; any failure jumps to FailCreate() which cleans up partial
+    // builds and sets LLBC_ERROR_INVALID.
+    std::vector<LLBC_BaseLogMatchRule *> rules;
+    rules.reserve(4);
+    LLBC_BaseLogControlAction *action = nullptr;
+
+    // 1) at least one match rule must be enabled.
+    if (!item.HasAnyMatch())
+        return FailCreate(rules, action);
+
+    // 2) build a rule for every enabled match dimension (AND-combined).
+    for (int mt = LLBC_LogControlMatchType::Begin;
+         mt < LLBC_LogControlMatchType::End;
+         ++mt)
+    {
+        if (!LLBC_BaseLogMatchRule::IsEnabled(mt, item))
+            continue;
+
+        auto *r = LLBC_BaseLogMatchRule::Create(mt, item);
+        if (!r)
+            return FailCreate(rules, action);
+        rules.push_back(r);
+    }
+
+    // 3) action.
+    action = LLBC_BaseLogControlAction::Create(item);
+    if (!action)
+        return FailCreate(rules, action);
+
+    // 4) appender scope: reject any unknown appender type. The actual scope
+    //    check is inlined in Match() because it operates on appenderType
+    //    rather than on LogData.
+    for (int t : item.appenderTypes)
+    {
+        if (!LLBC_LogAppenderType::IsValid(t))
+            return FailCreate(rules, action);
+    }
+
+    return new LLBC_LogControlExecutor(item, std::move(rules), action);
+}
+
+bool LLBC_LogControlExecutor::Match(int appenderType,
+                                    const LLBC_LogData &data,
+                                    int currentLevel) const
+{
+    // Appender scope: empty == all appenders. Inlined here (instead of a
+    // dedicated rule subclass) because it operates on appenderType.
+    if (!_item.appenderTypes.empty())
+    {
+        bool scopeHit = false;
+        for (int t : _item.appenderTypes)
+        {
+            if (t == appenderType)
+            {
+                scopeHit = true;
+                break;
+            }
+        }
+        if (!scopeHit)
+            return false;
+    }
+
+    // Rules are AND-combined; `_rules` is never empty (Create() guarantees).
+    for (const auto *rule : _rules)
+    {
+        if (!rule->Match(data, currentLevel))
+            return false;
+    }
+
+    return true;
+}
+
+void LLBC_LogControlExecutor::Action(ApplyResult &io) const
+{
+    _action->Apply(io);
+}
+
+__LLBC_NS_END

--- a/llbc/src/core/log/LogControlMgr.cpp
+++ b/llbc/src/core/log/LogControlMgr.cpp
@@ -1,0 +1,144 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#include "llbc/common/Export.h"
+
+#include "llbc/core/thread/Guard.h"
+
+#include "llbc/core/log/LogData.h"
+#include "llbc/core/log/LogControlMgr.h"
+
+__LLBC_NS_BEGIN
+
+LLBC_LogControlMgr::LLBC_LogControlMgr()
+: _lock()
+, _execs(nullptr)
+, _suppressedCount(0)
+{
+}
+
+int LLBC_LogControlMgr::SetControls(const std::vector<LLBC_LogControlItem> &items)
+{
+    if (items.empty())
+    {
+        LLBC_LockGuard guard(_lock);
+        _execs.reset();
+        return LLBC_OK;
+    }
+
+    // Build outside the lock; on any invalid item the previously published
+    // snapshot stays in effect.
+    auto next = std::make_shared<ExecutorList>();
+    next->reserve(items.size());
+    for (const auto &item : items)
+    {
+        std::unique_ptr<LLBC_LogControlExecutor> exec(LLBC_LogControlExecutor::Create(item));
+        if (!exec)
+            return LLBC_FAILED;
+        next->push_back(std::move(exec));
+    }
+
+    LLBC_LockGuard guard(_lock);
+    _execs = std::move(next);
+    return LLBC_OK;
+}
+
+size_t LLBC_LogControlMgr::GetControlCount() const
+{
+    LLBC_LockGuard guard(_lock);
+    return _execs ? _execs->size() : 0;
+}
+
+void LLBC_LogControlMgr::GetControls(std::vector<LLBC_LogControlItem> &out) const
+{
+    out.clear();
+
+    // Snapshot under the lock, traverse outside.
+    std::shared_ptr<const ExecutorList> snap;
+    {
+        LLBC_LockGuard guard(_lock);
+        snap = _execs;
+    }
+
+    if (!snap)
+        return;
+    out.reserve(snap->size());
+    for (const auto &e : *snap)
+        out.push_back(e->GetItem());
+}
+
+uint64 LLBC_LogControlMgr::GetSuppressedCount() const
+{
+    LLBC_LockGuard guard(_lock);
+    return _suppressedCount;
+}
+
+void LLBC_LogControlMgr::ResetSuppressedCount()
+{
+    LLBC_LockGuard guard(_lock);
+    _suppressedCount = 0;
+}
+
+bool LLBC_LogControlMgr::IsEmpty() const
+{
+    LLBC_LockGuard guard(_lock);
+    return !_execs || _execs->empty();
+}
+
+LLBC_LogControlMgr::ApplyResult LLBC_LogControlMgr::Apply(int appenderType,
+                                                          const LLBC_LogData &data,
+                                                          int originalLevel) const
+{
+    ApplyResult r{ false, originalLevel };
+
+    // Snapshot under the lock, traverse outside; the shared_ptr copy pins
+    // the snapshot for the rest of this call.
+    std::shared_ptr<const ExecutorList> snap;
+    {
+        LLBC_LockGuard guard(_lock);
+        snap = _execs;
+    }
+
+    if (!snap || snap->empty())
+        return r;
+
+    // Declaration-order traversal; Match() runs against the current effective
+    // level so chained SetLevel actions are observable to later executors.
+    // Mute short-circuits the chain.
+    for (const auto &exec : *snap)
+    {
+        if (!exec->Match(appenderType, data, r.effectiveLevel))
+            continue;
+
+        exec->Action(r);
+        if (r.muted)
+        {
+            LLBC_LockGuard guard(_lock);
+            ++_suppressedCount;
+            return r;
+        }
+    }
+
+    return r;
+}
+
+__LLBC_NS_END

--- a/llbc/src/core/log/LogMatchRule.cpp
+++ b/llbc/src/core/log/LogMatchRule.cpp
@@ -1,0 +1,181 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of 
+// this software and associated documentation files (the "Software"), to deal in 
+// the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
+// the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#include "llbc/common/Export.h"
+
+#include "llbc/core/log/LogData.h"
+#include "llbc/core/log/LogLevel.h"
+#include "llbc/core/log/LogMatchRule.h"
+
+__LLBC_NS_BEGIN
+
+int LLBC_LogFileMatchRule::Initialize(const LLBC_LogControlItem &item)
+{
+    // Empty lineRanges == whole-file wildcard (OK); non-empty segments must
+    // be half-open [begin, end) with begin >= 0.
+    if (item.file.file.empty())
+        return LLBC_FAILED;
+    for (const auto &seg : item.file.lineRanges)
+    {
+        if (seg.first < 0 || seg.second <= seg.first)
+            return LLBC_FAILED;
+    }
+
+    _matchFile = item.file.file;
+    _matchLineRanges = item.file.lineRanges;
+    return LLBC_OK;
+}
+
+bool LLBC_LogFileMatchRule::Match(const LLBC_LogData &data, int currentLevel) const
+{
+    if (data.file[0] == '\0')
+        return false;
+    if (_matchFile != data.file)
+        return false;
+    if (_matchLineRanges.empty())
+        return true;
+    for (const auto &seg : _matchLineRanges)
+    {
+        if (data.line >= seg.first && data.line < seg.second)
+            return true;
+    }
+    return false;
+}
+
+int LLBC_LogFuncMatchRule::Initialize(const LLBC_LogControlItem &item)
+{
+    if (item.func.values.empty())
+        return LLBC_FAILED;
+    for (const auto &fn : item.func.values)
+    {
+        if (fn.empty())
+            return LLBC_FAILED;
+    }
+
+    _matchFuncs = item.func.values;
+    return LLBC_OK;
+}
+
+bool LLBC_LogFuncMatchRule::Match(const LLBC_LogData &data, int currentLevel) const
+{
+    if (data.func[0] == '\0')
+        return false;
+    for (const auto &fn : _matchFuncs)
+    {
+        if (fn == data.func)
+            return true;
+    }
+    return false;
+}
+
+int LLBC_LogThreadIdMatchRule::Initialize(const LLBC_LogControlItem &item)
+{
+    if (item.threadId.values.empty())
+        return LLBC_FAILED;
+
+    _matchThreadIds = item.threadId.values;
+    return LLBC_OK;
+}
+
+bool LLBC_LogThreadIdMatchRule::Match(const LLBC_LogData &data, int currentLevel) const
+{
+    for (auto tid : _matchThreadIds)
+    {
+        if (tid == data.threadId)
+            return true;
+    }
+    return false;
+}
+
+int LLBC_LogLevelMatchRule::Initialize(const LLBC_LogControlItem &item)
+{
+    if (item.level.values.empty())
+        return LLBC_FAILED;
+    for (int lvl : item.level.values)
+    {
+        if (!LLBC_LogLevel::IsValid(lvl))
+            return LLBC_FAILED;
+    }
+
+    _matchLevels = item.level.values;
+    return LLBC_OK;
+}
+
+bool LLBC_LogLevelMatchRule::Match(const LLBC_LogData &data, int currentLevel) const
+{
+    // Matches currentLevel (chain-rewritten effective level), not data.level,
+    // so "SetLevel then match by level" is composable.
+    for (int lvl : _matchLevels)
+    {
+        if (lvl == currentLevel)
+            return true;
+    }
+    return false;
+}
+
+bool LLBC_BaseLogMatchRule::IsEnabled(int matchType, const LLBC_LogControlItem &item)
+{
+    switch (matchType)
+    {
+    case LLBC_LogControlMatchType::File:     return item.file.enabled;
+    case LLBC_LogControlMatchType::Func:     return item.func.enabled;
+    case LLBC_LogControlMatchType::ThreadId: return item.threadId.enabled;
+    case LLBC_LogControlMatchType::Level:    return item.level.enabled;
+    default:                                 return false;
+    }
+}
+
+LLBC_BaseLogMatchRule *LLBC_BaseLogMatchRule::Create(int matchType, const LLBC_LogControlItem &item)
+{
+    LLBC_BaseLogMatchRule *rule = nullptr;
+    switch (matchType)
+    {
+    case LLBC_LogControlMatchType::File:
+        rule = new LLBC_LogFileMatchRule;
+        break;
+
+    case LLBC_LogControlMatchType::Func:
+        rule = new LLBC_LogFuncMatchRule;
+        break;
+
+    case LLBC_LogControlMatchType::ThreadId:
+        rule = new LLBC_LogThreadIdMatchRule;
+        break;
+
+    case LLBC_LogControlMatchType::Level:
+        rule = new LLBC_LogLevelMatchRule;
+        break;
+
+    default:
+        return nullptr;
+    }
+
+    if (rule->Initialize(item) != LLBC_OK)
+    {
+        LLBC_XDelete(rule);
+        return nullptr;
+    }
+
+    return rule;
+}
+
+__LLBC_NS_END

--- a/llbc/src/core/log/Logger.cpp
+++ b/llbc/src/core/log/Logger.cpp
@@ -31,6 +31,8 @@
 #include "llbc/core/log/LogLevel.h"
 #include "llbc/core/log/LogData.h"
 #include "llbc/core/log/LogTrace.h"
+#include "llbc/core/log/LogControl.h"
+#include "llbc/core/log/LogControlMgr.h"
 #include "llbc/core/log/LoggerConfigInfo.h"
 #include "llbc/core/log/LogTimeAccessor.h"
 #include "llbc/core/log/BaseLogAppender.h"
@@ -52,6 +54,8 @@ LLBC_Logger::LLBC_Logger()
 , _logTraceMgr(new LLBC_LogTraceMgr(LLBC_CFG_CORE_LOG_TRACE_SEPARATORS[0],
                                     LLBC_CFG_CORE_LOG_TRACE_SEPARATORS[1],
                						LLBC_CFG_CORE_LOG_TRACE_SEPARATORS[2]))
+
+, _logControlMgr(new LLBC_LogControlMgr)
 
 , _logRunnable(nullptr)
 
@@ -100,6 +104,10 @@ int LLBC_Logger::Initialize(const LLBC_LoggerConfigInfo *config, LLBC_LogRunnabl
     _logLevel = config->GetLogLevel();
     _config = new LLBC_LoggerConfigInfo(*config);
     _logTraceMgr->UpdateColorLogTraces(_config->GetRequireColorLogTraces());
+
+    // Apply log output control items parsed from config.
+    if (_logControlMgr->SetControls(_config->GetLogControls()) != LLBC_OK)
+        return LLBC_FAILED;
 
     _logTimeAccessor = &_config->GetLogTimeAccessor();
 
@@ -441,6 +449,50 @@ void LLBC_Logger::ClearAllLogTraces()
     _lock.Unlock();
 }
 
+int LLBC_Logger::SetLogControls(const std::vector<LLBC_LogControlItem> &items)
+{
+    if (UNLIKELY(!_logControlMgr))
+    {
+        LLBC_SetLastError(LLBC_ERROR_NOT_INIT);
+        return LLBC_FAILED;
+    }
+
+    return _logControlMgr->SetControls(items);
+}
+
+size_t LLBC_Logger::GetLogControlCount() const
+{
+    if (UNLIKELY(!_logControlMgr))
+        return 0;
+
+    return _logControlMgr->GetControlCount();
+}
+
+void LLBC_Logger::GetLogControls(std::vector<LLBC_LogControlItem> &out) const
+{
+    out.clear();
+    if (UNLIKELY(!_logControlMgr))
+        return;
+
+    _logControlMgr->GetControls(out);
+}
+
+uint64 LLBC_Logger::GetLogControlSuppressedCount() const
+{
+    if (UNLIKELY(!_logControlMgr))
+        return 0;
+
+    return _logControlMgr->GetSuppressedCount();
+}
+
+void LLBC_Logger::ResetLogControlSuppressedCount()
+{
+    if (UNLIKELY(!_logControlMgr))
+        return;
+
+    _logControlMgr->ResetSuppressedCount();
+}
+
 int LLBC_Logger::VOutput(int level,
                          const char *tag,
                          const char *file,
@@ -727,14 +779,43 @@ void LLBC_Logger::AddAppender(LLBC_BaseLogAppender *appender)
     tmpAppender->SetAppenderNext(appender);
 }
 
-int LLBC_Logger::OutputLogData(const LLBC_LogData &data)
+int LLBC_Logger::OutputLogData(LLBC_LogData &data)
 {
     LLBC_BaseLogAppender *appender = _appenders;
     if (!appender)
         return LLBC_OK;
 
+    // Fast-path: skip Apply() entirely when no control item is installed
+    // (common in production, keeps the hot path branch-light).
+    const bool hasControl = _logControlMgr && !_logControlMgr->IsEmpty();
+
+    // Apply() may temporarily rewrite `data.level` per appender (SetLevel);
+    // Defer restores it on every return path so the caller observes no net
+    // change. The read-modify-restore window is closed within a single thread
+    // (sync mode holds `_lock`; async mode runs on the LogRunnable thread),
+    // so the transient value is not observable elsewhere.
+    const int originalLevel = data.level;
+    LLBC_Defer(data.level = originalLevel);
+
     while (appender)
     {
+        int outputLevel = originalLevel;
+
+        if (hasControl)
+        {
+            const auto r = _logControlMgr->Apply(appender->GetType(),
+                                                 data,
+                                                 originalLevel);
+            if (r.muted)
+            {
+                appender = appender->GetAppenderNext();
+                continue;
+            }
+
+            outputLevel = r.effectiveLevel;
+        }
+
+        data.level = outputLevel;
         if (appender->Output(data) != LLBC_OK)
             return LLBC_FAILED;
 
@@ -806,6 +887,7 @@ void LLBC_Logger::ClearNonRunnableMembers(bool keepErrNo)
     _lastFlushTime = 0;
 
     LLBC_XDelete(_logTraceMgr);
+    LLBC_XDelete(_logControlMgr);
 
     _logTimeAccessor = nullptr;
 

--- a/llbc/src/core/log/LoggerConfigInfo.cpp
+++ b/llbc/src/core/log/LoggerConfigInfo.cpp
@@ -1,22 +1,22 @@
-    // The MIT License (MIT)
+// The MIT License (MIT)
 
 // Copyright (c) 2013 lailongwei<lailongwei@126.com>
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of 
-// this software and associated documentation files (the "Software"), to deal in 
-// the Software without restriction, including without limitation the rights to 
-// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of 
-// the Software, and to permit persons to whom the Software is furnished to do so, 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all 
+//
+// The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS 
-// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
@@ -25,7 +25,7 @@
 #include "llbc/core/os/OS_SysConf.h"
 #include "llbc/core/os/OS_Process.h"
 #include "llbc/core/utils/Util_Text.h"
-#include  "llbc/core/file/Directory.h"
+#include "llbc/core/file/Directory.h"
 #include "llbc/core/variant/Variant.h"
 
 #include "llbc/core/log/LogLevel.h"
@@ -43,6 +43,217 @@
                                                                (_notConfigUseRoot ? rootCfg->rootMeth() : (dft))) \
 
 __LLBC_NS_BEGIN
+
+// LogControls CIR parsing helpers, file-scope, only used by
+// LLBC_LoggerConfigInfo::ParseLogControls. All are total on bad input:
+// return false or empty; caller silently skips the offending item.
+//
+// CIR (Config Intermediate Representation) is a plain map/seq/scalar Variant
+// tree produced by LoggerConfigurator regardless of the source format. This
+// module never touches LLBC_XMLKeys or any XML-shape metadata -- the schema
+// dictionary below is the ONLY contract with LoggerConfigurator.
+//
+// LogControls CIR schema (see doc in LoggerConfigInfo.h GetLogControls()):
+//   Seq<
+//     Dict {
+//       "match":    Dict { "file": Dict{"name":Str, "lines"?:Str},
+//                          "func"|"threadId"|"level": Str | Seq<Str> },
+//       "appenders": Str | Seq<Str>,           # optional
+//       "action":    Dict { "type":Str, "newLevel"?:Str }
+//     }
+//   >
+//
+// Repeated same-name children in XML are always emitted as Seq by the
+// Configurator layer; a single occurrence stays as a scalar. Helpers below
+// tolerate both shapes so any future loader (yaml/json/...) that already
+// emits Seq for singletons continues to work.
+
+// Parse a level: name ("Debug"/"Info"/..., case-insensitive) or decimal int.
+static bool ParseLevelStr(const LLBC_String &s, int &outLevel)
+{
+    if (s.empty())
+        return false;
+
+    // Try int form first (LLBC_LogLevel::GetLevelEnum is strict on names).
+    if (s.isdigit() || (s.size() > 1 && (s[0] == '-' || s[0] == '+') &&
+                        s.substr(1).isdigit()))
+    {
+        const long n = std::strtol(s.c_str(), nullptr, 10);
+        if (n < INT_MIN || n > INT_MAX)
+            return false;
+        const int lvl = static_cast<int>(n);
+        if (!LLBC_LogLevel::IsValid(lvl))
+            return false;
+        outLevel = lvl;
+        return true;
+    }
+
+    // Name form.
+    const int lvl = LLBC_LogLevel::GetLevelEnum(s);
+    if (!LLBC_LogLevel::IsValid(lvl))
+        return false;
+    outLevel = lvl;
+    return true;
+}
+
+// Parse an appender type name ("console"/"file"/"network", case-insensitive).
+static bool ParseAppenderTypeStr(const LLBC_String &s, int &outType)
+{
+    if (s.empty())
+        return false;
+    const int t = LLBC_LogAppenderType::GetTypeEnum(s.c_str());
+    if (!LLBC_LogAppenderType::IsValid(t))
+        return false;
+    outType = t;
+    return true;
+}
+
+// Parse a thread-id string ("12345"; leading '+'/'-' allowed).
+static bool ParseThreadIdStr(const LLBC_String &s, LLBC_ThreadId &outTid)
+{
+    if (s.empty())
+        return false;
+    const char *p = s.c_str();
+    if (*p == '-' || *p == '+')
+        ++p;
+    if (*p == '\0')
+        return false;
+    for (const char *q = p; *q; ++q)
+        if (!isdigit(static_cast<unsigned char>(*q)))
+            return false;
+    char *endp = nullptr;
+    const long long n = std::strtoll(s.c_str(), &endp, 10);
+    if (!endp || *endp != '\0')
+        return false;
+    outTid = static_cast<LLBC_ThreadId>(n);
+    return true;
+}
+
+// Parse the `lines` attr of <file>: comma-separated segments, each "N" (=>
+// [N, N+1)) or "N-M" (=> [N, M), M > N). Whitespace tolerated.
+// e.g. "100, 102-112" -> [(100,101), (102,112)]. Returns false on any bad
+// segment (caller skips the whole item).
+static bool ParseLineSpec(const LLBC_String &spec,
+                          std::vector<std::pair<int, int> > &outRanges)
+{
+    outRanges.clear();
+    LLBC_String s = LLBC_String(spec).strip();
+    if (s.empty())
+        return false;
+
+    auto segs = s.split(',', -1, true);
+    if (segs.empty())
+        return false;
+    for (auto &raw : segs)
+    {
+        LLBC_String seg = raw.strip();
+        if (seg.empty())
+            return false;
+
+        const auto dashPos = seg.find('-');
+        if (dashPos == LLBC_String::npos)
+        {
+            // Single line "N" -> [N, N+1).
+            if (!seg.isdigit())
+                return false;
+            const long ln = std::strtol(seg.c_str(), nullptr, 10);
+            if (ln < 0 || ln >= INT_MAX)
+                return false;
+            outRanges.emplace_back(static_cast<int>(ln), static_cast<int>(ln) + 1);
+        }
+        else
+        {
+            // Range "N-M" -> [N, M).
+            LLBC_String beg = seg.substr(0, dashPos).strip();
+            LLBC_String end = seg.substr(dashPos + 1).strip();
+            if (!beg.isdigit() || !end.isdigit())
+                return false;
+            const long lb = std::strtol(beg.c_str(), nullptr, 10);
+            const long le = std::strtol(end.c_str(), nullptr, 10);
+            if (lb < 0 || le <= lb || le > INT_MAX)
+                return false;
+            outRanges.emplace_back(static_cast<int>(lb), static_cast<int>(le));
+        }
+    }
+    return !outRanges.empty();
+}
+
+// Parse a CIR `file` node (Dict{"name":Str, "lines"?:Str}) into (name, ranges).
+// Absent / empty `lines` => empty ranges (whole-file wildcard).
+static bool ParseFileNode(const LLBC_Variant &fileNode,
+                          LLBC_String &outName,
+                          std::vector<std::pair<int, int> > &outRanges)
+{
+    outRanges.clear();
+    if (!fileNode.Is<LLBC_Variant::Dict>())
+        return false;
+
+    LLBC_String name = fileNode["name"].As<LLBC_Variant::Str>().strip();
+    if (name.empty())
+        return false;
+
+    const LLBC_String linesSpec = fileNode["lines"].As<LLBC_Variant::Str>().strip();
+    if (!linesSpec.empty() && !ParseLineSpec(linesSpec, outRanges))
+        return false;
+
+    outName = std::move(name);
+    return true;
+}
+
+// Normalize a CIR "one-or-many" node into a Seq for uniform iteration.
+//
+// Accepted input shapes (all sources: xml-CIR, yaml, json, .cfg):
+//   - Nil                        -> empty Seq
+//   - Seq<T>                     -> copy of the input Seq
+//   - Dict with `wrapperKey`     -> unwrap once, then re-normalize
+//                                   (handles XML container element wrapping
+//                                   repeated children, e.g. <items><item>...
+//                                   </item><item>...</item></items>)
+//   - Dict (no wrapper) / Str /
+//     other scalar               -> 1-element Seq holding the node as-is
+//
+// The result is a value-typed Seq; callers just iterate `.As<LLBC_Variant::Seq>()` without
+// having to branch on scalar/Seq/Dict-wrapper. `wrapperKey` is optional:
+// pass empty (default) to skip wrapper unwrapping when a caller knows the
+// node is already at leaf level (e.g. Str|Seq<Str>).
+static LLBC_Variant NormalizeToSeq(const LLBC_Variant &node,
+                                   const LLBC_String &wrapperKey = "")
+{
+    // Unwrap XML-style single-child container: Dict{ wrapperKey: X } -> X.
+    if (!wrapperKey.empty() && node.Is<LLBC_Variant::Dict>() && !node[wrapperKey].Is<void>())
+        return NormalizeToSeq(node[wrapperKey], "");
+
+    LLBC_Variant out;
+    out.Become<LLBC_Variant::Seq>();
+    if (node.Is<void>())
+        return out;
+    if (node.Is<LLBC_Variant::Seq>())
+    {
+        for (auto &elem : node.As<LLBC_Variant::Seq>())
+            out.SeqPushBack(elem);
+        return out;
+    }
+    // Scalar (Str/Int/...) or Dict-single -> wrap as 1-element Seq.
+    out.SeqPushBack(node);
+    return out;
+}
+
+// Collect a CIR "scalar-or-Seq" leaf (typical for repeated leaf children
+// like <func>a</func><func>b</func>) into a typed vector via `extract`.
+// Entries where `extract` returns false are dropped silently.
+template <typename T, typename Fn>
+static void CollectValues(const LLBC_Variant &node,
+                          std::vector<T> &out,
+                          Fn extract)
+{
+    T tmp;
+    const LLBC_Variant elems = NormalizeToSeq(node);
+    for (auto &elem : elems.As<LLBC_Variant::Seq>())
+    {
+        if (extract(elem, tmp))
+            out.push_back(std::move(tmp));
+    }
+}
 
 LLBC_LoggerConfigInfo::LLBC_LoggerConfigInfo()
 : _notConfigUseRoot(false)
@@ -91,7 +302,7 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
     // Not config use default/root option.
     LLBC_String notCfgUseOpt;
     if (cfg["notConfigUse"])
-        notCfgUseOpt = cfg["notConfigUse"].As<LLBC_String>();
+        notCfgUseOpt = cfg["notConfigUse"].As<LLBC_Variant::Str>();
     else if (rootCfg)
         notCfgUseOpt = rootCfg->IsNotConfigUseRoot() ? "root" : "default";
     else
@@ -103,7 +314,7 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
 
     // Require color log traces.
     auto keyContentsGroups =
-        cfg["requireColorLogTraces"].As<LLBC_String>().strip().split(LLBC_CFG_CORE_LOG_TRACE_SEPARATORS[0], -1, true);
+        cfg["requireColorLogTraces"].As<LLBC_Variant::Str>().strip().split(LLBC_CFG_CORE_LOG_TRACE_SEPARATORS[0], -1, true);
     for (auto &group : keyContentsGroups)
     {
         auto keyContentsPair = group.strip().split(LLBC_CFG_CORE_LOG_TRACE_SEPARATORS[1], 1, true);
@@ -120,39 +331,41 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
         for (auto &content : contents)
         {
             auto normalizedContent = content.strip();
-            if (!normalizedContent.empty()) 
-                contentVec.emplace_back(normalizedContent); 
+            if (!normalizedContent.empty())
+                contentVec.emplace_back(normalizedContent);
         }
 
         if (!contentVec.empty())
-            _requireColorLogTraces.emplace(LLBC_LogTrace::TraceKey(key), contentVec); 
+            _requireColorLogTraces.emplace(LLBC_LogTrace::TraceKey(key), contentVec);
     }
+
+    ParseLogControls(cfg["logControls"], _logControls);
 
     _asyncMode = __LLBC_GetLogCfg(
         "asynchronous", ASYNC_MODE, IsAsyncMode, AsLooseBool);
     if (_asyncMode)
         _independentThread = __LLBC_GetLogCfg(
             "independentThread", INDEPENDENT_THREAD, IsIndependentThread, AsLooseBool);
-     _flushInterval = __LLBC_GetLogCfg(
-         "flushInterval", LOG_FLUSH_INTERVAL, GetFlushInterval, As<int>);
+    _flushInterval = __LLBC_GetLogCfg(
+        "flushInterval", LOG_FLUSH_INTERVAL, GetFlushInterval, As<int>);
 
     // Json styled log configs.
     _addTimestampInJsonLog = __LLBC_GetLogCfg(
         "addTimestampInJsonLog", ADD_TIMESTAMP_IN_JSON_LOG, IsAddTimestampInJsonLog, AsLooseBool);
 
     // Console log configs.
-     _logToConsole = __LLBC_GetLogCfg("logToConsole", LOG_TO_CONSOLE, IsLogToConsole, AsLooseBool);
+    _logToConsole = __LLBC_GetLogCfg("logToConsole", LOG_TO_CONSOLE, IsLogToConsole, AsLooseBool);
     if (_logToConsole)
     {
         if (cfg["consoleLogLevel"])
-            _consoleLogLevel = LLBC_LogLevel::GetLevelEnum(cfg["consoleLogLevel"].As<LLBC_String>().c_str());
+            _consoleLogLevel = LLBC_LogLevel::GetLevelEnum(cfg["consoleLogLevel"].As<LLBC_Variant::Str>().c_str());
         else
             _consoleLogLevel = _notConfigUseRoot ? rootCfg->GetConsoleLogLevel() : LLBC_CFG_LOG_DEFAULT_LEVEL;
 
         if (cfg["consolePattern"])
-            _consolePattern = cfg["consolePattern"].As<LLBC_String>();
+            _consolePattern = cfg["consolePattern"].As<LLBC_Variant::Str>();
         else
-            _consolePattern = _notConfigUseRoot ? 
+            _consolePattern = _notConfigUseRoot ?
                 rootCfg->GetConsolePattern().c_str() : LLBC_CFG_LOG_DEFAULT_CONSOLE_LOG_PATTERN;
         _colourfulOutput = __LLBC_GetLogCfg(
             "colourfulOutput", COLOURFUL_OUTPUT, IsColourfulOutput, AsLooseBool);
@@ -164,7 +377,7 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
     {
         // File log level.
         if (cfg["fileLogLevel"])
-            _fileLogLevel = LLBC_LogLevel::GetLevelEnum(cfg["fileLogLevel"].As<LLBC_String>().c_str());
+            _fileLogLevel = LLBC_LogLevel::GetLevelEnum(cfg["fileLogLevel"].As<LLBC_Variant::Str>().c_str());
         else
             _fileLogLevel = _notConfigUseRoot ? rootCfg->GetFileLogLevel() : LLBC_CFG_LOG_DEFAULT_LEVEL;
 
@@ -184,7 +397,7 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
 
         // Log file name.
         if (cfg["logFile"])
-            _logFile = cfg["logFile"].As<LLBC_String>().strip();
+            _logFile = cfg["logFile"].As<LLBC_Variant::Str>().strip();
 
         if (_logFile.empty())
         {
@@ -215,14 +428,14 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
             "logCodeFilePath", LOG_CODE_FILE_PATH, IsLogCodeFilePath, AsLooseBool);
         // Log file pattern.
         if (cfg["filePattern"])
-            _filePattern = cfg["filePattern"].As<LLBC_String>();
+            _filePattern = cfg["filePattern"].As<LLBC_Variant::Str>();
         else
-            _filePattern = _notConfigUseRoot ? 
+            _filePattern = _notConfigUseRoot ?
                 rootCfg->GetFilePattern().c_str() : LLBC_CFG_LOG_DEFAULT_FILE_LOG_PATTERN;
 
         // File rolling mode.
         if (cfg["fileRollingMode"])
-            _fileRollingMode = LLBC_LogRollingMode::Str2Mode(cfg["fileRollingMode"].As<LLBC_String>());
+            _fileRollingMode = LLBC_LogRollingMode::Str2Mode(cfg["fileRollingMode"].As<LLBC_Variant::Str>());
         else
             _fileRollingMode = _notConfigUseRoot ?
                 rootCfg->GetFileRollingMode() : LLBC_CFG_LOG_DEFAULT_FILE_ROLLING_MODE;
@@ -250,13 +463,13 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
         if (_asyncMode)
             _fileBufferSize = __LLBC_GetLogCfg(
                 "fileBufferSize", LOG_FILE_BUFFER_SIZE, GetFileBufferSize, As<int>);
-        
+
         // Advise discard file page cache.
         _fadviseDiscardEnabled = LLBC_CFG_LOG_DEFAULT_ENABLE_FADVISE_DISCARD;
-        if (!cfg["enableFadviseDiscard"].As<LLBC_String>().strip().empty())
+        if (!cfg["enableFadviseDiscard"].As<LLBC_Variant::Str>().strip().empty())
             _fadviseDiscardEnabled = cfg["enableFadviseDiscard"].AsLooseBool();
 
-        if (_fadviseDiscardEnabled) 
+        if (_fadviseDiscardEnabled)
         {
             // Fadvise discard size.
             _fadviseDiscardSize = NormalizeSizeStr(cfg["fadviseDiscardSize"],
@@ -268,11 +481,11 @@ int LLBC_LoggerConfigInfo::Initialize(const LLBC_String &loggerName,
 
             // File page cache retain size.
             int fadviseDiscardRetainPercent = LLBC_CFG_LOG_DEFAULT_FADVISE_DISCARD_RETAIN_PERCENT;
-            if (!cfg["fadviseDiscardRetainPercent"].As<LLBC_String>().strip().empty())
+            if (!cfg["fadviseDiscardRetainPercent"].As<LLBC_Variant::Str>().strip().empty())
                 fadviseDiscardRetainPercent = std::clamp(cfg["fadviseDiscardRetainPercent"].As<int>(),
                                                          LLBC_CFG_LOG_FADVISE_DISCARD_RETAIN_PERCENT_MIN,
                                                          LLBC_CFG_LOG_FADVISE_DISCARD_RETAIN_PERCENT_MAX);
-            
+
             // Align page cache retain size.
             _fadviseDiscardRetainSize = (_fadviseDiscardSize * fadviseDiscardRetainPercent / 100) & ~(LLBC_pageSize - 1);
         }
@@ -318,9 +531,9 @@ int LLBC_LoggerConfigInfo::GetAppenderLogLevel(int appenderType) const
 void LLBC_LoggerConfigInfo::NormalizeLogFileName()
 {
     // Replace process id: %p.
-    const LLBC_String curProcId = 
+    const LLBC_String curProcId =
         LLBC_Num2Str(LLBC_GetCurrentProcessId());
-    _logFile.findreplace("%p", curProcId); 
+    _logFile.findreplace("%p", curProcId);
 
     // Replace exec name: %e/%m.
     // Note: %m pattern is deprecated.
@@ -436,6 +649,140 @@ sint64 LLBC_LoggerConfigInfo::NormalizeSizeStr(const LLBC_String &sizeStr, sint6
 
     // Clamp.
     return std::clamp(static_cast<sint64>(nmlLogFileSize), low, high);
+}
+
+void LLBC_LoggerConfigInfo::ParseLogControls(const LLBC_Variant &cfg,
+                                             std::vector<LLBC_LogControlItem> &out)
+{
+    // `cfg` == CIR node for the `logControls` key. Expected shapes:
+    //   - Dict{"item": Str|Dict|Seq<Dict>} : XML-style container element
+    //     wrapping repeated <item> children (a single <item> collapses to a
+    //     scalar/Dict in CIR; multiple <item>s produce a Seq of Dicts).
+    //   - Seq<Dict>                        : loader-native list (yaml/json).
+    //   - Str|Dict{...}                    : single item, no wrapper.
+    // Absent (Nil) or malformed shapes are silent no-ops -- keep bootstrap
+    // robust; consistent with per-item skip-on-error policy below.
+    // NormalizeToSeq handles all shapes uniformly: it unwraps the "item"
+    // container when present, and lifts a lone scalar/Dict into a
+    // 1-element Seq -- so downstream just iterates.
+    const LLBC_Variant items = NormalizeToSeq(cfg, "item");
+    for (auto &itemNode : items.As<LLBC_Variant::Seq>())
+    {
+        if (!itemNode.Is<LLBC_Variant::Dict>())
+            continue;
+
+        LLBC_LogControlItem item;
+
+        // 1) match: enabled rules AND-combined; each rule's values OR-combined.
+        const LLBC_Variant &matchNode = itemNode["match"];
+        if (matchNode.Is<LLBC_Variant::Dict>())
+        {
+            // 1.1) file: at most one per item (data model carries a single
+            //      basename + ranges). A present-but-malformed `file` rejects
+            //      the whole item.
+            const LLBC_Variant &fileNode = matchNode["file"];
+            if (!fileNode.Is<void>())
+            {
+                LLBC_String name;
+                std::vector<std::pair<int, int> > ranges;
+                if (!ParseFileNode(fileNode, name, ranges))
+                    continue;
+                item.file.enabled = true;
+                item.file.file = std::move(name);
+                item.file.lineRanges = std::move(ranges);
+            }
+
+            // 1.2) func: Str | Seq<Str>; empty entries dropped.
+            {
+                std::vector<LLBC_String> funcs;
+                CollectValues<LLBC_String>(
+                    matchNode["func"], funcs,
+                    [](const LLBC_Variant &elem, LLBC_String &o) {
+                        o = elem.As<LLBC_Variant::Str>().strip();
+                        return !o.empty();
+                    });
+                if (!funcs.empty())
+                {
+                    item.func.enabled = true;
+                    item.func.values = std::move(funcs);
+                }
+            }
+
+            // 1.3) threadId: Str | Seq<Str>.
+            {
+                std::vector<LLBC_ThreadId> tids;
+                CollectValues<LLBC_ThreadId>(
+                    matchNode["threadId"], tids,
+                    [](const LLBC_Variant &elem, LLBC_ThreadId &o) {
+                        return ParseThreadIdStr(elem.As<LLBC_Variant::Str>().strip(), o);
+                    });
+                if (!tids.empty())
+                {
+                    item.threadId.enabled = true;
+                    item.threadId.values = std::move(tids);
+                }
+            }
+
+            // 1.4) level: Str | Seq<Str>; name or int accepted.
+            {
+                std::vector<int> lvls;
+                CollectValues<int>(
+                    matchNode["level"], lvls,
+                    [](const LLBC_Variant &elem, int &o) {
+                        return ParseLevelStr(elem.As<LLBC_Variant::Str>().strip(), o);
+                    });
+                if (!lvls.empty())
+                {
+                    item.level.enabled = true;
+                    item.level.values = std::move(lvls);
+                }
+            }
+        }
+
+        if (!item.HasAnyMatch())
+            continue;
+
+        // 2) appenders (optional): Dict{"appender": Str|Seq<Str>}; empty/
+        //    absent == all appenders. Unknown names dropped silently.
+        //    The dict shape mirrors the XML container element <appenders>
+        //    holding repeated <appender> children; a scalar/Seq shortcut
+        //    (loader emits appenders directly as Str|Seq<Str>) is also
+        //    accepted for source formats that don't need the container.
+        //    NormalizeToSeq handles both via the "appender" wrapper key.
+        const LLBC_Variant appenders =
+            NormalizeToSeq(itemNode["appenders"], "appender");
+        for (auto &elem : appenders.As<LLBC_Variant::Seq>())
+        {
+            int t = 0;
+            if (ParseAppenderTypeStr(elem.As<LLBC_Variant::Str>().strip(), t))
+                item.appenderTypes.push_back(t);
+        }
+
+        // 3) action: Dict{"type":Str, "newLevel"?:Str}. Tagged-union.
+        const LLBC_Variant &actionNode = itemNode["action"];
+        if (!actionNode.Is<LLBC_Variant::Dict>())
+            continue;
+        const LLBC_String actionType = actionNode["type"].As<LLBC_Variant::Str>().strip().tolower();
+        if (actionType == "mute")
+        {
+            item.action = LLBC_LogControlAction::Mute;
+        }
+        else if (actionType == "setlevel")
+        {
+            item.action = LLBC_LogControlAction::SetLevel;
+            // Operand: newLevel. Missing/malformed rejects the whole item.
+            int nlvl = 0;
+            if (!ParseLevelStr(actionNode["newLevel"].As<LLBC_Variant::Str>().strip(), nlvl))
+                continue;
+            item.newLevel = nlvl;
+        }
+        else
+        {
+            continue;
+        }
+
+        out.push_back(std::move(item));
+    }
 }
 
 __LLBC_NS_END

--- a/llbc/src/core/log/LoggerConfigInfo.cpp
+++ b/llbc/src/core/log/LoggerConfigInfo.cpp
@@ -207,8 +207,9 @@ static bool ParseFileNode(const LLBC_Variant &fileNode,
 //   - Seq<T>                     -> copy of the input Seq
 //   - Dict with `wrapperKey`     -> unwrap once, then re-normalize
 //                                   (handles XML container element wrapping
-//                                   repeated children, e.g. <items><item>...
-//                                   </item><item>...</item></items>)
+//                                   repeated children, e.g.
+//                                   <logControls><logControl>...</logControl>
+//                                   <logControl>...</logControl></logControls>)
 //   - Dict (no wrapper) / Str /
 //     other scalar               -> 1-element Seq holding the node as-is
 //
@@ -655,17 +656,18 @@ void LLBC_LoggerConfigInfo::ParseLogControls(const LLBC_Variant &cfg,
                                              std::vector<LLBC_LogControlItem> &out)
 {
     // `cfg` == CIR node for the `logControls` key. Expected shapes:
-    //   - Dict{"item": Str|Dict|Seq<Dict>} : XML-style container element
-    //     wrapping repeated <item> children (a single <item> collapses to a
-    //     scalar/Dict in CIR; multiple <item>s produce a Seq of Dicts).
-    //   - Seq<Dict>                        : loader-native list (yaml/json).
-    //   - Str|Dict{...}                    : single item, no wrapper.
+    //   - Dict{"logControl": Str|Dict|Seq<Dict>} : XML-style container element
+    //     wrapping repeated <logControl> children (a single <logControl>
+    //     collapses to a scalar/Dict in CIR; multiple <logControl>s produce
+    //     a Seq of Dicts).
+    //   - Seq<Dict>                              : loader-native list (yaml/json).
+    //   - Str|Dict{...}                          : single item, no wrapper.
     // Absent (Nil) or malformed shapes are silent no-ops -- keep bootstrap
     // robust; consistent with per-item skip-on-error policy below.
-    // NormalizeToSeq handles all shapes uniformly: it unwraps the "item"
+    // NormalizeToSeq handles all shapes uniformly: it unwraps the "logControl"
     // container when present, and lifts a lone scalar/Dict into a
     // 1-element Seq -- so downstream just iterates.
-    const LLBC_Variant items = NormalizeToSeq(cfg, "item");
+    const LLBC_Variant items = NormalizeToSeq(cfg, "logControl");
     for (auto &itemNode : items.As<LLBC_Variant::Seq>())
     {
         if (!itemNode.Is<LLBC_Variant::Dict>())

--- a/llbc/src/core/log/LoggerConfigurator.cpp
+++ b/llbc/src/core/log/LoggerConfigurator.cpp
@@ -22,14 +22,14 @@
 
 #include "llbc/common/Export.h"
 
+#include "llbc/core/os/OS_Console.h"
 #include "llbc/core/file/Directory.h"
 #include "llbc/core/helper/STLHelper.h"
 #include "llbc/core/config/Properties.h"
-#include "llbc/core/tinyxml2/tinyxml2.h"
 #include "llbc/core/utils/Util_Text.h"
-#include "llbc/core/utils/Util_Variant.h"
 
 #include "llbc/core/log/Logger.h"
+#include "llbc/core/log/LogConfigLoader.h"
 #include "llbc/core/log/LoggerConfigInfo.h"
 #include "llbc/core/log/BaseLogAppender.h"
 #include "llbc/core/log/LoggerConfigurator.h"
@@ -60,33 +60,39 @@ int LLBC_LoggerConfigurator::Initialize(const LLBC_String &cfgFilePath,
     }
     else if (ext == ".xml")
     {
-        // Load xml file.
-        LLBC_TINYXML2_NS XMLDocument xmlDoc;
-        const auto xmlLoadRet = xmlDoc.LoadFile(cfgFilePath.c_str());
-        if (xmlLoadRet != LLBC_TINYXML2_NS XML_SUCCESS)
-        {
-            LLBC_String customErrStr;
-            customErrStr.format("load log config file failed(xml format), "
-                                "file:%s, errno(tinyxml2:%d), error str:%s",
-                                cfgFilePath.c_str(), xmlLoadRet, xmlDoc.ErrorStr());
-            LLBC_SetLastError(LLBC_ERROR_FORMAT, customErrStr.c_str());
+        // XML -> CIR (plain map/seq/scalar). LogConfigLoader returns the
+        // full document CIR keyed by top-level tag(s); log configs always
+        // wrap loggers under <Log>, so strip that wrapper to align with the
+        // Properties-loaded shape: Dict<loggerName, loggerCfg>.
+        LLBC_Variant docCir;
+        if (LLBC_LogConfigLoader::LoadXmlFromFile(cfgFilePath, docCir) != LLBC_OK)
             return LLBC_FAILED;
-        }
-
-        // Convert to variant object(brief format).
-        LLBC_Variant detailCfg;
-        LLBC_VariantUtil::Xml2Variant(xmlDoc, detailCfg);
-        for (auto &loggerXmlCfg : detailCfg["Log"][LLBC_XMLKeys::Children].As<LLBC_Variant::Seq>())
-        {
-            LLBC_Variant &loggerCfg = cfg[loggerXmlCfg[LLBC_XMLKeys::Name].As<LLBC_String>()];
-            for (auto &logCfgItem : loggerXmlCfg[LLBC_XMLKeys::Children].As<LLBC_Variant::Seq>())
-                loggerCfg[logCfgItem[LLBC_XMLKeys::Name]] = logCfgItem[LLBC_XMLKeys::Value];
-        }
+        cfg = std::move(docCir["Log"]);
     }
     else
     {
         LLBC_SetLastError(LLBC_ERROR_NOT_SUPPORT);
         return LLBC_FAILED;
+    }
+
+    if (ext == ".cfg")
+    {
+        for (auto &loggerCfgItem : cfg.As<LLBC_Variant::Dict>())
+        {
+            const auto &loggerCfg = loggerCfgItem.second;
+            if (!loggerCfg.Is<LLBC_Variant::Dict>() || !loggerCfg["logControls"])
+                continue;
+
+            // `logControls` is XML-only (its structure is XML-tree shaped).    
+            LLBC_String customErrStr;
+            customErrStr.format(
+                "cfg key `%s.logControls` is not supported -- log control "
+                "items must be configured via XML (<logControls> nested "
+                "element block); see doc/log_control.md.",
+                loggerCfgItem.first.As<LLBC_Variant::Str>().c_str());
+            LLBC_SetLastError(LLBC_ERROR_NOT_SUPPORT, customErrStr.c_str());
+            return LLBC_FAILED;
+        }
     }
 
     // Save config file path.
@@ -228,7 +234,16 @@ int LLBC_LoggerConfigurator::ReConfig(LLBC_Logger *logger) const
         // - Re-Config other appender attributes.
         // ... ...
     }
-    
+
+    // Re-Config log output controls (logger-wide, not per-appender).
+    // The logger config parsing layer (LoggerConfigInfo) has already filtered
+    // out malformed entries; we still propagate any failure faithfully so the
+    // caller sees it. SetLogControls is atomic: on failure the previous
+    // snapshot stays effective, on success the new snapshot is published in
+    // one step (no transient empty state observable to log emitters).
+    if (logger->SetLogControls(info->GetLogControls()) != LLBC_OK)
+        return LLBC_FAILED;
+
     return LLBC_OK;
 }
 

--- a/llbc/src/core/rapidjson/json.cpp
+++ b/llbc/src/core/rapidjson/json.cpp
@@ -56,4 +56,27 @@ std::ostream &operator<<(std::ostream &o, const LLBC_JsonValue &value)
     return o << buffer.GetString();
 }
 
+const LLBC_JsonValue &LLBC_JsonGetMember(const LLBC_JsonValue &parent, const char *key)
+{
+    static const LLBC_JsonValue kNull;
+    if (!parent.IsObject())
+        return kNull;
+    auto it = parent.FindMember(key);
+    return it != parent.MemberEnd() ? it->value : kNull;
+}
+
+const char *LLBC_JsonGetStr(const LLBC_JsonValue &v, const char *def)
+{
+    return v.IsString() ? v.GetString() : def;
+}
+
+int LLBC_JsonGetInt(const LLBC_JsonValue &v, int def)
+{
+    if (v.IsInt())
+        return v.GetInt();
+    if (v.IsInt64())
+        return static_cast<int>(v.GetInt64());
+    return def;
+}
+
 __LLBC_NS_END

--- a/tests/func_test/core/log/FuncTest_Core_Log.cpp
+++ b/tests/func_test/core/log/FuncTest_Core_Log.cpp
@@ -58,6 +58,12 @@ int FuncTest_Core_Log::Run(int argc, char *argv[])
     // Defer finalize logger mgr.
     LLBC_Defer(LLBC_LoggerMgrSingleton->Finalize());
 
+    // log output control test (config-driven, XML-only).
+    // Must run AFTER LoggerMgr::Initialize because it Reloads the manager
+    // from `LogTestCfg.xml` to pick up the <logControls> subtree that flat
+    // `.cfg` cannot carry.
+    LLBC_ErrorAndReturnIf(DoLogControlTest() != LLBC_OK, LLBC_FAILED);
+
     // log color filter test.
     DoLogColorFilterTest();
 
@@ -881,4 +887,349 @@ void FuncTest_Core_Log::OnLogHook(const LLBC_LogData *logData)
                    logData->logger->GetLoggerName().c_str(),
                    LLBC_LogLevel::GetLevelStr(logData->level).c_str(),
                    logData->msg);
+}
+
+// ----------------------------------------------------------------------------
+// Log output control items test (Mute / SetLevel) — config-driven only.
+// ----------------------------------------------------------------------------
+// The log control list is a startup/reload-only configuration surface; there
+// is no public runtime API to mutate it after initialization. Coverage here
+// is therefore limited to the two ingestion paths that actually exist:
+//
+//   1) Config-driven items (logcontrol_full)
+//        - file+line exact / wildcard (line==0) / half-open range / multi-seg
+//        - func name single / multi-value (OR within one item)
+//        - threadId multi-value (parsing / structural assertions only)
+//        - SetLevel: rewrite level to a higher value
+//        - single-appender scope restriction
+//        - declaration order is preserved; control item count matches config
+//   2) LoggerMgr::Reload re-installs the config-driven control list.
+// ----------------------------------------------------------------------------
+
+bool TestCase_Core_Log::EmitAndCheckSuppressed(LLBC_Logger *logger,
+                                               int level,
+                                               const char *file,
+                                               int line,
+                                               const char *func,
+                                               const char *msg,
+                                               size_t expectedHits)
+{
+    // Emit one fake-source log record and check whether the control filter
+    // dropped (Mute action) it on `expectedHits` appender(s). The suppressed
+    // count is incremented exactly once per (record, appender) pair that hits
+    // a Mute action.
+    const uint64 before = logger->GetLogControlSuppressedCount();
+    logger->Output(level, nullptr, file, line, func, "%s", msg);
+    return logger->GetLogControlSuppressedCount() == before + expectedHits;
+}
+
+int TestCase_Core_Log::DoLogControlTest()
+{
+    LLBC_PrintLn("DoLogControlTest (log control items) begin");
+
+    // The logger manager was initialized with `LogTestCfg.cfg`, which can only
+    // carry flat properties; `logControls` is structurally nested and is
+    // therefore XML-only. We Reload to `LogTestCfg.xml` here so the
+    // logcontrol_full logger (already declared with its basic output
+    // properties in `.cfg`) picks up its <logControls> subtree.
+    // See doc/log_control.md, sections 3 and 6.
+    if (LLBC_LoggerMgrSingleton->Reload("LogTestCfg.xml") != LLBC_OK)
+    {
+        LLBC_FilePrintLn(stderr,
+                         "Reload LogTestCfg.xml for log control test failed, err:%s",
+                         LLBC_FormatLastError());
+        return LLBC_FAILED;
+    }
+
+    // ------------------------------------------------------------------
+    // 1) Config-driven items: logcontrol_full
+    //    Configured (declaration order):
+    //      [0] file=mute_fileA.cpp line==100        -> mute
+    //      [1] file=mute_fileA.cpp line==200        -> mute
+    //      [2] file=mute_fileB.cpp (any line)       -> mute
+    //      [3] func=MutedFuncOne                    -> mute (all appenders)
+    //      [4] func=MutedFuncTwo, scope=[console]   -> mute
+    //      [5] file=mute_fileC.cpp                  -> setlevel warn
+    //      [6] file=mute_fileD.cpp                  -> setlevel error
+    //      [7] file=mute_fileE.cpp [300,305)        -> mute  (single-range)
+    //      [8] file=mute_fileF.cpp [400,410)        -> mute  (single-range)
+    //      [9] file=mute_fileG.cpp 50, 60-65, 70    -> mute  (multi-segment)
+    //     [10] file=mute_fileH.cpp 100-103, 200     -> mute  (multi-segment)
+    //     [11] func=[MutedFuncMA, MutedFuncMB]      -> mute  (func array multi-value)
+    //     [12] threadId=[1, 2147483640]             -> mute  (threadId array multi-value)
+    //    Only `console` appender is enabled, so each muted record contributes
+    //    +1 to GetLogControlSuppressedCount().
+    // ------------------------------------------------------------------
+    auto fullLogger = LLBC_LoggerMgrSingleton->GetLogger("logcontrol_full");
+    LLBC_ErrorAndReturnIf(fullLogger == nullptr,
+                          LLBC_FAILED, "get logcontrol_full failed");
+    fullLogger->ResetLogControlSuppressedCount();
+
+    {
+        std::vector<LLBC_LogControlItem> items;
+        fullLogger->GetLogControls(items);
+        LLBC_PrintLn("[full] parsed control item count: %zu", items.size());
+        LLBC_ErrorAndReturnIf(items.size() != 13,
+                              LLBC_FAILED, "[full] expect 13 control items");
+        // Spot-check declaration order.
+        LLBC_ErrorAndReturnIf(!items[0].file.enabled || items[0].file.file != "mute_fileA.cpp" ||
+                              items[0].file.lineRanges.size() != 1 ||
+                              items[0].file.lineRanges[0].first != 100 ||
+                              items[0].file.lineRanges[0].second != 101 ||
+                              items[0].action != LLBC_LogControlAction::Mute,
+                              LLBC_FAILED, "[full] item[0] mismatch");
+        LLBC_ErrorAndReturnIf(!items[4].func.enabled || items[4].func.values.size() != 1 ||
+                              items[4].func.values[0] != "MutedFuncTwo" ||
+                              items[4].appenderTypes.size() != 1 ||
+                              items[4].appenderTypes[0] != LLBC_LogAppenderType::Console,
+                              LLBC_FAILED, "[full] item[4] mismatch");
+        LLBC_ErrorAndReturnIf(items[5].action != LLBC_LogControlAction::SetLevel ||
+                              items[5].newLevel != LLBC_LogLevel::Warn,
+                              LLBC_FAILED, "[full] item[5] mismatch");
+        // Range items: half-open [begin, end), single-segment.
+        LLBC_ErrorAndReturnIf(!items[7].file.enabled || items[7].file.file != "mute_fileE.cpp" ||
+                              items[7].file.lineRanges.size() != 1 ||
+                              items[7].file.lineRanges[0].first != 300 ||
+                              items[7].file.lineRanges[0].second != 305 ||
+                              items[7].action != LLBC_LogControlAction::Mute,
+                              LLBC_FAILED, "[full] item[7] (string range) mismatch");
+        LLBC_ErrorAndReturnIf(!items[8].file.enabled || items[8].file.file != "mute_fileF.cpp" ||
+                              items[8].file.lineRanges.size() != 1 ||
+                              items[8].file.lineRanges[0].first != 400 ||
+                              items[8].file.lineRanges[0].second != 410 ||
+                              items[8].action != LLBC_LogControlAction::Mute,
+                              LLBC_FAILED, "[full] item[8] (object range) mismatch");
+        // Multi-segment items: G (string) "50, 60-65, 70" -> [50,51),[60,65),[70,71);
+        //                      H (object lines) "100-103, 200" -> [100,103),[200,201).
+        LLBC_ErrorAndReturnIf(!items[9].file.enabled || items[9].file.file != "mute_fileG.cpp" ||
+                              items[9].file.lineRanges.size() != 3 ||
+                              items[9].file.lineRanges[0] != std::make_pair(50, 51) ||
+                              items[9].file.lineRanges[1] != std::make_pair(60, 65) ||
+                              items[9].file.lineRanges[2] != std::make_pair(70, 71),
+                              LLBC_FAILED, "[full] item[9] (string multi-seg) mismatch");
+        LLBC_ErrorAndReturnIf(!items[10].file.enabled || items[10].file.file != "mute_fileH.cpp" ||
+                              items[10].file.lineRanges.size() != 2 ||
+                              items[10].file.lineRanges[0] != std::make_pair(100, 103) ||
+                              items[10].file.lineRanges[1] != std::make_pair(200, 201),
+                              LLBC_FAILED, "[full] item[10] (object multi-seg) mismatch");
+        // Multi-value func / threadId: arrays in JSON.
+        LLBC_ErrorAndReturnIf(!items[11].func.enabled ||
+                              items[11].func.values.size() != 2 ||
+                              items[11].func.values[0] != "MutedFuncMA" ||
+                              items[11].func.values[1] != "MutedFuncMB",
+                              LLBC_FAILED, "[full] item[11] (func array) mismatch");
+        LLBC_ErrorAndReturnIf(!items[12].threadId.enabled ||
+                              items[12].threadId.values.size() != 2 ||
+                              items[12].threadId.values[0] != static_cast<LLBC_ThreadId>(1) ||
+                              items[12].threadId.values[1] != static_cast<LLBC_ThreadId>(2147483640),
+                              LLBC_FAILED, "[full] item[12] (threadId array) mismatch");
+    }
+
+    // 1.a) file+line exact: A:100 muted, A:101 pass, A:200 muted.
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileA.cpp", 100, "AnyFunc", "A100 muted", 1),
+        LLBC_FAILED, "[full.line] A:100 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileA.cpp", 101, "AnyFunc", "A101 pass", 0),
+        LLBC_FAILED, "[full.line] A:101 wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileA.cpp", 200, "AnyFunc", "A200 muted", 1),
+        LLBC_FAILED, "[full.line] A:200 not muted");
+
+    // 1.b) file wildcard: B:any-line muted.
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileB.cpp", 1, "AnyFunc", "B:1 muted", 1),
+        LLBC_FAILED, "[full.line] B:1 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileB.cpp", 99999, "AnyFunc", "B:99999 muted", 1),
+        LLBC_FAILED, "[full.line] B:99999 not muted");
+
+    // 1.c) func: MutedFuncOne / MutedFuncTwo muted (the latter via console-only
+    //      scope; since only console appender exists, both should land).
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "any.cpp", 1, "MutedFuncOne", "func one muted", 1),
+        LLBC_FAILED, "[full.func] MutedFuncOne not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "any.cpp", 1, "MutedFuncTwo", "func two muted", 1),
+        LLBC_FAILED, "[full.func] MutedFuncTwo not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "any.cpp", 1, "OtherFunc", "OtherFunc pass", 0),
+        LLBC_FAILED, "[full.func] OtherFunc wrongly muted");
+
+    // 1.d) SetLevel: file=mute_fileC.cpp -> warn rewrite. The record is NOT
+    //      muted by the control filter (so suppressedCount unchanged), but
+    //      its level becomes WARN before reaching the appender. We verify
+    //      the "no mute" side here (positive observation of level rewrite is
+    //      covered later in (3) by chaining with another mute item).
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileC.cpp", 1, "Foo", "C info -> warn", 0),
+        LLBC_FAILED, "[full.setlevel] C info wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Error,
+                                "mute_fileD.cpp", 1, "Foo", "D error -> error", 0),
+        LLBC_FAILED, "[full.setlevel] D error wrongly muted");
+
+    // 1.f) file+line RANGE: half-open [begin, end). E:[300,305), F:[400,410).
+    //      Endpoints: begin included, end excluded (consistent with llbc's
+    //      other range APIs).
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileE.cpp", 299, "AnyFunc", "E:299 pass (below begin)", 0),
+        LLBC_FAILED, "[full.range] E:299 wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileE.cpp", 300, "AnyFunc", "E:300 muted (begin included)", 1),
+        LLBC_FAILED, "[full.range] E:300 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileE.cpp", 302, "AnyFunc", "E:302 muted (mid)", 1),
+        LLBC_FAILED, "[full.range] E:302 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileE.cpp", 304, "AnyFunc", "E:304 muted (end-1, included)", 1),
+        LLBC_FAILED, "[full.range] E:304 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileE.cpp", 305, "AnyFunc", "E:305 pass (end excluded)", 0),
+        LLBC_FAILED, "[full.range] E:305 wrongly muted (end should be excluded)");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileF.cpp", 405, "AnyFunc", "F:405 muted (object range mid)", 1),
+        LLBC_FAILED, "[full.range] F:405 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileF.cpp", 410, "AnyFunc", "F:410 pass (object range end excluded)", 0),
+        LLBC_FAILED, "[full.range] F:410 wrongly muted (end should be excluded)");
+
+    // 1.g) file+line MULTI-SEGMENT.
+    //   G "50, 60-65, 70" -> hits 50 / 60..64 / 70; misses 49,51..59,65,69,71
+    //   H "100-103, 200"  -> hits 100..102 / 200;  misses 99,103,199,201
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 49, "AnyFunc", "G:49 pass", 0),
+        LLBC_FAILED, "[full.multiseg] G:49 wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 50, "AnyFunc", "G:50 muted (single)", 1),
+        LLBC_FAILED, "[full.multiseg] G:50 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 51, "AnyFunc", "G:51 pass (gap)", 0),
+        LLBC_FAILED, "[full.multiseg] G:51 wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 60, "AnyFunc", "G:60 muted (range begin)", 1),
+        LLBC_FAILED, "[full.multiseg] G:60 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 64, "AnyFunc", "G:64 muted (range end-1)", 1),
+        LLBC_FAILED, "[full.multiseg] G:64 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 65, "AnyFunc", "G:65 pass (range end excluded)", 0),
+        LLBC_FAILED, "[full.multiseg] G:65 wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 70, "AnyFunc", "G:70 muted (last single)", 1),
+        LLBC_FAILED, "[full.multiseg] G:70 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileG.cpp", 71, "AnyFunc", "G:71 pass (after last)", 0),
+        LLBC_FAILED, "[full.multiseg] G:71 wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileH.cpp", 102, "AnyFunc", "H:102 muted (object range mid)", 1),
+        LLBC_FAILED, "[full.multiseg] H:102 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileH.cpp", 103, "AnyFunc", "H:103 pass (range end excluded)", 0),
+        LLBC_FAILED, "[full.multiseg] H:103 wrongly muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileH.cpp", 200, "AnyFunc", "H:200 muted (single in lines)", 1),
+        LLBC_FAILED, "[full.multiseg] H:200 not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "mute_fileH.cpp", 201, "AnyFunc", "H:201 pass", 0),
+        LLBC_FAILED, "[full.multiseg] H:201 wrongly muted");
+
+    // 1.h) func MULTI-VALUE (config-driven, JSON array): MutedFuncMA / MutedFuncMB
+    //      both muted, MutedFuncMC pass. Threadid multi-value (item[12]) is not
+    //      exercised here since neither tid in the array equals the current
+    //      thread's id (synthetic values), so it has no effect on these emits.
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "any.cpp", 1, "MutedFuncMA", "func MA muted", 1),
+        LLBC_FAILED, "[full.multifunc] MutedFuncMA not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "any.cpp", 1, "MutedFuncMB", "func MB muted", 1),
+        LLBC_FAILED, "[full.multifunc] MutedFuncMB not muted");
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "any.cpp", 1, "MutedFuncMC", "func MC pass", 0),
+        LLBC_FAILED, "[full.multifunc] MutedFuncMC wrongly muted");
+
+    // 1.e) un-registered file should always pass.
+    LLBC_ErrorAndReturnIf(
+        !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                "no_such_file.cpp", 100, "AnyFunc", "unrelated pass", 0),
+        LLBC_FAILED, "[full.misc] unrelated file wrongly muted");
+
+    LLBC_PrintLn("[full] suppressed count after pass: %llu",
+                 (unsigned long long)fullLogger->GetLogControlSuppressedCount());
+
+    // ------------------------------------------------------------------
+    // 2) LoggerMgr::Reload propagates logControls into the live logger.
+    // We reload the XML config (note: .cfg cannot carry logControls in the
+    // new design, so we must reload from the same XML used at test entry)
+    // and verify that:
+    //   - the logger's logControls list is repopulated to a non-zero size,
+    //   - and the canonical config-driven rule (file=mute_fileA.cpp:100)
+    //     becomes effective again.
+    // ------------------------------------------------------------------
+    {
+        LLBC_ErrorAndReturnIf(
+            LLBC_LoggerMgrSingleton->Reload("LogTestCfg.xml") != LLBC_OK,
+            LLBC_FAILED,
+            "[reload] LoggerMgr::Reload failed: %s",
+            LLBC_FormatLastError());
+
+        // Re-acquire the logger pointer after reload just to be safe (the
+        // logger identity is preserved by design, but we don't want the test
+        // to depend on that beyond the interface).
+        fullLogger = LLBC_LoggerMgrSingleton->GetLogger("logcontrol_full");
+        LLBC_ErrorAndReturnIf(fullLogger == nullptr,
+                              LLBC_FAILED,
+                              "[reload] get logcontrol_full failed after reload");
+
+        LLBC_ErrorAndReturnIf(
+            fullLogger->GetLogControlCount() == 0,
+            LLBC_FAILED,
+            "[reload] logControls not repopulated after reload");
+
+        fullLogger->ResetLogControlSuppressedCount();
+
+        // Config-driven canonical rule re-armed.
+        LLBC_ErrorAndReturnIf(
+            !EmitAndCheckSuppressed(fullLogger, LLBC_LogLevel::Info,
+                                    "mute_fileA.cpp", 100, "AnyFunc",
+                                    "post-reload A:100 muted", 1),
+            LLBC_FAILED,
+            "[reload] canonical rule not effective after reload");
+    }
+
+    LLBC_PrintLn("DoLogControlTest done. final suppressed count of full logger: %llu",
+                 (unsigned long long)fullLogger->GetLogControlSuppressedCount());
+
+    return LLBC_OK;
 }

--- a/tests/func_test/core/log/FuncTest_Core_Log.cpp
+++ b/tests/func_test/core/log/FuncTest_Core_Log.cpp
@@ -906,7 +906,7 @@ void FuncTest_Core_Log::OnLogHook(const LLBC_LogData *logData)
 //   2) LoggerMgr::Reload re-installs the config-driven control list.
 // ----------------------------------------------------------------------------
 
-bool TestCase_Core_Log::EmitAndCheckSuppressed(LLBC_Logger *logger,
+bool FuncTest_Core_Log::EmitAndCheckSuppressed(LLBC_Logger *logger,
                                                int level,
                                                const char *file,
                                                int line,
@@ -923,7 +923,7 @@ bool TestCase_Core_Log::EmitAndCheckSuppressed(LLBC_Logger *logger,
     return logger->GetLogControlSuppressedCount() == before + expectedHits;
 }
 
-int TestCase_Core_Log::DoLogControlTest()
+int FuncTest_Core_Log::DoLogControlTest()
 {
     LLBC_PrintLn("DoLogControlTest (log control items) begin");
 

--- a/tests/func_test/core/log/LogTestCfg.cfg
+++ b/tests/func_test/core/log/LogTestCfg.cfg
@@ -124,6 +124,11 @@ root.maxBackupIndex=20
 root.lazyCreateLogFile=false
 # 日志染色列表, 格式: key1:val1,val2|key2:val1,val2....
 root.requireColorLogTraces=
+# 日志输出控制项 (logControls): 仅 XML 配置支持, .cfg 不支持.
+# 原因: logControls 是嵌套结构 (item -> match -> file/func/threadId/level/...),
+# .cfg 是扁平的 key=value 格式, 无法表达这种嵌套. 在 .cfg 中写
+# `root.logControls=...` 会触发 stderr 警告并被忽略.
+# 完整 schema 与样例见 doc/log_control.md 及 testsuite/core/log/LogTestCfg.xml.
 # 是否建议操作系统回收file page cache.
 root.enableFadviseDiscard=false
 # 建议操作系统回收file page cache单次大小, 如果不配置, 使用默认值: LLBC_CFG_LOG_DEFAULT_FADVISE_DISCARD_SIZE.
@@ -230,6 +235,21 @@ color_test.consoleLogLevel=WARN
 logtrace_enable_level.filePattern=%T [%-5L][%f:%l]<exec:%-20e><tag:%g><logger:%N><realTime:%R><%x{enablelevel:debug}> - %m%n
 logtrace_enable_level.logToFile=true
 logtrace_enable_level.fileLogLevel=TRACE
+
+############################################################################
+# log output control 测试相关 logger 配置
+# 注意: logControls 仅 XML 配置支持, .cfg 不支持 (因其无法表达嵌套结构).
+# 这里仅声明 logger 自身的输出属性, 真正的 logControls 数据通过
+# LoggerMgr->Reload("LogTestCfg.xml") 在测试用例初始化阶段从 XML 装载;
+# 故 logger 名称 (logcontrol_full) 必须与 XML 中一致.
+# 另外, LoggerMgr::Reload 是全量重配 -- .cfg 里声明过的每个 logger 都必须能在
+# XML 中找到同名块, 否则 ReConfig 会返回 LLBC_ERROR_NOT_FOUND.
+############################################################################
+logcontrol_full.asynchronous=false
+logcontrol_full.logToConsole=true
+logcontrol_full.logToFile=false
+logcontrol_full.consoleLogLevel=TRACE
+logcontrol_full.fileLogLevel=TRACE
 
 ############################################################################
 # fadvise logger属性配置

--- a/tests/func_test/core/log/LogTestCfg.xml
+++ b/tests/func_test/core/log/LogTestCfg.xml
@@ -29,6 +29,14 @@
         <!-- 在以json格式输出Log时, 是否添加时间字戳到json log中, key:timestamp, 默认不添加 -->
         <addTimestampInJsonLog>true</addTimestampInJsonLog>
 
+        <!-- 日志输出控制项 (log control items), 仅 XML 配置支持 (.cfg 不支持因其无法承载嵌套结构).
+             schema 详见 doc/log_control.md 第 3 节, 以及下方的 logcontrol_full / logcontrol_robust 块.
+             match 内部各启用维度之间为 AND (all-of, 必须同时命中); 每条规则自身的取值集合
+             (file.lineRanges / func.values / threadId.values / level.values) 之内为 OR (one-of).
+             多控制项按声明顺序应用; setLevel 改写对后续控制项的 level 匹配可见;
+             解析失败的元素静默跳过, 不影响其它合法元素. -->
+        <logControls></logControls>
+
         <!-- 控制台输出器配置选项 -->
         <!-- 确定日志是否输出到控制台,可以的取值:true/false. -->
         <logToConsole>true</logToConsole>
@@ -232,6 +240,127 @@
         <fadviseDiscardSize>40MiB</fadviseDiscardSize>
         <fadviseDiscardRetainPercent>50</fadviseDiscardRetainPercent>
     </fadvise>
+
+    <color_test>
+        <requireColorLogTraces>uin:1086,1087|coroid:100001</requireColorLogTraces>
+        <fileLogLevel>WARN</fileLogLevel>
+        <consoleLogLevel>WARN</consoleLogLevel>
+    </color_test>
+
+    <logtrace_enable_level>
+        <filePattern>%T [%-5L][%f:%l]&lt;exec:%-20e&gt;&lt;tag:%g&gt;&lt;logger:%N&gt;&lt;realTime:%R&gt;&lt;%x{enablelevel:debug}&gt; - %m%n</filePattern>
+        <logToFile>true</logToFile>
+        <fileLogLevel>TRACE</fileLogLevel>
+    </logtrace_enable_level>
+
+    <!-- log output control 测试相关 logger 配置. 配置项 logControls 为嵌套 XML 子树,
+         schema 见 root.logControls 注释; .cfg 配置不支持 logControls (无法承载嵌套结构). -->
+
+    <!-- 全规则齐全 (含: 文件名+行号 / 文件名+行号范围 / 函数名 / 文件 setLevel / 单 appender 限定 / 多取值 OR) -->
+    <!-- 那些"应 pass"的样本会被 console 真打出来, 这是预期行为(同时充当反向断言). -->
+    <logcontrol_full>
+        <asynchronous>false</asynchronous>
+        <logToConsole>true</logToConsole>
+        <logToFile>false</logToFile>
+        <consoleLogLevel>TRACE</consoleLogLevel>
+        <fileLogLevel>TRACE</fileLogLevel>
+        <logControls>
+            <!-- file=mute_fileA.cpp 行 100 静音 (attr lines) -->
+            <item>
+                <match>
+                    <file name="mute_fileA.cpp" lines="100"/>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- file=mute_fileA.cpp 行 200 静音 (attr lines) -->
+            <item>
+                <match>
+                    <file name="mute_fileA.cpp" lines="200"/>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- file=mute_fileB.cpp 全文件静音 (省略 lines 即通配) -->
+            <item>
+                <match>
+                    <file name="mute_fileB.cpp"/>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- 函数 MutedFuncOne 静音 -->
+            <item>
+                <match>
+                    <func>MutedFuncOne</func>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- 函数 MutedFuncTwo 静音, 仅作用于 console appender -->
+            <item>
+                <match>
+                    <func>MutedFuncTwo</func>
+                </match>
+                <appenders><appender>console</appender></appenders>
+                <action type="mute"/>
+            </item>
+            <!-- file=mute_fileC.cpp 提级到 warn -->
+            <item>
+                <match>
+                    <file name="mute_fileC.cpp"/>
+                </match>
+                <action type="setLevel"><newLevel>warn</newLevel></action>
+            </item>
+            <!-- file=mute_fileD.cpp 提级到 error -->
+            <item>
+                <match>
+                    <file name="mute_fileD.cpp"/>
+                </match>
+                <action type="setLevel"><newLevel>error</newLevel></action>
+            </item>
+            <!-- file=mute_fileE.cpp 行号半开区间 [300,305) 静音 (attr lines) -->
+            <item>
+                <match>
+                    <file name="mute_fileE.cpp" lines="300-305"/>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- file=mute_fileF.cpp 行号半开区间 [400,410) 静音 (attr lines) -->
+            <item>
+                <match>
+                    <file name="mute_fileF.cpp" lines="400-410"/>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- file=mute_fileG.cpp 多段行号 "50, 60-65, 70" 静音 (attr lines) -->
+            <item>
+                <match>
+                    <file name="mute_fileG.cpp" lines="50, 60-65, 70"/>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- file=mute_fileH.cpp 多段行号 "100-103, 200" 静音 (attr lines) -->
+            <item>
+                <match>
+                    <file name="mute_fileH.cpp" lines="100-103, 200"/>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- func 多值 ["MutedFuncMA","MutedFuncMB"] (任一命中即静音) -->
+            <item>
+                <match>
+                    <func>MutedFuncMA</func>
+                    <func>MutedFuncMB</func>
+                </match>
+                <action type="mute"/>
+            </item>
+            <!-- threadId 多值 [1, 2147483640] (任一命中即静音) -->
+            <item>
+                <match>
+                    <threadId>1</threadId>
+                    <threadId>2147483640</threadId>
+                </match>
+                <action type="mute"/>
+            </item>
+        </logControls>
+    </logcontrol_full>
 
     <!-- 其它 logger(s) 配置 -->
 </Log>

--- a/tests/func_test/core/log/LogTestCfg.xml
+++ b/tests/func_test/core/log/LogTestCfg.xml
@@ -266,99 +266,99 @@
         <fileLogLevel>TRACE</fileLogLevel>
         <logControls>
             <!-- file=mute_fileA.cpp 行 100 静音 (attr lines) -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileA.cpp" lines="100"/>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- file=mute_fileA.cpp 行 200 静音 (attr lines) -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileA.cpp" lines="200"/>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- file=mute_fileB.cpp 全文件静音 (省略 lines 即通配) -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileB.cpp"/>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- 函数 MutedFuncOne 静音 -->
-            <item>
+            <logControl>
                 <match>
                     <func>MutedFuncOne</func>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- 函数 MutedFuncTwo 静音, 仅作用于 console appender -->
-            <item>
+            <logControl>
                 <match>
                     <func>MutedFuncTwo</func>
                 </match>
                 <appenders><appender>console</appender></appenders>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- file=mute_fileC.cpp 提级到 warn -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileC.cpp"/>
                 </match>
                 <action type="setLevel"><newLevel>warn</newLevel></action>
-            </item>
+            </logControl>
             <!-- file=mute_fileD.cpp 提级到 error -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileD.cpp"/>
                 </match>
                 <action type="setLevel"><newLevel>error</newLevel></action>
-            </item>
+            </logControl>
             <!-- file=mute_fileE.cpp 行号半开区间 [300,305) 静音 (attr lines) -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileE.cpp" lines="300-305"/>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- file=mute_fileF.cpp 行号半开区间 [400,410) 静音 (attr lines) -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileF.cpp" lines="400-410"/>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- file=mute_fileG.cpp 多段行号 "50, 60-65, 70" 静音 (attr lines) -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileG.cpp" lines="50, 60-65, 70"/>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- file=mute_fileH.cpp 多段行号 "100-103, 200" 静音 (attr lines) -->
-            <item>
+            <logControl>
                 <match>
                     <file name="mute_fileH.cpp" lines="100-103, 200"/>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- func 多值 ["MutedFuncMA","MutedFuncMB"] (任一命中即静音) -->
-            <item>
+            <logControl>
                 <match>
                     <func>MutedFuncMA</func>
                     <func>MutedFuncMB</func>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
             <!-- threadId 多值 [1, 2147483640] (任一命中即静音) -->
-            <item>
+            <logControl>
                 <match>
                     <threadId>1</threadId>
                     <threadId>2147483640</threadId>
                 </match>
                 <action type="mute"/>
-            </item>
+            </logControl>
         </logControls>
     </logcontrol_full>
 


### PR DESCRIPTION
# Log Output Control Items（日志输出控制项）

每个 logger 持有一个有序的 `std::vector<LLBC_LogControlItem>`；`Logger::OutputLogData()` 里对每个 appender 独立、按声明顺序应用。控制项**只从配置装载**（`Initialize` / `Reload`）。

实现分三层，源码见 `llbc/core/log/`：

| 层 | 类型 | 职责 |
| --- | --- | --- |
| 配置项 | `LLBC_LogControlItem`（`LogControl.h`） | 纯数据结构，描述一条控制项：一组 match 规则 + appender scope + 一个 action |
| 执行器 | `LLBC_LogControlExecutor`（`LogControlExecutor.h`） | 一条配置项编译后的"匹配 + 动作"最小单元；`SetLogControls` 时**一次性**编译为不可变形态，热路径不再做校验 |
| 管理器 | `LLBC_LogControlMgr`（`LogControlMgr.h`） | 持有 `shared_ptr<const ExecutorList>` 快照，对外提供 `Apply`；`Initialize` / `Reload` 时原子发布新快照，`Apply` 拷指针后**出锁遍历** |

---

## 1. 控制项结构

结构定义位于 `llbc/core/log/LogControl.h`：

```cpp
template <typename T>
struct LLBC_LogMatchSet
{
    bool enabled;
    std::vector<T> values;
};

struct LLBC_LogFileMatch
{
    bool enabled;
    LLBC_String file;                             // file basename
    std::vector<std::pair<int, int>> lineRanges;  // half-open [begin, end)
};

struct LLBC_LogControlItem
{
    // a) match rules; AND-combined when enabled, each rule's values OR-combined.
    LLBC_LogFileMatch               file;
    LLBC_LogMatchSet<LLBC_String>   func;         // exact function names, no wildcard
    LLBC_LogMatchSet<LLBC_ThreadId> threadId;
    LLBC_LogMatchSet<int>           level;        // matched against effective level

    // b) appender scope; empty == all appenders.
    std::vector<int> appenderTypes;               // LLBC_LogAppenderType::{Console, File, Network}

    // c) action; default Unset -> must be assigned explicitly.
    int action;                                   // LLBC_LogControlAction::Mute / SetLevel
    int newLevel;                                 // valid when action == SetLevel

    bool HasAnyMatch() const;                     // 至少一个维度启用，否则非法
};
```

三点关键语义（源码 doc-comment 已述，此处强调）：

- **AND/OR**：已启用的 match 维度之间是 AND；单维度内 `values` / `lineRanges` 是 OR。跨维度 OR 请写多条 `<logControl>`。
- **`file.lineRanges`** 是半开区间 `[begin, end)` 的并集：单行 `N` 存为 `[N, N+1)`，空 = 通配整文件。每段须满足 `0 <= begin < end`。
- **`level` 匹配的是"当前 effective level"**（可与前面 executor 的 `SetLevel` 链式组合），不是 `data.level`。
- **`action` 必须显式赋值**：默认哨兵 `Unset` 会被 `SetLogControls` 拒绝，避免漏写 action 静默变成破坏性 Mute。`Mute` 命中即链遍历终止；`SetLevel` 只改写 level，遍历继续。

---

## 2. 应用顺序

```cpp
LLBC_LogControlApplyResult Apply(int appenderType,
                                 const LLBC_LogData &data,
                                 int originalLevel) const;
// LLBC_LogControlApplyResult { bool muted; int effectiveLevel; }
```

对 `(record, appender)` 这一对：

1. 拷贝 `shared_ptr<const ExecutorList>` 快照后**出锁遍历**；executor 按声明顺序推进。
2. 每个 executor：先过 appender scope（空 == all），再对所有已启用维度 `Match(data, currentLevel)`；任一失败即跳过。level 规则读的是 `currentLevel`，不是 `data.level`。
3. 命中后：`Mute` → `muted = true`，**立即返回**；`SetLevel` → 更新 `currentLevel`，**继续**遍历。

---

## 3. XML 配置：`logControls`

`logControls` 是每个 logger 配置下的**嵌套子树**，每个 `<logControl>` 描述一个控制项。**仅 `.xml` 支持**——`.cfg` 是扁平 `key=value`，无法承载嵌套；若在 `.cfg` 里写 `myLogger.logControls=...` 会 stderr 告警并整段忽略。

```xml
<logControls>
  <logControl>
    <match>
      <!-- file: 每个 <logControl> 至多一个 <file>；多文件请写多条 <logControl>。
           `name` 必填，`lines` 可选：
             缺省 / 空       -> 整文件通配
             "N"             -> 单行, 内部存为 [N, N+1)
             "N-M"           -> 半开区间 [N, M), 需 M > N
             "s1, s2, ..."   -> 多段 OR, 以逗号 ',' 分隔, 段两侧允许空白 -->
      <file name="Foo.cpp" lines="42, 60-65, 100-110"/>

      <!-- 多值 OR：重复子元素 -->
      <func>DoBar</func>
      <func>DoBaz</func>
      <threadId>12345</threadId>
      <level>warn</level>
      <level>error</level>
    </match>

    <appenders>                    <!-- 可选；缺省 / 为空 == 全部 appender -->
      <appender>console</appender>
      <appender>file</appender>
    </appenders>

    <action>                       <!-- mute 无操作数 -->
      <type>mute</type>
    </action>
  </logControl>

  <logControl>
    <match><file name="perf.cpp"/></match>
    <action>                       <!-- setLevel 携带 <newLevel> -->
      <type>setLevel</type>
      <newLevel>warn</newLevel>
    </action>
  </logControl>
</logControls>
```

### 字段解析规则（对照 `ParseLogControls`）

| 字段 | 允许形态 | 值语义 |
| --- | --- | --- |
| `<file name="..." lines="..."/>` | attr 形式；`name` 必填非空；`lines` 可选字符串 | `name` 是 basename；`lines` 段间以 `,` 分隔，段两侧空白 strip 后忽略；单段 `N` 存为 `[N, N+1)`，`N-M` 存为 `[N, M)`（要求 `0 <= N < M < INT_MAX`） |
| `<func>` | 单个或重复子元素 | 每项 strip 后非空即收；OR |
| `<threadId>` | 单个或重复子元素 | 十进制整数，允许前导 `+` / `-`；范围 `LLBC_ThreadId`；OR |
| `<level>` | 单个或重复子元素 | 名称（`Debug` / `Info` / … 大小写不敏感）**或**十进制整数；必须落在 `LLBC_LogLevel::Begin..End` 内；OR |
| `<appenders><appender>` | 容器 + 重复子元素 | 名称：`console` / `file` / `network`，大小写不敏感；未知名**静默丢弃**（不拒 item）；容器缺失 / 全部无效 == 全部 appender |
| `<action><type>` | 必填 | 大小写不敏感；仅 `mute` / `setlevel` |
| `<action><newLevel>` | 仅 `setLevel` 时读取 | 同 `<level>` 值语义 |

### 错误处理速查

`ParseLogControls` 的三条原则：**未知即静默丢弃、可降级维度自动禁用、结构性错误拒整条 logControl**。

| 触发条件 | 处理 |
| --- | --- |
| `<logControls>` 缺失 / 非 Dict / 出现在 `.cfg` 中 | 静默忽略整段（`.cfg` 会额外发一条 stderr 告警） |
| `<logControl>` 下的未知 tag、多余的 `<match>` / `<file>` / `<appenders>` / `<action>` | 静默忽略；同名标量子元素只取第一次出现的值 |
| `<func>` / `<threadId>` / `<level>` 个别项非法或为空 | 只丢该项；若该维度最终无有效值，则该维度自动不启用；item 保留 |
| `<appender>` 未知名 | 静默丢弃；若全部无效，等价于 appenders 缺失（== 全部 appender） |
| `<file>` 存在但 `name` 空 **或** `lines` 任一段非法 | **拒整条 logControl** |
| `<action>` 缺失 / 非 Dict、`<type>` 未知、`setLevel` 缺 `<newLevel>` 或 `<newLevel>` 非法 | **拒整条 logControl** |
| 所有 match 维度均未启用（`HasAnyMatch()` 失败） | **拒整条 logControl** |

被拒的 logControl 不影响同一 `<logControls>` 里其它 logControl 的解析。

解析阶段**不做去重、不做跨 item 校验**：`link.cpp` 先 `SetLevel` 再按 `level==warn` `Mute` 这种链式构造由声明顺序保证。

---

## 4. 典型用法

### 4.1 静音某函数（只在 console）

用 `<func>` 精确命中 + `<appenders>` 收窄作用域：file appender 仍然照常记录。

```xml
<logControls>
  <logControl>
    <match><func>NoisyFunc</func></match>
    <appenders><appender>console</appender></appenders>
    <action><type>mute</type></action>
  </logControl>
</logControls>
```

### 4.2 链式：先提级再按级别静音

跨 logControl 交互：**声明顺序即应用顺序**，两条必须在同一份配置里。

```xml
<logControls>
  <logControl>
    <match><file name="link.cpp"/></match>
    <action><type>setLevel</type><newLevel>warn</newLevel></action>
  </logControl>
  <logControl>
    <match><level>warn</level></match>
    <action><type>mute</type></action>
  </logControl>
</logControls>
<!-- link.cpp 上的 info 记录: 先被第 1 条改写为 warn, 再被第 2 条 level==warn 的 mute 命中 -->
```

---

## 5. Reload

`LLBC_LoggerMgrSingleton->Reload(cfgPath)` 会重新解析配置并对每个 logger 调一次 `SetLogControls` **整体重建**列表（不增量、不合并）。

- 某个 logger 的新配置非法 → 该 logger 保留旧 logControls，`Reload()` 返回 `LLBC_FAILED`。

```cpp
if (LLBC_LoggerMgrSingleton->Reload() != LLBC_OK)
    fprintf(stderr, "reload failed: %s\n", LLBC_FormatLastError());
```
