### PR TITLE
test: 补充 common 端序与版本单元测试

### DIFF
--- a/llbc/include/llbc/common/BasicString.h
+++ b/llbc/include/llbc/common/BasicString.h
@@ -54,7 +54,7 @@ public:
 
 public:
 #if LLBC_TARGET_PLATFORM_NON_WIN32
-    static const size_type npos = _Base::npos;
+    static constexpr size_type npos = _Base::npos;
 #endif
 
 public:

--- a/llbc/src/common/Endian.cpp
+++ b/llbc/src/common/Endian.cpp
@@ -60,14 +60,14 @@ int LLBC_Endian::Str2Type(const char *str)
     lowerCaseStr[len] = '\0';
 
     int type;
-    if (memcmp(LLBC_INTERNAL_NS
-        __g_endian_type_desc[LLBC_Endian::BigEndian], lowerCaseStr, len) == 0)
+    if (strcmp(LLBC_INTERNAL_NS
+        __g_endian_type_desc[LLBC_Endian::BigEndian], lowerCaseStr) == 0)
     {
         type = LLBC_Endian::BigEndian;
         goto finally;
     }
-    else if (memcmp(LLBC_INTERNAL_NS
-        __g_endian_type_desc[LLBC_Endian::LittleEndian], lowerCaseStr, len) == 0)
+    else if (strcmp(LLBC_INTERNAL_NS
+        __g_endian_type_desc[LLBC_Endian::LittleEndian], lowerCaseStr) == 0)
     {
         type = LLBC_Endian::LittleEndian;
         goto finally;

--- a/tests/unit_test/common/UnitTest_Com_Endian.cpp
+++ b/tests/unit_test/common/UnitTest_Com_Endian.cpp
@@ -1,0 +1,105 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <cstring>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/common/Endian.cpp
+// @coverage-target: llbc/include/llbc/common/EndianInl.h
+
+namespace
+{
+
+enum class EndianTestEnum : uint32
+{
+    Value = 0x01020304u,
+};
+
+} // namespace
+
+// Endian names are public configuration values. Matching must be case
+// insensitive but exact: prefixes such as "big" are not valid names.
+TEST(EndianTest, ConvertsAndValidatesEndianNames)
+{
+    EXPECT_TRUE(LLBC_Endian::IsValid(LLBC_Endian::BigEndian));
+    EXPECT_TRUE(LLBC_Endian::IsValid(LLBC_Endian::LittleEndian));
+    EXPECT_FALSE(LLBC_Endian::IsValid(LLBC_Endian::UnknownEndian));
+    EXPECT_FALSE(LLBC_Endian::IsValid(-1));
+
+    EXPECT_STREQ(LLBC_Endian::Type2Str(LLBC_Endian::BigEndian), "big endian");
+    EXPECT_STREQ(LLBC_Endian::Type2Str(LLBC_Endian::LittleEndian), "little endian");
+    EXPECT_STREQ(LLBC_Endian::Type2Str(-1), "unknown endian");
+    EXPECT_STREQ(LLBC_Endian::Type2Str(999), "unknown endian");
+
+    EXPECT_EQ(LLBC_Endian::Str2Type("BIG ENDIAN"), LLBC_Endian::BigEndian);
+    EXPECT_EQ(LLBC_Endian::Str2Type("little endian"), LLBC_Endian::LittleEndian);
+    EXPECT_EQ(LLBC_Endian::Str2Type("big"), LLBC_Endian::UnknownEndian);
+    EXPECT_EQ(LLBC_Endian::Str2Type("little"), LLBC_Endian::UnknownEndian);
+    EXPECT_EQ(LLBC_Endian::Str2Type(nullptr), LLBC_Endian::UnknownEndian);
+}
+
+// Byte reversal covers scalar widths and enum values. Applying it twice must
+// restore the original bit representation.
+TEST(EndianTest, ReversesByteOrderForSupportedScalarWidths)
+{
+    EXPECT_EQ(LLBC_ReverseBytes<uint8>(0x5au), 0x5au);
+    EXPECT_EQ(LLBC_ReverseBytes<uint16>(0x1234u), 0x3412u);
+    EXPECT_EQ(LLBC_ReverseBytes<uint32>(0x01020304u), 0x04030201u);
+    EXPECT_EQ(LLBC_ReverseBytes<uint64>(0x0102030405060708ULL), 0x0807060504030201ULL);
+    EXPECT_EQ(LLBC_ReverseBytes(EndianTestEnum::Value),
+              static_cast<EndianTestEnum>(0x04030201u));
+
+    const long nativeSigned = -123456789L;
+    const ulong nativeUnsigned = 0x12345678UL;
+    EXPECT_EQ(LLBC_ReverseBytes(LLBC_ReverseBytes(nativeSigned)), nativeSigned);
+    EXPECT_EQ(LLBC_ReverseBytes(LLBC_ReverseBytes(nativeUnsigned)), nativeUnsigned);
+
+    const double value = 123.25;
+    const double reversedTwice = LLBC_ReverseBytes(LLBC_ReverseBytes(value));
+    EXPECT_EQ(::memcmp(&value, &reversedTwice, sizeof(value)), 0);
+
+    // Do not use long double here: x87 ABIs store it with padding, and the
+    // byte-reversed intermediate can be an unstable floating representation.
+}
+
+// Host/network conversion is an involution regardless of the local machine
+// endian. The exported machine-endian constant must match the actual layout.
+TEST(EndianTest, ConvertsBetweenHostAndNetworkOrder)
+{
+    const uint32 judge = 1;
+    const int actualEndian =
+        (*reinterpret_cast<const uint8 *>(&judge) == 1) ?
+            LLBC_Endian::LittleEndian : LLBC_Endian::BigEndian;
+    EXPECT_EQ(LLBC_MachineEndian, actualEndian);
+    EXPECT_TRUE(LLBC_Endian::IsValid(LLBC_DefaultEndian));
+
+    const uint16 value16 = 0x1234u;
+    const uint32 value32 = 0x01020304u;
+    const uint64 value64 = 0x0102030405060708ULL;
+    EXPECT_EQ(LLBC_Net2Host(LLBC_Host2Net(value16)), value16);
+    EXPECT_EQ(LLBC_Net2Host(LLBC_Host2Net(value32)), value32);
+    EXPECT_EQ(LLBC_Net2Host(LLBC_Host2Net(value64)), value64);
+}

--- a/tests/unit_test/common/UnitTest_Com_Version.cpp
+++ b/tests/unit_test/common/UnitTest_Com_Version.cpp
@@ -1,0 +1,56 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/common/Version.cpp
+
+// Version reporting is consumed by diagnostics and deployment tooling. The
+// concise form identifies the build while the verbose form exposes configured
+// core and communication capabilities.
+TEST(VersionTest, ReportsConciseAndVerboseBuildInformation)
+{
+    EXPECT_GT(LLBC_majorVersion, 0);
+    EXPECT_GE(LLBC_minorVersion, 0);
+    EXPECT_GE(LLBC_updateNo, 0);
+
+    const auto concise = LLBC_GetVersionInfo();
+    const LLBC_String expectedPrefix =
+        LLBC_String().format("%d.%d.%d_",
+                             LLBC_majorVersion,
+                             LLBC_minorVersion,
+                             LLBC_updateNo);
+    EXPECT_EQ(concise.find(expectedPrefix), 0lu);
+    EXPECT_NE(concise.find(LLBC_isDebugVer ? "debug" : "release"), LLBC_String::npos);
+    EXPECT_NE(concise.find("arch:"), LLBC_String::npos);
+    EXPECT_NE(concise.find("compiled with:"), LLBC_String::npos);
+
+    const auto verbose = LLBC_GetVersionInfo(true);
+    EXPECT_TRUE(verbose.find(concise) == 0);
+    EXPECT_NE(verbose.find("core info:"), LLBC_String::npos);
+    EXPECT_NE(verbose.find("thread info:"), LLBC_String::npos);
+    EXPECT_NE(verbose.find("logger info:"), LLBC_String::npos);
+    EXPECT_NE(verbose.find("communication info:"), LLBC_String::npos);
+}


### PR DESCRIPTION
## 概述

补充 common 模块的端序、字节序和版本信息覆盖，并修复测试发现的字符串常量及端序名称解析问题。

## 内容

### 单元测试

- 验证端序名称、标量/枚举字节翻转、Host/Network 转换。
- 验证精简与完整版本信息的关键字段。
- 不对 `long double` 做字节反转往返断言：x87 ABI 的存储含 padding，反转后的中间位型可能不是稳定浮点表示；保留整数、枚举和 `double` 的有效覆盖。

### 库代码修正

- `BasicString::npos`：原 `static const` 在测试中被 ODR-use 时需要类外定义，导致链接失败；改为 `constexpr` 后常量可在头文件内完整定义，值仍与底层 string 的 `npos` 一致。
- `Endian::Str2Type`：原 `memcmp(..., input_len)` 会把 `big` 等前缀当作完整名称；改为 `strcmp` 要求长度和内容都匹配，保持大小写归一化后的既有语义。

## 质量保证

- 独立分支：103 tests passed。
- 最终组合：330/330 tests passed（Ubuntu 24.04 / Clang coverage）。
- CentOS 8 / GCC 8、macOS、Windows 构建全部真实执行并通过：[组合验证](https://github.com/reckfullol/llbc/actions/runs/30164371701)。

