### PR TITLE
ci: 修复 macOS / Windows / coverage 构建 job 失败

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -43,10 +43,11 @@ jobs:
         
       - name: Compile tests
         run: |
-          # msbuild.exe build/vs2022/llbc_vs2022.sln -p:Configuration=debug32 -p:Platform=x86 -t:tests
-          # msbuild.exe build/vs2022/llbc_vs2022.sln -p:Configuration=release32 -p:Platform=x86 -t:tests
-          # msbuild.exe build/vs2022/llbc_vs2022.sln -p:Configuration=debug64 -p:Platform=x64 -t:tests
-          msbuild.exe build/vs2022/llbc_vs2022.sln -p:Configuration=release64 -p:Platform=x64 -t:tests
+          # Solution-folder target syntax is <group>\<project>; there is no target named "tests"
+          # (that is the solution folder), so -t:tests fails with MSB4057. Build the actual projects.
+          msbuild.exe build/vs2022/llbc_vs2022.sln -p:Configuration=release64 -p:Platform=x64 -t:tests\func_test
+          msbuild.exe build/vs2022/llbc_vs2022.sln -p:Configuration=release64 -p:Platform=x64 -t:tests\quick_start
+          msbuild.exe build/vs2022/llbc_vs2022.sln -p:Configuration=release64 -p:Platform=x64 -t:tests\example
 
 #      - name: Compile pyllbc lib code
 #        run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,23 +7,23 @@ include("${CMAKE_SOURCE_DIR}/tools/cmake/config.cmake")
 # Set project.
 project(llbc VERSION "${LLBC_VERSION}")
 
-# Coverage: clang source-based coverage instrumentation (non-MSVC). Because both the core lib and
-# unit_test link llbc_build_flags, this instruments the module .cpp (in the lib) AND the inline
-# overloads (*Inl.h) compiled into the test TU. googletest does not inherit these flags.
-if (LLBC_ENABLE_COVERAGE AND NOT MSVC)
-	target_compile_options(llbc_build_flags INTERFACE -fprofile-instr-generate -fcoverage-mapping)
-	target_link_options(llbc_build_flags INTERFACE -fprofile-instr-generate -fcoverage-mapping)
-endif()
+# Note: coverage instrumentation (LLBC_ENABLE_COVERAGE) is applied in tools/cmake/config.cmake
+# via the llbc_sln_build_settings interface library.
 
 # Add llbc lib directory.
 add_subdirectory(${LLBC_LIB_DIR})
 # Add llbc lib test directories.
 add_subdirectory(${LLBC_LIB_EXAMPLE_DIR})
 add_subdirectory(${LLBC_LIB_FUNC_TEST_DIR})
-# if (EXISTS "${LLBC_3RD_DIR_GOOGLETEST}/CMakeLists.txt")
-# 	add_subdirectory(${LLBC_LIB_UNIT_TEST_DIR})
-# else()
-# 	message(NOTICE "3rd - googletest not found(dir: ${LLBC_3RD_DIR_GOOGLETEST}), unit_test will be skipped")
-# 	message(NOTICE "- run <git submodule update --init tests/3rdparty/googletest> to update")
-# endif()
+if (EXISTS "${LLBC_3RD_DIR_GOOGLETEST}/CMakeLists.txt")
+	# Build googletest from the submodule -> provides the `gtest` target unit_test links against.
+	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+	set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+	set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+	add_subdirectory(${LLBC_3RD_DIR_GOOGLETEST} ${CMAKE_BINARY_DIR}/googletest EXCLUDE_FROM_ALL)
+	add_subdirectory(${LLBC_LIB_UNIT_TEST_DIR})
+else()
+	message(NOTICE "3rd - googletest not found(dir: ${LLBC_3RD_DIR_GOOGLETEST}), unit_test will be skipped")
+	message(NOTICE "- run <git submodule update --init tests/3rdparty/googletest> to update")
+endif()
 add_subdirectory(${LLBC_LIB_QUICK_START_DIR})

--- a/tests/unit_test/CMakeLists.txt
+++ b/tests/unit_test/CMakeLists.txt
@@ -12,13 +12,13 @@ link_directories(${LLBC_OUTPUT_DIR})
 # gtest is provided as a CMake target by add_subdirectory(tests/3rdparty/googletest) in the root
 # CMakeLists (it carries its own include dirs), so no manual include/link paths are needed here.
 if(WIN32)
-    set(LLBC_LIB_UNIT_TEST_STATIC_LIB ws2_32 Mswsock DbgHelp gtest llbc_lib)
+    set(LLBC_LIB_UNIT_TEST_STATIC_LIB ws2_32 Mswsock DbgHelp gtest llbc_lib_static)
     set(LLBC_LIB_UNIT_TEST_SHARED_LIB ws2_32 Mswsock DbgHelp gtest llbc_lib_shared)
 elseif(UNIX AND NOT APPLE)
