### PR TITLE
feat: CMake 构建对齐 premake（核心库 + 测试，不含 wrapper）#555

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake minimum version.
-cmake_minimum_required (VERSION 3.2...3.5)
+cmake_minimum_required (VERSION 3.16)
 
 # Setup c/cxx compilers and linker, if needed.
 # set(CUSTOM_COMPILE_TOOLSET_DIR "<custom compile toolset dir>")
@@ -21,8 +21,37 @@ message("==> stdc lib dir: ${STDC_LIB_DIR}")
 # Set project name.
 project(llbc)
 
-# Set project c++ standard.
+# ****************************************************************************
+# Build options (mirror premake5_cfg.lua toggles).
+option(LLBC_DISABLE_CXX11_ABI "Disable libstdc++ CXX11 ABI (define _GLIBCXX_USE_CXX11_ABI=0)" OFF)
+option(LLBC_ENABLE_ASAN       "Enable AddressSanitizer (non-Windows only)"                    OFF)
+option(LLBC_WARNINGS_AS_ERRORS "Treat warnings as errors (-Werror, non-MSVC)"                 ON)
+option(LLBC_SYNC_VERSION      "Run llbc_prebuild.py to sync version into Version.cpp"         OFF)
+
+# Default to Release when no build type / multi-config is specified.
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+	set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
+# Set project c++ standard (strict C++17, no GNU extensions -> -std=c++17).
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Default hidden symbol visibility (mirror premake -fvisibility=hidden; works with LLBC_EXPORT/LLBC_HIDDEN).
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
+# Debug/asan target file suffix (mirror premake targetsuffix: _debug / _asan / _asan_debug).
+if (LLBC_ENABLE_ASAN)
+	set(CMAKE_DEBUG_POSTFIX _asan_debug)
+	set(CMAKE_RELEASE_POSTFIX _asan)
+	set(CMAKE_RELWITHDEBINFO_POSTFIX _asan)
+	set(CMAKE_MINSIZEREL_POSTFIX _asan)
+else()
+	set(CMAKE_DEBUG_POSTFIX _debug)
+endif()
 
 # Set project cmake options.
 set(CMAKE_COLOR_MAKEFILE on)
@@ -34,9 +63,52 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX")
 endif()
 
+# ****************************************************************************
+# Common build flags carrier (mirror premake workspace-level c++ settings).
+# Only llbc's own targets link this; 3rdparty(googletest) must NOT inherit -Werror etc.
+add_library(llbc_build_flags INTERFACE)
+
+if (NOT MSVC)
+	target_compile_options(llbc_build_flags INTERFACE -Wall -Wno-strict-aliasing)
+	if (LLBC_WARNINGS_AS_ERRORS)
+		target_compile_options(llbc_build_flags INTERFACE -Werror)
+	endif()
+endif()
+
+# DEBUG macro on debug builds (mirror premake "configurations:debug*" defines { "DEBUG" }).
+target_compile_definitions(llbc_build_flags INTERFACE $<$<CONFIG:Debug>:DEBUG>)
+
+# CXX11 ABI selection (non-Windows).
+if (NOT WIN32)
+	if (LLBC_DISABLE_CXX11_ABI)
+		target_compile_definitions(llbc_build_flags INTERFACE _GLIBCXX_USE_CXX11_ABI=0)
+	else()
+		target_compile_definitions(llbc_build_flags INTERFACE _GLIBCXX_USE_CXX11_ABI=1)
+	endif()
+endif()
+
+# Export dynamic symbol table for backtraces (mirror premake linkoptions { "-rdynamic" }).
+if (NOT WIN32)
+	target_link_options(llbc_build_flags INTERFACE -rdynamic)
+endif()
+
+# macOS: Foundation framework(.mm sources) + rpath so shared-linked exes find the dylib in the flat output dir.
+if (APPLE)
+	target_link_options(llbc_build_flags INTERFACE "SHELL:-framework Foundation")
+	target_link_options(llbc_build_flags INTERFACE "SHELL:-Wl,-rpath,@loader_path")
+endif()
+
+# AddressSanitizer (non-Windows).
+if (LLBC_ENABLE_ASAN AND NOT WIN32)
+	target_compile_options(llbc_build_flags INTERFACE -fsanitize=address -g)
+	target_link_options(llbc_build_flags INTERFACE -fsanitize=address)
+endif()
+
+# ****************************************************************************
 # Set llbc core lib directory.
 set(LLBC_LIB_DIR ${PROJECT_SOURCE_DIR}/llbc)
 # Set llbc core lib tests directory.