-    set(LLBC_LIB_UNIT_TEST_STATIC_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 gtest llbc_lib)
+    set(LLBC_LIB_UNIT_TEST_STATIC_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 gtest llbc_lib_static)
     set(LLBC_LIB_UNIT_TEST_SHARED_LIB -ldl -lpthread -luuid -lunwind -lunwind-x86_64 gtest llbc_lib_shared)
 elseif(APPLE)
-    set(LLBC_LIB_UNIT_TEST_STATIC_LIB -liconv gtest llbc_lib)
+    set(LLBC_LIB_UNIT_TEST_STATIC_LIB -liconv gtest llbc_lib_static)
     set(LLBC_LIB_UNIT_TEST_SHARED_LIB gtest llbc_lib_shared)
 endif()
 

--- a/tests/unit_test/common/UnitTest_Com_Stream.cpp
+++ b/tests/unit_test/common/UnitTest_Com_Stream.cpp
@@ -351,7 +351,10 @@ TEST(StreamTest, SelfAssign)
     const size_t wposBefore = stream.GetWritePos();
     const void *bufBefore = stream.GetBuf();
 
-    stream = stream;
+    // Assign through a reference so the intentional self-assignment still exercises the
+    // self-assign path at runtime without tripping clang's syntactic -Wself-assign-overloaded.
+    LLBC_Stream &streamSelfRef = stream;
+    stream = streamSelfRef;
 
     ASSERT_EQ(stream.GetWritePos(), wposBefore);
     ASSERT_EQ(stream.GetBuf(), bufBefore);

--- a/tools/cmake/config.cmake
+++ b/tools/cmake/config.cmake
@@ -23,7 +23,7 @@ set(LLBC_LIB_QUICK_START_DIR ${LLBC_LIB_TESTS_DIR}/quick_start)
 # - Set llbc wrap libraries directory.
 set(LLBC_WRAP_DIR ${LLBC_TOP_DIR}/wrap)
 # - 3rd direstories.
-set(LLBC_3RD_DIR_GOOGLETEST "${LLBC_LIB_UNIT_TEST_DIR}/3rdparty/googletest")
+set(LLBC_3RD_DIR_GOOGLETEST "${LLBC_LIB_TESTS_DIR}/3rdparty/googletest")
 # - Set llbc output directory.
 set(LLBC_OUTPUT_DIR ${LLBC_TOP_DIR}/output/cmake)
 file(MAKE_DIRECTORY ${LLBC_OUTPUT_DIR})


### PR DESCRIPTION
## 背景
当前 master 上 CI 的 **MacOS build**、**Windows build**、**Unit test coverage** 三个 job 均失败。本 PR 逐一定位并以最小改动修复（已在 fork 验证转绿）。

## 修改

### 1. macOS —— `UnitTest_Com_Stream.cpp` 自赋值用例
`StreamTest.SelfAssign` 的 `stream = stream;` 被 clang `-Wself-assign-overloaded` 在 `-Werror` 下判错：
```
UnitTest_Com_Stream.cpp:354:12: error: explicitly assigning value of variable of type 'LLBC_Stream' to itself [-Werror,-Wself-assign-overloaded]
```
改为**经引用自赋值**（`LLBC_Stream &ref = stream; stream = ref;`）——保留自赋值语义测试，又不触发该语法级告警。（gcc 不报此告警，故 Linux 一直绿。）

### 2. Windows —— `windows-build.yml` 的 `Compile tests`
用了 `-t:tests`，但 `tests` 是解决方案文件夹而非工程 → `MSB4057: The target "tests" does not exist`。改为按 `<分组>\<工程>` 构建实际工程：`tests\func_test`、`tests\quick_start`、`tests\example`。

### 3. coverage —— cmake 重构遗留导致 configure/链接失败
重构后 cmake 的 unit_test 构建链断裂：
- 根 `CMakeLists.txt` 残留旧 coverage 块，引用已改名的 `llbc_build_flags`（现为 `config.cmake` 的 `llbc_sln_build_settings`）→ configure 报错。删除该残留块（coverage 插桩已由 config.cmake 统一处理）。
- `config.cmake` 的 `LLBC_3RD_DIR_GOOGLETEST` 指向 `tests/unit_test/3rdparty/googletest`，但子模块实际在 `tests/3rdparty/googletest`（`.gitmodules` 为准）→ 修正路径。
- 根 `CMakeLists.txt` 重新启用 unit_test：恢复 googletest 子目录（提供 `gtest` 目标）+ unit_test 子目录（原为注释停用）。
- `tests/unit_test/CMakeLists.txt` 仍链接旧目标名 `llbc_lib`（重构已改名 `llbc_lib_static`，example/func_test/quick_start 均已更新，唯 unit_test 因当时停用被遗漏）→ 对齐为 `llbc_lib_static`。

## 验证
在 fork（reckfullol/llbc）对本分支跑 CI：Linux / macOS / Windows / Unit test coverage 均 ✅。coverage 脚本本地（clang）完整跑通，unit_test 99 用例编译/链接/运行/出报告正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)