+set(LLBC_LIB_TESTS_DIR ${PROJECT_SOURCE_DIR}/tests)
 set(LLBC_LIB_EXAMPLE_DIR ${PROJECT_SOURCE_DIR}/tests/example)
 set(LLBC_LIB_FUNC_TEST_DIR ${PROJECT_SOURCE_DIR}/tests/func_test)
 set(LLBC_LIB_UNIT_TEST_DIR ${PROJECT_SOURCE_DIR}/tests/unit_test)
@@ -47,9 +119,27 @@ set(LLBC_WRAP_DIR ${PROJECT_SOURCE_DIR}/wrap)
 # Set llbc output directory.
 set(LLBC_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/output/cmake)
 
+# ****************************************************************************
+# googletest (dependency of unit_test). Built from the git submodule via add_subdirectory,
+# so it respects the same compiler/standard/ABI instead of the old fragile `cmake .. && make` custom target.
+set(LLBC_GTEST_DIR ${LLBC_LIB_TESTS_DIR}/3rdparty/googletest)
+if (EXISTS ${LLBC_GTEST_DIR}/CMakeLists.txt)
+	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+	set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+	set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+	add_subdirectory(${LLBC_GTEST_DIR} ${CMAKE_BINARY_DIR}/googletest EXCLUDE_FROM_ALL)
+	set(LLBC_HAS_GTEST ON)
+else()
+	message(WARNING "googletest submodule not found at ${LLBC_GTEST_DIR}; unit_test will be skipped. "
+	                "Run: git submodule update --init tests/3rdparty/googletest")
+	set(LLBC_HAS_GTEST OFF)
+endif()
+
 # Add sub directory.
 add_subdirectory(${LLBC_LIB_DIR})
 add_subdirectory(${LLBC_LIB_EXAMPLE_DIR})
 add_subdirectory(${LLBC_LIB_FUNC_TEST_DIR})
-add_subdirectory(${LLBC_LIB_UNIT_TEST_DIR})
+if (LLBC_HAS_GTEST)
+	add_subdirectory(${LLBC_LIB_UNIT_TEST_DIR})
+endif()
 add_subdirectory(${LLBC_LIB_QUICK_START_DIR})

--- a/llbc/CMakeLists.txt
+++ b/llbc/CMakeLists.txt
@@ -16,9 +16,24 @@ include_directories(${LLBC_LIB_INCLUDE})
 if(WIN32)
     set(LLBC_LIB_LINK_LIB ws2_32 Mswsock DbgHelp)
 elseif(UNIX AND NOT APPLE)
-    set(LLBC_LIB_LINK_LIB -ldl -lpthread -luuid -lunwind -unwind-x86_64)
+    set(LLBC_LIB_LINK_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64)
 elseif(APPLE)
     set(LLBC_LIB_LINK_LIB -liconv)
+endif()
+
+# Optional: sync version number into src/common/Version.cpp before build (mirror premake llbc_prebuild.py).
+# Opt-in only (mutates source tree); enable with -DLLBC_SYNC_VERSION=ON.
+if(LLBC_SYNC_VERSION)
+    find_package(Python3 COMPONENTS Interpreter)
+    if(Python3_Interpreter_FOUND)
+        add_custom_target(llbc_version_sync ALL
+            COMMAND ${Python3_EXECUTABLE}
+                    ${PROJECT_SOURCE_DIR}/tools/building_script/llbc_prebuild.py
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools/building_script
+            COMMENT "Syncing llbc version into Version.cpp")
+    else()
+        message(WARNING "LLBC_SYNC_VERSION=ON but Python3 interpreter not found; skipping version sync")
+    endif()
 endif()
 
 # Set llbc library output directory.
@@ -29,11 +44,27 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LLBC_OUTPUT_DIR})
 # Build core library static library.
 set(LLBC_LIB_STATIC ${PROJECT_NAME})
 add_library(${LLBC_LIB_STATIC} STATIC ${SOURCES})
-target_link_libraries(${LLBC_LIB_STATIC})
+target_link_libraries(${LLBC_LIB_STATIC} PRIVATE llbc_build_flags)
 target_compile_definitions(${LLBC_LIB_STATIC} PRIVATE -DLLBC_LIB_STATIC)
 
 # Build core library shared library.
 set(LLBC_LIB_SHARED ${PROJECT_NAME}_shared)
 add_library(${LLBC_LIB_SHARED} SHARED ${SOURCES})
-target_link_libraries(${LLBC_LIB_SHARED} ${LLBC_LIB_LINK_LIB})
+target_link_libraries(${LLBC_LIB_SHARED} PRIVATE llbc_build_flags ${LLBC_LIB_LINK_LIB})
 target_compile_definitions(${LLBC_LIB_SHARED} PRIVATE -DLLBC_LIB_SHARED)
+
+# Align output artifact name with premake: libllbc.a + libllbc.{so,dylib} (instead of libllbc_lib*).
+# Note: naming alignment targets Linux/macOS; on Windows the static/shared import libs would collide
+# on the same base name, but Windows uses the Visual Studio/premake path, not this CMake path.
+if(NOT WIN32)
+    set_target_properties(${LLBC_LIB_STATIC} ${LLBC_LIB_SHARED} PROPERTIES OUTPUT_NAME llbc)
+endif()
+
+# Install rules (mirror `make install` -> /usr/lib + /usr/include).
+include(GNUInstallDirs)
+install(TARGETS ${LLBC_LIB_STATIC} ${LLBC_LIB_SHARED}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY ${LLBC_LIB_INCLUDE}/llbc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${LLBC_LIB_INCLUDE}/llbc.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/tests/example/CMakeLists.txt
+++ b/tests/example/CMakeLists.txt
@@ -16,8 +16,8 @@ if(WIN32)
     set(LLBC_LIB_EXAMPLE_STATIC_LIB ws2_32 Mswsock DbgHelp llbc_lib)
     set(LLBC_LIB_EXAMPLE_SHARED_LIB ws2_32 Mswsock DbgHelp llbc_lib_shared)
 elseif(UNIX AND NOT APPLE)
-    set(LLBC_LIB_EXAMPLE_STATIC_LIB -ldl -lpthread -luuid -lunwind -unwind-x86_64 llbc_lib -lunwind -lunwind-x86_64)
-    set(LLBC_LIB_EXAMPLE_SHARED_LIB -ldl -lpthread -luuid -lunwind -unwind-x86_64 llbc_lib_shared -lunwind -lunwind-x86_64)
+    set(LLBC_LIB_EXAMPLE_STATIC_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 llbc_lib)
+    set(LLBC_LIB_EXAMPLE_SHARED_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 llbc_lib_shared)
 elseif(APPLE)
     set(LLBC_LIB_EXAMPLE_STATIC_LIB -liconv llbc_lib)
     set(LLBC_LIB_EXAMPLE_SHARED_LIB llbc_lib_shared)
@@ -27,14 +27,17 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LLBC_OUTPUT_DIR})
 file(MAKE_DIRECTORY ${LLBC_OUTPUT_DIR})
 
-# Build example.
+# Build example (static-linked -> example; shared-linked -> example_shared; debug adds _debug suffix).
 set(LLBC_LIB_EXAMPLE_LINK_STATIC_EXE ${PROJECT_NAME})
 add_executable(${LLBC_LIB_EXAMPLE_LINK_STATIC_EXE} ${LLBC_LIB_EXAMPLE_SRC_FILES})
-target_link_libraries(${LLBC_LIB_EXAMPLE_LINK_STATIC_EXE} ${LLBC_LIB_EXAMPLE_STATIC_LIB})
+target_link_libraries(${LLBC_LIB_EXAMPLE_LINK_STATIC_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_EXAMPLE_STATIC_LIB})
 target_compile_definitions(${LLBC_LIB_EXAMPLE_LINK_STATIC_EXE} PRIVATE -DLLBC_LINK_STATIC_LIBRARY)
+set_target_properties(${LLBC_LIB_EXAMPLE_LINK_STATIC_EXE} PROPERTIES OUTPUT_NAME example
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")
 
 set(LLBC_LIB_EXAMPLE_LINK_SHARED_EXE ${PROJECT_NAME}_shared)
 add_executable(${LLBC_LIB_EXAMPLE_LINK_SHARED_EXE} ${LLBC_LIB_EXAMPLE_SRC_FILES})
-target_link_libraries(${LLBC_LIB_EXAMPLE_LINK_SHARED_EXE} ${LLBC_LIB_EXAMPLE_SHARED_LIB})
+target_link_libraries(${LLBC_LIB_EXAMPLE_LINK_SHARED_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_EXAMPLE_SHARED_LIB})
 target_compile_definitions(${LLBC_LIB_EXAMPLE_LINK_SHARED_EXE} PRIVATE -DLLBC_LINK_SHARED_LIBRARY)
-
+set_target_properties(${LLBC_LIB_EXAMPLE_LINK_SHARED_EXE} PROPERTIES OUTPUT_NAME example_shared
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")

--- a/tests/func_test/CMakeLists.txt
+++ b/tests/func_test/CMakeLists.txt
@@ -16,8 +16,8 @@ if(WIN32)
     set(LLBC_LIB_FUNC_TEST_STATIC_LIB ws2_32 Mswsock DbgHelp llbc_lib)
     set(LLBC_LIB_FUNC_TEST_SHARED_LIB ws2_32 Mswsock DbgHelp llbc_lib_shared)
 elseif(UNIX AND NOT APPLE)
-    set(LLBC_LIB_FUNC_TEST_STATIC_LIB -ldl -lpthread -luuid -lunwind -unwind-x86_64 llbc_lib -lunwind -lunwind-x86_64)
-    set(LLBC_LIB_FUNC_TEST_SHARED_LIB -ldl -lpthread -luuid -lunwind -unwind-x86_64 llbc_lib_shared -lunwind -lunwind-x86_64)
+    set(LLBC_LIB_FUNC_TEST_STATIC_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 llbc_lib)
+    set(LLBC_LIB_FUNC_TEST_SHARED_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 llbc_lib_shared)
 elseif(APPLE)
     set(LLBC_LIB_FUNC_TEST_STATIC_LIB -liconv llbc_lib)
     set(LLBC_LIB_FUNC_TEST_SHARED_LIB llbc_lib_shared)
@@ -27,23 +27,30 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LLBC_OUTPUT_DIR})
 file(MAKE_DIRECTORY ${LLBC_OUTPUT_DIR})
 
-# Copy all func test config file to output directory.
+# Copy all func test config file to output directory (mirror premake func_test postbuild copy).
 file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/core/config/test_ini.ini DESTINATION ${LLBC_OUTPUT_DIR})
 file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/core/config/test_prop.properties DESTINATION ${LLBC_OUTPUT_DIR})
 file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/core/log/LogTestCfg.cfg DESTINATION ${LLBC_OUTPUT_DIR})
+file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/core/log/LogTestCfg.xml DESTINATION ${LLBC_OUTPUT_DIR})
 file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/app/AppCfgTest.cfg DESTINATION ${LLBC_OUTPUT_DIR})
 file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/app/AppCfgTest.properties DESTINATION ${LLBC_OUTPUT_DIR})
 file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/app/AppCfgTest.ini DESTINATION ${LLBC_OUTPUT_DIR})
 file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/app/AppCfgTest.xml DESTINATION ${LLBC_OUTPUT_DIR})
+file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/app/AppCfgReloadFailedTest.cfg DESTINATION ${LLBC_OUTPUT_DIR})
+file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/app/AppCfgReloadFailedTest.ini DESTINATION ${LLBC_OUTPUT_DIR})
+file(COPY ${LLBC_LIB_FUNC_TEST_DIR}/app/AppCfgReloadFailedTest.xml DESTINATION ${LLBC_OUTPUT_DIR})
 
-# Build func test.
+# Build func test (static-linked -> func_test; shared-linked -> func_test_shared; debug adds _debug suffix).
 set(LLBC_LIB_FUNC_TEST_LINK_STATIC_EXE ${PROJECT_NAME})
 add_executable(${LLBC_LIB_FUNC_TEST_LINK_STATIC_EXE} ${LLBC_LIB_FUNC_TEST_SRC_FILES})
-target_link_libraries(${LLBC_LIB_FUNC_TEST_LINK_STATIC_EXE} ${LLBC_LIB_FUNC_TEST_STATIC_LIB})
+target_link_libraries(${LLBC_LIB_FUNC_TEST_LINK_STATIC_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_FUNC_TEST_STATIC_LIB})
 target_compile_definitions(${LLBC_LIB_FUNC_TEST_LINK_STATIC_EXE} PRIVATE -DLLBC_LINK_STATIC_LIBRARY)
+set_target_properties(${LLBC_LIB_FUNC_TEST_LINK_STATIC_EXE} PROPERTIES OUTPUT_NAME func_test
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")
 
 set(LLBC_LIB_FUNC_TEST_LINK_SHARED_EXE ${PROJECT_NAME}_shared)
 add_executable(${LLBC_LIB_FUNC_TEST_LINK_SHARED_EXE} ${LLBC_LIB_FUNC_TEST_SRC_FILES})
-target_link_libraries(${LLBC_LIB_FUNC_TEST_LINK_SHARED_EXE} ${LLBC_LIB_FUNC_TEST_SHARED_LIB})
+target_link_libraries(${LLBC_LIB_FUNC_TEST_LINK_SHARED_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_FUNC_TEST_SHARED_LIB})
 target_compile_definitions(${LLBC_LIB_FUNC_TEST_LINK_SHARED_EXE} PRIVATE -DLLBC_LINK_SHARED_LIBRARY)
-
+set_target_properties(${LLBC_LIB_FUNC_TEST_LINK_SHARED_EXE} PROPERTIES OUTPUT_NAME func_test_shared
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")

--- a/tests/func_test/app/FuncTest_App_AppPhaseWaitingTest.cpp
+++ b/tests/func_test/app/FuncTest_App_AppPhaseWaitingTest.cpp
@@ -238,6 +238,7 @@ private:
     void SchedulePhaseTimer(LLBC_Timer &timer, const char *phaseDesc, bool exceptTimeout)
     {
         timer.SetTimeoutHandler([this, phaseDesc, exceptTimeout](LLBC_Timer *timer) {
+            (void)exceptTimeout;
             assert(exceptTimeout);
             LLBC_PrintLn("%s-%s Timeout: timeout times:%zu/%zu",
                          LLBC_GetTypeName(*this),

--- a/tests/quick_start/CMakeLists.txt
+++ b/tests/quick_start/CMakeLists.txt
@@ -16,8 +16,8 @@ if(WIN32)
     set(LLBC_LIB_QUICK_START_STATIC_LIB ws2_32 Mswsock DbgHelp llbc_lib)
     set(LLBC_LIB_QUICK_START_SHARED_LIB ws2_32 Mswsock DbgHelp llbc_lib_shared)
 elseif(UNIX AND NOT APPLE)
-    set(LLBC_LIB_QUICK_START_STATIC_LIB -ldl -lpthread -luuid -lunwind -unwind-x86_64 llbc_lib -lunwind -lunwind-x86_64)
-    set(LLBC_LIB_QUICK_START_SHARED_LIB -ldl -lpthread -luuid -lunwind -unwind-x86_64 llbc_lib_shared -lunwind -lunwind-x86_64)
+    set(LLBC_LIB_QUICK_START_STATIC_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 llbc_lib)
+    set(LLBC_LIB_QUICK_START_SHARED_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 llbc_lib_shared)
 elseif(APPLE)
     set(LLBC_LIB_QUICK_START_STATIC_LIB -liconv llbc_lib)
     set(LLBC_LIB_QUICK_START_SHARED_LIB llbc_lib_shared)
@@ -27,14 +27,17 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LLBC_OUTPUT_DIR})
 file(MAKE_DIRECTORY ${LLBC_OUTPUT_DIR})
 
-# Build example.
+# Build quick start (static-linked -> quick_start; shared-linked -> quick_start_shared; debug adds _debug suffix).
 set(LLBC_LIB_QUICK_START_LINK_STATIC_EXE ${PROJECT_NAME})
 add_executable(${LLBC_LIB_QUICK_START_LINK_STATIC_EXE} ${LLBC_LIB_QUICK_START_SRC_FILES})
-target_link_libraries(${LLBC_LIB_QUICK_START_LINK_STATIC_EXE} ${LLBC_LIB_QUICK_START_STATIC_LIB})
+target_link_libraries(${LLBC_LIB_QUICK_START_LINK_STATIC_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_QUICK_START_STATIC_LIB})
 target_compile_definitions(${LLBC_LIB_QUICK_START_LINK_STATIC_EXE} PRIVATE -DLLBC_LINK_STATIC_LIBRARY)
+set_target_properties(${LLBC_LIB_QUICK_START_LINK_STATIC_EXE} PROPERTIES OUTPUT_NAME quick_start
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")
 
 set(LLBC_LIB_QUICK_START_LINK_SHARED_EXE ${PROJECT_NAME}_shared)
 add_executable(${LLBC_LIB_QUICK_START_LINK_SHARED_EXE} ${LLBC_LIB_QUICK_START_SRC_FILES})
-target_link_libraries(${LLBC_LIB_QUICK_START_LINK_SHARED_EXE} ${LLBC_LIB_QUICK_START_SHARED_LIB})
+target_link_libraries(${LLBC_LIB_QUICK_START_LINK_SHARED_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_QUICK_START_SHARED_LIB})
 target_compile_definitions(${LLBC_LIB_QUICK_START_LINK_SHARED_EXE} PRIVATE -DLLBC_LINK_SHARED_LIBRARY)
-
+set_target_properties(${LLBC_LIB_QUICK_START_LINK_SHARED_EXE} PROPERTIES OUTPUT_NAME quick_start_shared
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")

--- a/tests/unit_test/CMakeLists.txt
+++ b/tests/unit_test/CMakeLists.txt
@@ -8,30 +8,18 @@ set(LLBC_CORE_LIB_INCLUDE ${LLBC_LIB_DIR}/include)
 include_directories(${LLBC_CORE_LIB_INCLUDE})
 link_directories(${LLBC_OUTPUT_DIR})
 
-# Include gtest directory.
-set(LLBC_GTEST_DIR ${LLBC_LIB_TESTS_DIR}/3rdparty/googletest)
-include_directories(${LLBC_GTEST_DIR}/googletest/include)
-link_directories(${LLBC_GTEST_DIR}/build/lib)
-
-# Define custom target: compile googletest framework.
-add_custom_target(
-    build_googletest
-    COMMAND echo "Building googletest..."
-    COMMAND mkdir -p ${LLBC_GTEST_DIR}/build
-    COMMAND cd ${LLBC_GTEST_DIR}/build && cmake .. && make
-    DEPENDS ${LLBC_GTEST_DIR}/CMakeLists.txt
-)
-
 # Set unit test dependency libraries.
+# gtest is provided as a CMake target by add_subdirectory(tests/3rdparty/googletest) in the root
+# CMakeLists (it carries its own include dirs), so no manual include/link paths are needed here.
 if(WIN32)
-    set(LLBC_LIB_UNIT_TEST_STATIC_LIB ws2_32 Mswsock DbgHelp llbc_lib)
-    set(LLBC_LIB_UNIT_TEST_SHARED_LIB ws2_32 Mswsock DbgHelp llbc_lib_shared)
+    set(LLBC_LIB_UNIT_TEST_STATIC_LIB ws2_32 Mswsock DbgHelp gtest llbc_lib)
+    set(LLBC_LIB_UNIT_TEST_SHARED_LIB ws2_32 Mswsock DbgHelp gtest llbc_lib_shared)
 elseif(UNIX AND NOT APPLE)
-    set(LLBC_LIB_UNIT_TEST_STATIC_LIB gtest -ldl -lpthread -luuid llbc_lib -lunwind -lunwind-x86_64)
-    set(LLBC_LIB_UNIT_TEST_SHARED_LIB gtest -ldl -lpthread -luuid llbc_lib_shared -lunwind -lunwind-x86_64)
+    set(LLBC_LIB_UNIT_TEST_STATIC_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 gtest llbc_lib)
+    set(LLBC_LIB_UNIT_TEST_SHARED_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 gtest llbc_lib_shared)
 elseif(APPLE)
-    set(LLBC_LIB_UNIT_TEST_STATIC_LIB -liconv -lgtest llbc_lib)
-    set(LLBC_LIB_UNIT_TEST_SHARED_LIB -lgtest llbc_lib_shared)
+    set(LLBC_LIB_UNIT_TEST_STATIC_LIB -liconv gtest llbc_lib)
+    set(LLBC_LIB_UNIT_TEST_SHARED_LIB gtest llbc_lib_shared)
 endif()
 
 # Include unit test directory.
@@ -41,16 +29,17 @@ include_directories(${LLBC_LIB_UNIT_TEST_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LLBC_OUTPUT_DIR})
 file(MAKE_DIRECTORY ${LLBC_OUTPUT_DIR})
 
-# Build unit test.
+# Build unit test (static-linked -> unit_test; shared-linked -> unit_test_shared; debug adds _debug suffix).
 set(LLBC_LIB_UNIT_TEST_LINK_STATIC_EXE ${PROJECT_NAME})
 add_executable(${LLBC_LIB_UNIT_TEST_LINK_STATIC_EXE} ${LLBC_LIB_UNIT_TEST_SRC_FILES})
-add_dependencies(${LLBC_LIB_UNIT_TEST_LINK_STATIC_EXE} build_googletest)
-target_link_libraries(${LLBC_LIB_UNIT_TEST_LINK_STATIC_EXE} ${LLBC_LIB_UNIT_TEST_STATIC_LIB})
+target_link_libraries(${LLBC_LIB_UNIT_TEST_LINK_STATIC_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_UNIT_TEST_STATIC_LIB})
 target_compile_definitions(${LLBC_LIB_UNIT_TEST_LINK_STATIC_EXE} PRIVATE -DLLBC_LINK_STATIC_LIBRARY)
+set_target_properties(${LLBC_LIB_UNIT_TEST_LINK_STATIC_EXE} PROPERTIES OUTPUT_NAME unit_test
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")
 
 set(LLBC_LIB_UNIT_TEST_LINK_SHARED_EXE ${PROJECT_NAME}_shared)
 add_executable(${LLBC_LIB_UNIT_TEST_LINK_SHARED_EXE} ${LLBC_LIB_UNIT_TEST_SRC_FILES})
-add_dependencies(${LLBC_LIB_UNIT_TEST_LINK_SHARED_EXE} build_googletest)
-target_link_libraries(${LLBC_LIB_UNIT_TEST_LINK_SHARED_EXE} ${LLBC_LIB_UNIT_TEST_SHARED_LIB})
+target_link_libraries(${LLBC_LIB_UNIT_TEST_LINK_SHARED_EXE} PRIVATE llbc_build_flags ${LLBC_LIB_UNIT_TEST_SHARED_LIB})
 target_compile_definitions(${LLBC_LIB_UNIT_TEST_LINK_SHARED_EXE} PRIVATE -DLLBC_LINK_SHARED_LIBRARY)
-
+set_target_properties(${LLBC_LIB_UNIT_TEST_LINK_SHARED_EXE} PROPERTIES OUTPUT_NAME unit_test_shared
+    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" RELEASE_POSTFIX "${CMAKE_RELEASE_POSTFIX}")


### PR DESCRIPTION
将 CMake 次要构建路径补齐到与 premake 等效（wrapper 除外）。

构建配置 / 选项
- cmake_minimum_required 提升至 3.16；未指定时默认 Release
- 严格 C++17（关闭 GNU 扩展）、默认隐藏符号可见性（-fvisibility=hidden）
- Debug 产物加 _debug 后缀；新增 LLBC_ENABLE_ASAN（_asan/_asan_debug 后缀）
- 新增开关 LLBC_DISABLE_CXX11_ABI、LLBC_WARNINGS_AS_ERRORS(默认 ON)、LLBC_SYNC_VERSION
- 抽出 INTERFACE 目标 llbc_build_flags 统一承载 -Wall -Werror、-rdynamic、DEBUG 宏、 cxx11-abi、macOS Foundation/@loader_path rpath、asan；仅本项目目标链接，不波及三方 googletest

产物 / 安装
- 核心库 static+shared 统一 OUTPUT_NAME=llbc → libllbc.a + libllbc.{so,dylib}
- 测试可执行去掉 llbc_ 前缀：func_test/unit_test/example/quick_start[+_shared]
- 新增 install() 规则：库装入 libdir、头文件装入 includedir（对齐 make install）

googletest
- unit_test 改用 add_subdirectory 引入并 out-of-source 构建、链接 gtest 目标， 不再依赖 PATH 中的 cmake，也不再写入 submodule 目录

修复
- 修正 -unwind-x86_64 → -lunwind-x86_64，并去掉重复的 unwind 链接项
- func_test 补齐缺失的配置文件拷贝（LogTestCfg.xml、AppCfgReloadFailedTest.{cfg,ini,xml}）
- 消除 Release(NDEBUG) 下 assert 被裁剪导致的 unused-lambda-capture 告警