### PR TITLE
test: 补充 comm 数据包、Service 与 Socket 单元测试

### DIFF
--- a/llbc/src/comm/PacketHeaderAssembler.cpp
+++ b/llbc/src/comm/PacketHeaderAssembler.cpp
@@ -27,6 +27,25 @@
 
 __LLBC_NS_BEGIN
 
+namespace
+{
+
+// Reads a header field out of the raw byte buffer. The fields are not guaranteed
+// to be naturally aligned (the 64-bit extData1 sits at offset 12), so a memcpy is
+// used instead of dereferencing a reinterpret_cast'ed pointer, which would be
+// unaligned-access / strict-aliasing UB (flagged by UBSan). With a compile-time
+// constant size the compiler lowers this to a single load, so it is exactly as
+// efficient as the raw dereference.
+template <typename _RawTy>
+inline _RawTy ReadHeaderField(const char *header)
+{
+    _RawTy val;
+    memcpy(&val, header, sizeof(_RawTy));
+    return val;
+}
+
+} // anonymous namespace
+
 LLBC_PacketHeaderAssembler::LLBC_PacketHeaderAssembler(size_t headerLen)
 : _headerLen(headerLen)
 , _header(LLBC_Malloc(char, headerLen))
@@ -74,11 +93,11 @@ void LLBC_PacketHeaderAssembler::Reset()
 
 void LLBC_PacketHeaderAssembler::SetToPacket(LLBC_Packet &packet) const
 {
-    uint32 len = *reinterpret_cast<uint32 *>(_header);
-    sint32 opcode = *reinterpret_cast<sint32 *>(_header + 4);
-    uint16 status = *reinterpret_cast<uint16 *>(_header + 8);
-    uint16 flags = *reinterpret_cast<uint16 *>(_header + 10);
-    sint64 extData1 = *reinterpret_cast<sint64 *>(_header + 12);
+    uint32 len = ReadHeaderField<uint32>(_header);
+    sint32 opcode = ReadHeaderField<sint32>(_header + 4);
+    uint16 status = ReadHeaderField<uint16>(_header + 8);
+    uint16 flags = ReadHeaderField<uint16>(_header + 10);
+    sint64 extData1 = ReadHeaderField<sint64>(_header + 12);
 
 #if LLBC_CFG_COMM_ORDER_IS_NET_ORDER
     len = LLBC_Net2Host(len);

--- a/tests/unit_test/comm/UnitTest_Comm_Component.cpp
+++ b/tests/unit_test/comm/UnitTest_Comm_Component.cpp
@@ -1,0 +1,190 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/comm/Component.cpp
+// @coverage-target: llbc/include/llbc/comm/ComponentInl.h
+
+namespace
+{
+
+LLBC_SessionInfo *MakeSessionInfo()
+{
+    auto *info = new LLBC_SessionInfo;
+    info->SetIsListenSession(true);
+    info->SetSessionId(101);
+    info->SetAcceptSessionId(99);
+    info->SetLocalAddr(LLBC_SockAddr_IN("127.0.0.1", 41001));
+    info->SetPeerAddr(LLBC_SockAddr_IN("127.0.0.1", 41002));
+    info->SetSocket(123);
+    return info;
+}
+
+class MethodComponent final : public LLBC_Component
+{
+public:
+    int Increment(const LLBC_Variant &arg, LLBC_Variant &ret)
+    {
+        ret = arg.As<int>() + 1;
+        return LLBC_OK;
+    }
+};
+
+} // namespace
+
+// Session metadata owns no transport resource itself. Its values and string
+// representation must remain stable when wrapped by a destroy notification.
+TEST(ComponentTest, PreservesSessionAndDestroyInformation)
+{
+    LLBC_SessionInfo info;
+    EXPECT_FALSE(info.IsListenSession());
+    EXPECT_EQ(info.GetSessionId(), 0);
+    EXPECT_EQ(info.GetAcceptSessionId(), 0);
+    EXPECT_EQ(info.GetSocket(), LLBC_INVALID_SOCKET_HANDLE);
+
+    info.SetIsListenSession(true);
+    info.SetSessionId(101);
+    info.SetAcceptSessionId(99);
+    info.SetLocalAddr(LLBC_SockAddr_IN("127.0.0.1", 41001));
+    info.SetPeerAddr(LLBC_SockAddr_IN("127.0.0.1", 41002));
+    info.SetSocket(123);
+    EXPECT_TRUE(info.IsListenSession());
+    EXPECT_EQ(info.GetSessionId(), 101);
+    EXPECT_EQ(info.GetAcceptSessionId(), 99);
+    EXPECT_EQ(info.GetLocalAddr(), LLBC_SockAddr_IN("127.0.0.1", 41001));
+    EXPECT_EQ(info.GetPeerAddr(), LLBC_SockAddr_IN("127.0.0.1", 41002));
+    EXPECT_EQ(info.GetSocket(), 123);
+    EXPECT_NE(std::string(info.ToString().c_str()).find("sessionId:101"), std::string::npos);
+
+    std::ostringstream infoOutput;
+    infoOutput << info;
+    EXPECT_NE(infoOutput.str().find("acceptSessionId:99"), std::string::npos);
+
+    char serviceReason[] = "component-test-close";
+    LLBC_SessionDestroyInfo serviceDestroy(
+        MakeSessionInfo(), new LLBC_SessionCloseInfo(serviceReason));
+    EXPECT_TRUE(serviceDestroy.IsListenSession());
+    EXPECT_EQ(serviceDestroy.GetSessionId(), 101);
+    EXPECT_EQ(serviceDestroy.GetAcceptSessionId(), 99);
+    EXPECT_EQ(serviceDestroy.GetSocket(), 123);
+    EXPECT_EQ(serviceDestroy.GetLocalAddr(), LLBC_SockAddr_IN("127.0.0.1", 41001));
+    EXPECT_EQ(serviceDestroy.GetPeerAddr(), LLBC_SockAddr_IN("127.0.0.1", 41002));
+    EXPECT_TRUE(serviceDestroy.IsDestroyedFromService());
+    EXPECT_EQ(serviceDestroy.GetErrno(), LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(serviceDestroy.GetSubErrno(), LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(serviceDestroy.GetReason(), serviceReason);
+    EXPECT_NE(std::string(serviceDestroy.ToString().c_str()).find(serviceReason), std::string::npos);
+
+    std::ostringstream destroyOutput;
+    destroyOutput << serviceDestroy;
+    EXPECT_NE(destroyOutput.str().find("fromService:true"), std::string::npos);
+
+    LLBC_SessionDestroyInfo networkDestroy(
+        MakeSessionInfo(), new LLBC_SessionCloseInfo(LLBC_ERROR_ARG, 7));
+    EXPECT_FALSE(networkDestroy.IsDestroyedFromService());
+    EXPECT_EQ(networkDestroy.GetErrno(), LLBC_ERROR_ARG);
+    EXPECT_EQ(networkDestroy.GetSubErrno(), LLBC_ERROR_SUCCESS);
+    EXPECT_FALSE(networkDestroy.GetReason().empty());
+}
+
+// Connection and protocol reports are passed to components by value. Every
+// field, including the human-readable representation, must reflect setters.
+TEST(ComponentTest, PreservesAsyncProtocolAndReloadReports)
+{
+    LLBC_AsyncConnResult asyncResult;
+    EXPECT_FALSE(asyncResult.IsConnected());
+    EXPECT_EQ(asyncResult.GetSessionId(), 0);
+    asyncResult.SetIsConnected(true);
+    asyncResult.SetSessionId(303);
+    asyncResult.SetReason("connected");
+    asyncResult.SetPeerAddr(LLBC_SockAddr_IN("127.0.0.1", 42001));
+    EXPECT_TRUE(asyncResult.IsConnected());
+    EXPECT_EQ(asyncResult.GetSessionId(), 303);
+    EXPECT_EQ(asyncResult.GetReason(), "connected");
+    EXPECT_EQ(asyncResult.GetPeerAddr(), LLBC_SockAddr_IN("127.0.0.1", 42001));
+    EXPECT_NE(std::string(asyncResult.ToString().c_str()).find("connected:true"), std::string::npos);
+
+    std::ostringstream asyncOutput;
+    asyncOutput << asyncResult;
+    EXPECT_NE(asyncOutput.str().find("peer_addr"), std::string::npos);
+
+    LLBC_ProtoReport report;
+    report.SetSessionId(303);
+    report.SetOpcode(7001);
+    report.SetLayer(LLBC_ProtocolLayer::CodecLayer);
+    report.SetLevel(LLBC_ProtoReportLevel::Warn);
+    report.SetReport("decode warning");
+    EXPECT_EQ(report.GetSessionId(), 303);
+    EXPECT_EQ(report.GetOpcode(), 7001);
+    EXPECT_EQ(report.GetLayer(), LLBC_ProtocolLayer::CodecLayer);
+    EXPECT_EQ(report.GetLevel(), LLBC_ProtoReportLevel::Warn);
+    EXPECT_EQ(report.GetReport(), "decode warning");
+    EXPECT_NE(std::string(report.ToString().c_str()).find("decode warning"), std::string::npos);
+
+    std::ostringstream reportOutput;
+    reportOutput << report;
+    EXPECT_NE(reportOutput.str().find("opcode:7001"), std::string::npos);
+
+    LLBC_AppReloadFailedInfo reloadFailure;
+    reloadFailure.SetErrNo(LLBC_ERROR_ARG);
+    reloadFailure.SetSubErrNo(7);
+    EXPECT_EQ(reloadFailure.GetErrNo(), LLBC_ERROR_ARG);
+    EXPECT_EQ(reloadFailure.GetSubErrNo(), 7);
+    EXPECT_FALSE(reloadFailure.GetErrDesc().empty());
+    EXPECT_NE(std::string(reloadFailure.ToString().c_str()).find("subErrNo:7"), std::string::npos);
+}
+
+// Component method dispatch must reject invalid registrations, preserve a
+// registered delegate, and expose its result through both wrapper classes.
+TEST(ComponentTest, RegistersAndDispatchesComponentMethods)
+{
+    MethodComponent component;
+    EXPECT_EQ(component.GetService(), nullptr);
+    EXPECT_EQ(component.GetConfigType(), LLBC_AppConfigType::End);
+    EXPECT_TRUE(component.GetConfig().Is<void>());
+    EXPECT_TRUE(component.GetAllMethods().GetAllMethods().empty());
+
+    LLBC_Variant result;
+    EXPECT_EQ(component.CallMethod("missing", 1, result), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+    EXPECT_EQ(component.AddMethod("", &MethodComponent::Increment), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+
+    ASSERT_EQ(component.AddMethod("increment", &MethodComponent::Increment), LLBC_OK);
+    EXPECT_EQ(component.AddMethod("increment", &MethodComponent::Increment), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_REPEAT);
+    ASSERT_EQ(component.CallMethod("increment", 41, result), LLBC_OK);
+    EXPECT_EQ(result.As<int>(), 42);
+    EXPECT_TRUE(component.GetAllMethods().GetMethod("increment"));
+    EXPECT_FALSE(component.GetAllMethods().GetMethod("missing"));
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+
+    component.SetConfig(LLBC_Variant("component-config"));
+    EXPECT_EQ(component.GetConfig(), "component-config");
+}

--- a/tests/unit_test/comm/UnitTest_Comm_Packet.cpp
+++ b/tests/unit_test/comm/UnitTest_Comm_Packet.cpp
@@ -1,5 +1,5 @@
 // The MIT License (MIT)
-
+//
 // Copyright (c) 2013 lailongwei<lailongwei@126.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,21 +22,516 @@
 #include <llbc.h>
 using namespace llbc;
 
+#include <array>
+#include <cstring>
+#include <deque>
+#include <list>
+#include <map>
+#include <sstream>
+#include <set>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
-TEST(PacketTest, RawPrimitiveRoundTrip)
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/comm/Packet.cpp
+// @coverage-target: llbc/include/llbc/comm/PacketInl.h
+// @coverage-target: llbc/src/comm/PacketHeaderAssembler.cpp
+// @coverage-target: llbc/include/llbc/comm/SessionOptsInl.h
+// @coverage-target: llbc/src/comm/SessionOpts.cpp
+// @coverage-target: llbc/src/comm/PollerType.cpp
+
+namespace
 {
-    constexpr uint64 expectedId = 0x0123456789abcdefULL;
-    constexpr sint32 expectedLevel = -123456789;
+
+class TestCoder final : public LLBC_Coder
+{
+public:
+    TestCoder(int *calls, bool result)
+    : _calls(calls)
+    , _result(result)
+    {
+    }
+
+    bool Encode(LLBC_Packet &packet) override
+    {
+        ++*_calls;
+        return _result && packet.Write(static_cast<uint32>(0x1a2b3c4du)) == LLBC_OK;
+    }
+
+    bool Decode(LLBC_Packet &packet) override
+    {
+        ++*_calls;
+        uint32 marker = 0;
+        return _result && packet.Read(marker) == LLBC_OK && marker == 0x1a2b3c4du;
+    }
+
+private:
+    int *_calls;
+    bool _result;
+};
+
+class CleanupRecorder
+{
+public:
+    void DeleteInt(void *value)
+    {
+        ++intCleanupCalls;
+        delete static_cast<int *>(value);
+    }
+
+    void DeletePayload(LLBC_MessageBlock *block)
+    {
+        ++payloadCleanupCalls;
+        delete block;
+    }
+
+    int intCleanupCalls = 0;
+    int payloadCleanupCalls = 0;
+};
+
+void AssignAddress(LLBC_SockAddr_IN &target, const LLBC_SockAddr_IN &source)
+{
+    target = source;
+}
+
+template <typename T>
+void PutHeaderValue(std::array<char, 20> &header, size_t offset, T value)
+{
+#if LLBC_CFG_COMM_ORDER_IS_NET_ORDER
+    value = LLBC_Host2Net(value);
+#endif
+    std::memcpy(header.data() + offset, &value, sizeof(value));
+}
+
+} // namespace
+
+// Packets carry transport metadata independently from their payload. The payload
+// uses the configured network byte order and supports stream-compatible values.
+TEST(PacketTest, PreservesHeaderMetadataAndPayloadValues)
+{
+    LLBC_Packet packet;
+    EXPECT_EQ(packet.GetLength(), 0u);
+    EXPECT_EQ(packet.GetPayload(), nullptr);
+    EXPECT_EQ(packet.GetPayloadLength(), 0u);
+    std::ostringstream emptyOutput;
+    emptyOutput << packet;
+    EXPECT_NE(emptyOutput.str().find("read_pos:0"), std::string::npos);
+
+    packet.SetLength(512);
+    packet.SetAcceptSessionId(7);
+    packet.SetHeader(42, 1001, -3, 0x03u);
+    packet.AddFlags(0x0cu);
+    packet.RemoveFlags(0x02u);
+    packet.SetExtData1(-1);
+    packet.SetExtData2(2);
+    packet.SetExtData3(3);
+
+    const LLBC_SockAddr_IN local("127.0.0.1", 31001);
+    const LLBC_SockAddr_IN peer("127.0.0.1", 31002);
+    packet.SetLocalAddr(local);
+    packet.SetPeerAddr(peer);
+    EXPECT_EQ(packet.GetLength(), 512u);
+    EXPECT_EQ(packet.GetSessionId(), 42);
+    EXPECT_EQ(packet.GetAcceptSessionId(), 7);
+    EXPECT_EQ(packet.GetOpcode(), 1001);
+    EXPECT_EQ(packet.GetStatus(), -3);
+    EXPECT_TRUE(packet.HasFlags(0x0du));
+    EXPECT_FALSE(packet.HasFlags(0x02u));
+    EXPECT_EQ(packet.GetExtData1(), -1);
+    EXPECT_EQ(packet.GetExtData2(), 2);
+    EXPECT_EQ(packet.GetExtData3(), 3);
+    EXPECT_EQ(packet.GetLocalAddr(), local);
+    EXPECT_EQ(packet.GetPeerAddr(), peer);
+
+    const uint32 number = 0x01020304u;
+    const std::string text = "packet-text";
+    const std::vector<sint16> values {-4, 0, 9};
+    ASSERT_EQ(packet.Write(number), LLBC_OK);
+    ASSERT_EQ(packet.Write(text), LLBC_OK);
+    ASSERT_EQ(packet.Write(values), LLBC_OK);
+    ASSERT_GT(packet.GetPayloadLength(), 0u);
+
+    uint32 readNumber = 0;
+    std::string readText;
+    std::vector<sint16> readValues;
+    EXPECT_EQ(packet.Read(readNumber), LLBC_OK);
+    EXPECT_EQ(packet.Read(readText), LLBC_OK);
+    EXPECT_EQ(packet.Read(readValues), LLBC_OK);
+    EXPECT_EQ(readNumber, number);
+    EXPECT_EQ(readText, text);
+    EXPECT_EQ(readValues, values);
+
+    std::ostringstream output;
+    output << packet;
+    EXPECT_NE(output.str().find("sid:42"), std::string::npos);
+    EXPECT_NE(output.str().find("opcode:1001"), std::string::npos);
+
+    packet.Clear();
+    EXPECT_EQ(packet.GetLength(), 0u);
+    EXPECT_EQ(packet.GetSessionId(), 0);
+    EXPECT_EQ(packet.GetAcceptSessionId(), 0);
+    EXPECT_EQ(packet.GetOpcode(), 0);
+    EXPECT_EQ(packet.GetStatus(), 0);
+    EXPECT_EQ(packet.GetFlags(), 0u);
+    EXPECT_EQ(packet.GetPayloadLength(), 0u);
+}
+
+// Coder and callback ownership is part of the packet lifecycle. Replacing or
+// clearing a packet must release its previous owned values exactly once.
+TEST(PacketTest, OwnsCodersPayloadAndPreHandleResults)
+{
+    LLBC_Packet packet;
+    int encodeCalls = 0;
+    int decodeCalls = 0;
+    packet.SetEncoder(new TestCoder(&encodeCalls, true));
+    ASSERT_TRUE(packet.Encode());
+    EXPECT_EQ(encodeCalls, 1);
+    EXPECT_EQ(packet.GetEncoder(), nullptr);
+
+    packet.SetDecoder(new TestCoder(&decodeCalls, true));
+    ASSERT_TRUE(packet.Decode());
+    EXPECT_EQ(decodeCalls, 1);
+    EXPECT_NE(packet.GetDecoder(), nullptr);
+
+    CleanupRecorder recorder;
+    packet.SetPreHandleResult(new int(10), &recorder, &CleanupRecorder::DeleteInt);
+    ASSERT_NE(packet.GetPreHandleResult<int>(), nullptr);
+    EXPECT_EQ(*packet.GetPreHandleResult<int>(), 10);
+    EXPECT_EQ(packet.GetPreHandleResult(), static_cast<void *>(packet.GetPreHandleResult<int>()));
+    packet.SetPreHandleResult(new int(20), &recorder, &CleanupRecorder::DeleteInt);
+    EXPECT_EQ(recorder.intCleanupCalls, 1);
+
+    packet.SetPayloadDeleteDeleg(
+        LLBC_Delegate<void(LLBC_MessageBlock *)>(&recorder, &CleanupRecorder::DeletePayload));
+    packet.SetPayload(new LLBC_MessageBlock);
+    ASSERT_NE(packet.GetMutablePayload(), nullptr);
+    ASSERT_EQ(packet.Write("x", 1), LLBC_OK);
+    packet.Clear();
+    EXPECT_EQ(recorder.intCleanupCalls, 2);
+    EXPECT_EQ(recorder.payloadCleanupCalls, 1);
+    EXPECT_EQ(packet.GetDecoder(), nullptr);
+
+    packet.SetPayload(new LLBC_MessageBlock);
+    LLBC_MessageBlock *detached = packet.DetachPayload();
+    ASSERT_NE(detached, nullptr);
+    EXPECT_EQ(packet.GetPayload(), nullptr);
+    delete detached;
+}
+
+// Every scalar and standard-container overload shares the packet wire format.
+// Exercise the public round-trip contract, including the stream and operator
+// conveniences that callers use to construct application payloads.
+TEST(PacketTest, RoundTripsScalarContainerAndStreamOverloads)
+{
+    LLBC_Packet packet;
+    const bool boolValue = true;
+    const sint8 sint8Value = -8;
+    const uint8 uint8Value = 8;
+    const sint16 sint16Value = -16;
+    const uint16 uint16Value = 16;
+    const sint32 sint32Value = -32;
+    const uint32 uint32Value = 32;
+    const long longValue = -64;
+    const ulong ulongValue = 64;
+    const sint64 sint64Value = -128;
+    const uint64 uint64Value = 128;
+    const float floatValue = 1.25f;
+    const double doubleValue = 2.5;
+    const std::list<uint16> listValue {1, 2, 3};
+    const std::deque<sint32> dequeValue {-1, 0, 1};
+    const std::set<uint32> setValue {4, 5, 6};
+    const std::map<uint16, std::string> mapValue {{7, "seven"}, {8, "eight"}};
+    const char cString[] = "packet-c-string";
+    LLBC_Stream stream;
+    stream.Write("stream-data", sizeof("stream-data"));
+
+    ASSERT_EQ(packet.Write(boolValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(sint8Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(uint8Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(sint16Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(uint16Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(sint32Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(uint32Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(longValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(ulongValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(sint64Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(uint64Value), LLBC_OK);
+    ASSERT_EQ(packet.Write(floatValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(doubleValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(cString), LLBC_OK);
+    ASSERT_EQ(packet.Write(static_cast<const char *>(nullptr)), LLBC_OK);
+    ASSERT_EQ(packet.Write(stream), LLBC_OK);
+    ASSERT_EQ(packet.Write(listValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(dequeValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(setValue), LLBC_OK);
+    ASSERT_EQ(packet.Write(mapValue), LLBC_OK);
+
+    bool readBool = false;
+    sint8 readSint8 = 0;
+    uint8 readUint8 = 0;
+    sint16 readSint16 = 0;
+    uint16 readUint16 = 0;
+    sint32 readSint32 = 0;
+    uint32 readUint32 = 0;
+    long readLong = 0;
+    ulong readUlong = 0;
+    sint64 readSint64 = 0;
+    uint64 readUint64 = 0;
+    float readFloat = 0;
+    double readDouble = 0;
+    char readCString[sizeof(cString)] {};
+    char readStream[sizeof("stream-data")] {};
+    std::list<uint16> readList;
+    std::deque<sint32> readDeque;
+    std::set<uint32> readSet;
+    std::map<uint16, std::string> readMap;
+    EXPECT_EQ(packet.Read(readBool), LLBC_OK);
+    EXPECT_EQ(packet.Read(readSint8), LLBC_OK);
+    EXPECT_EQ(packet.Read(readUint8), LLBC_OK);
+    EXPECT_EQ(packet.Read(readSint16), LLBC_OK);
+    EXPECT_EQ(packet.Read(readUint16), LLBC_OK);
+    EXPECT_EQ(packet.Read(readSint32), LLBC_OK);
+    EXPECT_EQ(packet.Read(readUint32), LLBC_OK);
+    EXPECT_EQ(packet.Read(readLong), LLBC_OK);
+    EXPECT_EQ(packet.Read(readUlong), LLBC_OK);
+    EXPECT_EQ(packet.Read(readSint64), LLBC_OK);
+    EXPECT_EQ(packet.Read(readUint64), LLBC_OK);
+    EXPECT_EQ(packet.Read(readFloat), LLBC_OK);
+    EXPECT_EQ(packet.Read(readDouble), LLBC_OK);
+    EXPECT_EQ(packet.Read(readCString, sizeof(readCString)), LLBC_OK);
+    EXPECT_EQ(packet.Read(readStream, sizeof(readStream)), LLBC_OK);
+    EXPECT_EQ(packet.Read(readList), LLBC_OK);
+    EXPECT_EQ(packet.Read(readDeque), LLBC_OK);
+    EXPECT_EQ(packet.Read(readSet), LLBC_OK);
+    EXPECT_EQ(packet.Read(readMap), LLBC_OK);
+    EXPECT_EQ(readBool, boolValue);
+    EXPECT_EQ(readSint8, sint8Value);
+    EXPECT_EQ(readUint8, uint8Value);
+    EXPECT_EQ(readSint16, sint16Value);
+    EXPECT_EQ(readUint16, uint16Value);
+    EXPECT_EQ(readSint32, sint32Value);
+    EXPECT_EQ(readUint32, uint32Value);
+    EXPECT_EQ(readLong, longValue);
+    EXPECT_EQ(readUlong, ulongValue);
+    EXPECT_EQ(readSint64, sint64Value);
+    EXPECT_EQ(readUint64, uint64Value);
+    EXPECT_FLOAT_EQ(readFloat, floatValue);
+    EXPECT_DOUBLE_EQ(readDouble, doubleValue);
+    EXPECT_STREQ(readCString, cString);
+    EXPECT_STREQ(readStream, "stream-data");
+    EXPECT_EQ(readList, listValue);
+    EXPECT_EQ(readDeque, dequeValue);
+    EXPECT_EQ(readSet, setValue);
+    EXPECT_EQ(readMap, mapValue);
+
+    LLBC_Packet streamOperators;
+    streamOperators << static_cast<sint32>(-99) << std::string("operator-value");
+    sint32 operatorNumber = 0;
+    std::string operatorText;
+    streamOperators >> operatorNumber >> operatorText;
+    EXPECT_EQ(operatorNumber, -99);
+    EXPECT_EQ(operatorText, "operator-value");
+}
+
+// Empty packets must report bounded reads, and ownership transfer methods must
+// leave no dangling payload, coder, result, or codec-error state behind.
+TEST(PacketTest, HandlesEmptyReadsAndExplicitOwnershipTransfers)
+{
+    LLBC_Packet packet;
+    uint32 value = 99;
+    EXPECT_EQ(packet.Read(value), LLBC_FAILED);
+    EXPECT_EQ(value, 0u);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_LIMIT);
+    EXPECT_EQ(packet.Read(nullptr, 1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_LIMIT);
+    EXPECT_TRUE(packet.Encode());
+    EXPECT_TRUE(packet.Decode());
+    EXPECT_EQ(packet.GiveUpPayload(), nullptr);
+    EXPECT_EQ(packet.GetCodecError(), "");
+
+    int failedEncodeCalls = 0;
+    packet.SetEncoder(new TestCoder(&failedEncodeCalls, false));
+    EXPECT_FALSE(packet.Encode());
+    EXPECT_EQ(failedEncodeCalls, 1);
+    delete packet.GiveUpEncoder();
+
+    int failedDecodeCalls = 0;
+    packet.SetDecoder(new TestCoder(&failedDecodeCalls, false));
+    EXPECT_FALSE(packet.Decode());
+    EXPECT_EQ(failedDecodeCalls, 1);
+    delete packet.GiveUpDecoder();
+
+    packet.SetCodecError("first-error");
+    EXPECT_EQ(packet.GetCodecError(), "first-error");
+    packet.SetCodecError("second-error");
+    EXPECT_EQ(packet.GetCodecError(), "second-error");
+
+    int encoderCalls = 0;
+    auto *encoder = new TestCoder(&encoderCalls, true);
+    packet.SetEncoder(encoder);
+    packet.SetEncoder(encoder);
+    EXPECT_EQ(packet.GiveUpEncoder(), encoder);
+    EXPECT_EQ(packet.GetEncoder(), nullptr);
+    delete encoder;
+
+    int decoderCalls = 0;
+    auto *decoder = new TestCoder(&decoderCalls, true);
+    packet.SetDecoder(decoder);
+    packet.SetDecoder(decoder);
+    EXPECT_EQ(packet.GiveUpDecoder(), decoder);
+    EXPECT_EQ(packet.GetDecoder(), nullptr);
+    delete decoder;
+
+    packet.SetEncoder(new TestCoder(&encoderCalls, true));
+    LLBC_MessageBlock *encoded = packet.GiveUpPayload();
+    ASSERT_NE(encoded, nullptr);
+    EXPECT_EQ(encoderCalls, 1);
+    EXPECT_EQ(packet.GetPayload(), nullptr);
+    delete encoded;
+
+    ASSERT_EQ(packet.Write(static_cast<uint32>(123)), LLBC_OK);
+    uint32 consumed = 0;
+    ASSERT_EQ(packet.Read(consumed), LLBC_OK);
+    EXPECT_EQ(consumed, 123u);
+    packet.ResetPayload();
+    EXPECT_EQ(packet.GetPayloadLength(), 0u);
+    packet.Clear();
+    EXPECT_EQ(packet.GetCodecError(), "");
+}
+
+// A normal packet header may arrive in multiple socket reads. The assembler
+// must consume only header bytes, retain partial input, and decode every field
+// into the packet using the configured wire byte order.
+TEST(PacketHeaderAssemblerTest, AssemblesPartialNetworkOrderedHeader)
+{
+    constexpr uint32 length = 4096;
+    constexpr sint32 opcode = -17;
+    constexpr uint16 status = 7;
+    constexpr uint16 flags = 0x35u;
+    constexpr sint64 extData = -1234567890123LL;
+    std::array<char, 20> header {};
+    PutHeaderValue(header, 0, length);
+    PutHeaderValue(header, 4, opcode);
+    PutHeaderValue(header, 8, status);
+    PutHeaderValue(header, 10, flags);
+    PutHeaderValue(header, 12, extData);
+
+    LLBC_PacketHeaderAssembler assembler(header.size());
+    size_t used = 0;
+    EXPECT_FALSE(assembler.Assemble(header.data(), 5, used));
+    EXPECT_EQ(used, 5u);
+    EXPECT_FALSE(assembler.Assemble(header.data() + 5, 9, used));
+    EXPECT_EQ(used, 9u);
+    EXPECT_TRUE(assembler.Assemble(header.data() + 14, header.size() - 14, used));
+    EXPECT_EQ(used, 6u);
+    EXPECT_TRUE(assembler.Assemble(header.data(), 1, used));
+    EXPECT_EQ(used, 0u);
 
     LLBC_Packet packet;
-    ASSERT_EQ(packet.Write(expectedId), LLBC_OK);
-    ASSERT_EQ(packet.Write(expectedLevel), LLBC_OK);
+    assembler.SetToPacket(packet);
+    EXPECT_EQ(packet.GetLength(), length);
+    EXPECT_EQ(packet.GetOpcode(), opcode);
+    EXPECT_EQ(packet.GetStatus(), status);
+    EXPECT_EQ(packet.GetFlags(), flags);
+    EXPECT_EQ(packet.GetExtData1(), extData);
 
-    uint64 actualId = 0;
-    sint32 actualLevel = 0;
-    ASSERT_EQ(packet.Read(actualId), LLBC_OK);
-    ASSERT_EQ(packet.Read(actualLevel), LLBC_OK);
-    EXPECT_EQ(actualId, expectedId);
-    EXPECT_EQ(actualLevel, expectedLevel);
+    assembler.Reset();
+    EXPECT_TRUE(assembler.Assemble(header.data(), header.size(), used));
+    EXPECT_EQ(used, header.size());
+}
+
+// Session options are immutable defaults plus simple value semantics, while
+// poller names are configuration-facing strings and must reject unknown values.
+TEST(CommValueTest, ComparesSessionOptionsAndConvertsPollerTypes)
+{
+    LLBC_SessionOpts options(false, 1, 2, 3, 4, 5);
+    EXPECT_FALSE(options.IsNoDelay());
+    EXPECT_EQ(options.GetSockSendBufSize(), 1u);
+    EXPECT_EQ(options.GetSockRecvBufSize(), 2u);
+    EXPECT_EQ(options.GetSessionSendBufSize(), 3u);
+    EXPECT_EQ(options.GetSessionRecvBufSize(), 4u);
+    EXPECT_EQ(options.GetMaxPacketSize(), 5u);
+
+    LLBC_SessionOpts copy = options;
+    EXPECT_TRUE(copy == options);
+    copy.SetNoDelay(true);
+    copy.SetSockSendBufSize(10);
+    copy.SetSockRecvBufSize(20);
+    copy.SetSessionSendBufSize(30);
+    copy.SetSessionRecvBufSize(40);
+    copy.SetMaxPacketSize(50);
+    EXPECT_FALSE(copy == options);
+    EXPECT_TRUE(copy.IsNoDelay());
+    EXPECT_EQ(copy.GetSockSendBufSize(), 10u);
+    EXPECT_EQ(copy.GetSockRecvBufSize(), 20u);
+    EXPECT_EQ(copy.GetSessionSendBufSize(), 30u);
+    EXPECT_EQ(copy.GetSessionRecvBufSize(), 40u);
+    EXPECT_EQ(copy.GetMaxPacketSize(), 50u);
+    EXPECT_TRUE(LLBC_DftSessionOpts.IsNoDelay());
+
+    EXPECT_TRUE(LLBC_PollerType::IsValid(LLBC_PollerType::SelectPoller));
+    EXPECT_FALSE(LLBC_PollerType::IsValid(LLBC_PollerType::End));
+    EXPECT_FALSE(LLBC_PollerType::IsValid(-1));
+    EXPECT_EQ(LLBC_PollerType::Type2Str(LLBC_PollerType::SelectPoller), "SelectPoller");
+    EXPECT_EQ(LLBC_PollerType::Type2Str(-1), "Invalid");
+    EXPECT_EQ(LLBC_PollerType::Str2Type("selectpoller"), LLBC_PollerType::SelectPoller);
+    EXPECT_EQ(LLBC_PollerType::Str2Type("unknown"), LLBC_PollerType::End);
+}
+
+// Socket addresses are transport values: conversion, copy, padding, and error
+// handling must work without opening a socket or changing process-wide state.
+TEST(SocketDataTypeTest, ConvertsAddressesAndValidatesPadding)
+{
+    LLBC_SockAddr_IN address("127.0.0.1", 12345);
+    EXPECT_EQ(address.GetAddressFamily(), AF_INET);
+    EXPECT_EQ(address.GetIpAsString(), "127.0.0.1");
+    EXPECT_EQ(address.GetIpAsNumber(), 0x7f000001);
+    EXPECT_EQ(address.GetPort(), 12345);
+    EXPECT_EQ(address.ToString(), "127.0.0.1:12345");
+
+    std::ostringstream output;
+    output << address;
+    EXPECT_EQ(output.str(), "127.0.0.1:12345");
+    EXPECT_EQ(address.SetAddressFamily(AF_UNSPEC), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(address.SetAddressFamily(AF_INET), LLBC_OK);
+
+    address.SetIp("10.20.30.40");
+    address.SetPort(54321);
+    EXPECT_EQ(address.GetIpAsString(), "10.20.30.40");
+    EXPECT_EQ(address.GetPort(), 54321);
+    address.SetIp(0x7f000001);
+    EXPECT_EQ(address.GetIpAsString(), "127.0.0.1");
+    address.SetIp(LLBC_String());
+    EXPECT_EQ(address.GetIpAsString(), "127.0.0.1");
+
+    std::array<char, 8> padding {{'p', 'a', 'd', 'd', 'i', 'n', 'g', '!'}};
+    size_t paddingLength = padding.size() - 1;
+    EXPECT_EQ(address.SetPaddingBuf(nullptr, padding.size()), LLBC_FAILED);
+    EXPECT_EQ(address.SetPaddingBuf(padding.data(), paddingLength), LLBC_FAILED);
+    EXPECT_EQ(address.GetPaddingBuf(nullptr, paddingLength), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(address.SetPaddingBuf(padding.data(), padding.size()), LLBC_OK);
+    std::array<char, 8> copiedPadding {};
+    paddingLength = copiedPadding.size();
+    EXPECT_EQ(address.GetPaddingBuf(copiedPadding.data(), paddingLength), LLBC_OK);
+    EXPECT_EQ(paddingLength, copiedPadding.size());
+    EXPECT_EQ(copiedPadding, padding);
+
+    const sockaddr_in osAddress = address.ToOSDataType();
+    LLBC_SockAddr_IN restored;
+    EXPECT_EQ(restored.FromOSDataType(nullptr), LLBC_FAILED);
+    EXPECT_EQ(restored.FromOSDataType(reinterpret_cast<const sockaddr *>(&osAddress),
+                                      sizeof(osAddress) - 1),
+              LLBC_FAILED);
+    EXPECT_EQ(restored.FromOSDataType(&osAddress), LLBC_OK);
+    EXPECT_EQ(restored, address);
+    LLBC_SockAddr_IN assigned;
+    assigned = restored;
+    AssignAddress(assigned, assigned);
+    EXPECT_EQ(assigned, restored);
+    assigned.ZeroPaddingBuf();
+    EXPECT_FALSE(assigned == restored);
 }

--- a/tests/unit_test/comm/UnitTest_Comm_Service.cpp
+++ b/tests/unit_test/comm/UnitTest_Comm_Service.cpp
@@ -1,0 +1,428 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/comm/Service.cpp
+
+namespace
+{
+
+constexpr int RequestOpcode = 7001;
+constexpr int ResponseOpcode = 7002;
+
+struct LoopbackState
+{
+    std::mutex lock;
+    std::condition_variable received;
+    int serverReceiveCount = 0;
+    int clientReceiveCount = 0;
+    int serverSendResult = LLBC_FAILED;
+    int clientConnectedSessionId = 0;
+    int clientDestroyedSessionId = 0;
+    int asyncResultSessionId = 0;
+    bool clientDestroyFromService = false;
+    bool asyncConnected = false;
+    std::string serverPayload;
+    std::string clientPayload;
+    std::string clientDestroyReason;
+    std::string asyncReason;
+    std::string asyncPeerIp;
+    uint16 asyncPeerPort = 0;
+};
+
+class PassThroughCoder final : public LLBC_Coder
+{
+public:
+    bool Encode(LLBC_Packet &packet) override
+    {
+        return true;
+    }
+
+    bool Decode(LLBC_Packet &packet) override
+    {
+        return true;
+    }
+};
+
+class PassThroughCoderFactory final : public LLBC_CoderFactory
+{
+public:
+    LLBC_Coder *Create() const override
+    {
+        return new PassThroughCoder;
+    }
+};
+
+class EchoServerComponent final : public LLBC_Component
+{
+public:
+    explicit EchoServerComponent(LoopbackState &state)
+    : _state(state)
+    {
+    }
+
+    int OnInit(bool &initFinished) override
+    {
+        LLBC_Service *service = GetService();
+        auto *coderFactory = new PassThroughCoderFactory;
+        if (service->AddCoderFactory(RequestOpcode, coderFactory) != LLBC_OK)
+        {
+            delete coderFactory;
+            return LLBC_FAILED;
+        }
+
+        return service->Subscribe(RequestOpcode, this, &EchoServerComponent::OnRequest);
+    }
+
+private:
+    void OnRequest(LLBC_Packet &packet)
+    {
+        const auto *payload = static_cast<const char *>(packet.GetPayload());
+        const size_t payloadLength = packet.GetPayloadLength();
+        const int sendResult = GetService()->Send(
+            packet.GetSessionId(), ResponseOpcode, payload, payloadLength);
+
+        {
+            std::lock_guard<std::mutex> guard(_state.lock);
+            ++_state.serverReceiveCount;
+            _state.serverSendResult = sendResult;
+            _state.serverPayload.assign(payload, payloadLength);
+        }
+        _state.received.notify_all();
+    }
+
+    LoopbackState &_state;
+};
+
+class EchoClientComponent final : public LLBC_Component
+{
+public:
+    explicit EchoClientComponent(LoopbackState &state)
+    : _state(state)
+    {
+    }
+
+    int OnInit(bool &initFinished) override
+    {
+        LLBC_Service *service = GetService();
+        auto *coderFactory = new PassThroughCoderFactory;
+        if (service->AddCoderFactory(ResponseOpcode, coderFactory) != LLBC_OK)
+        {
+            delete coderFactory;
+            return LLBC_FAILED;
+        }
+
+        return service->Subscribe(ResponseOpcode, this, &EchoClientComponent::OnResponse);
+    }
+
+    void OnEvent(int eventType, const LLBC_Variant &eventParams) override
+    {
+        if (eventType == LLBC_ComponentEventType::AsyncConnResult)
+        {
+            const LLBC_AsyncConnResult &result = *eventParams.As<LLBC_AsyncConnResult *>();
+            {
+                std::lock_guard<std::mutex> guard(_state.lock);
+                _state.asyncResultSessionId = result.GetSessionId();
+                _state.asyncConnected = result.IsConnected();
+                _state.asyncReason = result.GetReason().c_str();
+                _state.asyncPeerIp = result.GetPeerAddr().GetIpAsString().c_str();
+                _state.asyncPeerPort = result.GetPeerAddr().GetPort();
+            }
+            _state.received.notify_all();
+            return;
+        }
+
+        if (eventType == LLBC_ComponentEventType::SessionDestroy)
+        {
+            const LLBC_SessionDestroyInfo &destroyInfo =
+                *eventParams.As<LLBC_SessionDestroyInfo *>();
+            if (destroyInfo.IsListenSession())
+                return;
+
+            {
+                std::lock_guard<std::mutex> guard(_state.lock);
+                _state.clientDestroyedSessionId = destroyInfo.GetSessionId();
+                _state.clientDestroyFromService = destroyInfo.IsDestroyedFromService();
+                _state.clientDestroyReason = destroyInfo.GetReason().c_str();
+            }
+            _state.received.notify_all();
+            return;
+        }
+
+        if (eventType != LLBC_ComponentEventType::SessionCreate)
+            return;
+
+        const LLBC_SessionInfo &sessionInfo = *eventParams.As<LLBC_SessionInfo *>();
+        if (sessionInfo.IsListenSession())
+            return;
+
+        {
+            std::lock_guard<std::mutex> guard(_state.lock);
+            _state.clientConnectedSessionId = sessionInfo.GetSessionId();
+        }
+        _state.received.notify_all();
+    }
+
+private:
+    void OnResponse(LLBC_Packet &packet)
+    {
+        const auto *payload = static_cast<const char *>(packet.GetPayload());
+        const size_t payloadLength = packet.GetPayloadLength();
+
+        {
+            std::lock_guard<std::mutex> guard(_state.lock);
+            ++_state.clientReceiveCount;
+            _state.clientPayload.assign(payload, payloadLength);
+        }
+        _state.received.notify_all();
+    }
+
+    LoopbackState &_state;
+};
+
+class ServiceGuard
+{
+public:
+    explicit ServiceGuard(LLBC_Service *service)
+    : _service(service)
+    {
+    }
+
+    ~ServiceGuard()
+    {
+        if (!_service)
+            return;
+
+        if (_service->IsStarted())
+            _service->Stop(true);
+        delete _service;
+    }
+
+    LLBC_Service *Get() const
+    {
+        return _service;
+    }
+
+private:
+    LLBC_Service *_service;
+};
+
+LLBC_Service *StartServerOnAvailablePort(LoopbackState &state,
+                                         uint16 &port,
+                                         std::string &lastFailure)
+{
+    const uint16 firstPort = static_cast<uint16>(35000 + LLBC_GetCurrentProcessId() % 1000);
+    for (uint16 offset = 0; offset < 64; ++offset)
+    {
+        const uint16 candidatePort = static_cast<uint16>(firstPort + offset);
+        const LLBC_String serviceName = LLBC_String().format(
+            "UnitTestCommLoopbackServer-%d-%u", LLBC_GetCurrentProcessId(), offset);
+        LLBC_Service *service = LLBC_Service::Create(serviceName);
+        if (!service)
+            return nullptr;
+
+        if (service->AddComponent(new EchoServerComponent(state)) != LLBC_OK)
+        {
+            lastFailure = LLBC_FormatLastError();
+            delete service;
+            continue;
+        }
+
+        if (service->Listen("127.0.0.1", candidatePort) == 0)
+        {
+            lastFailure = LLBC_FormatLastError();
+            delete service;
+            continue;
+        }
+
+        if (service->Start() != LLBC_OK)
+        {
+            lastFailure = LLBC_FormatLastError();
+            delete service;
+            continue;
+        }
+
+        port = candidatePort;
+        return service;
+    }
+
+    return nullptr;
+}
+
+} // namespace
+
+// A normal-protocol service pair must establish a local session, preserve packet
+// headers across the wire, dispatch handlers, and release both service threads.
+TEST(ServiceTest, ExchangesPacketOverLoopbackAndStopsCleanly)
+{
+    LoopbackState state;
+    uint16 port = 0;
+    std::string serverStartFailure;
+    ServiceGuard server(StartServerOnAvailablePort(state, port, serverStartFailure));
+    ASSERT_NE(server.Get(), nullptr) << serverStartFailure;
+    ASSERT_NE(port, 0u);
+
+    const LLBC_String clientName = LLBC_String().format(
+        "UnitTestCommLoopbackClient-%d", LLBC_GetCurrentProcessId());
+    ServiceGuard client(LLBC_Service::Create(clientName));
+    ASSERT_NE(client.Get(), nullptr);
+    ASSERT_EQ(client.Get()->AddComponent(new EchoClientComponent(state)), LLBC_OK);
+    ASSERT_EQ(client.Get()->Start(), LLBC_OK);
+
+    const int sessionId = client.Get()->Connect("127.0.0.1", port);
+    ASSERT_NE(sessionId, 0);
+
+    std::unique_lock<std::mutex> lock(state.lock);
+    ASSERT_TRUE(state.received.wait_for(lock, std::chrono::seconds(3), [&state, sessionId]
+    {
+        return state.clientConnectedSessionId == sessionId;
+    }));
+    lock.unlock();
+
+    const std::string request = "loopback-packet";
+    ASSERT_EQ(client.Get()->Send(sessionId, RequestOpcode, request.data(), request.size()), LLBC_OK);
+
+    lock.lock();
+    const bool receivedResponse = state.received.wait_for(lock, std::chrono::seconds(3), [&state]
+    {
+        return state.serverReceiveCount == 1 && state.clientReceiveCount == 1;
+    });
+    ASSERT_TRUE(receivedResponse)
+        << "server receives: " << state.serverReceiveCount
+        << ", client receives: " << state.clientReceiveCount
+        << ", server send result: " << state.serverSendResult;
+    EXPECT_EQ(state.serverPayload, request);
+    EXPECT_EQ(state.clientPayload, request);
+    EXPECT_EQ(state.serverSendResult, LLBC_OK);
+    lock.unlock();
+
+    ASSERT_EQ(client.Get()->RemoveSession(sessionId, "unit-test-close"), LLBC_OK);
+    EXPECT_FALSE(client.Get()->IsSessionValidate(sessionId));
+
+    lock.lock();
+    ASSERT_TRUE(state.received.wait_for(lock, std::chrono::seconds(3), [&state, sessionId]
+    {
+        return state.clientDestroyedSessionId == sessionId;
+    }));
+    EXPECT_TRUE(state.clientDestroyFromService);
+    EXPECT_EQ(state.clientDestroyReason, "unit-test-close");
+    lock.unlock();
+
+    EXPECT_EQ(client.Get()->Stop(true), LLBC_OK);
+    EXPECT_EQ(server.Get()->Stop(true), LLBC_OK);
+}
+
+// AsyncConn returns a pending id first. A successful result and SessionCreate
+// event together establish the point at which callers may send application data.
+TEST(ServiceTest, AsyncConnectReportsCompletionBeforePacketExchange)
+{
+    LoopbackState state;
+    uint16 port = 0;
+    std::string serverStartFailure;
+    ServiceGuard server(StartServerOnAvailablePort(state, port, serverStartFailure));
+    ASSERT_NE(server.Get(), nullptr) << serverStartFailure;
+
+    const LLBC_String clientName = LLBC_String().format(
+        "UnitTestCommAsyncClient-%d", LLBC_GetCurrentProcessId());
+    ServiceGuard client(LLBC_Service::Create(clientName));
+    ASSERT_NE(client.Get(), nullptr);
+    ASSERT_EQ(client.Get()->AddComponent(new EchoClientComponent(state)), LLBC_OK);
+    ASSERT_EQ(client.Get()->Start(), LLBC_OK);
+
+    const int sessionId = client.Get()->AsyncConn("127.0.0.1", port);
+    ASSERT_NE(sessionId, 0);
+
+    std::unique_lock<std::mutex> lock(state.lock);
+    ASSERT_TRUE(state.received.wait_for(lock, std::chrono::seconds(3), [&state, sessionId]
+    {
+        return state.asyncResultSessionId == sessionId &&
+            state.clientConnectedSessionId == sessionId;
+    }));
+    EXPECT_TRUE(state.asyncConnected);
+    EXPECT_FALSE(state.asyncReason.empty());
+    EXPECT_EQ(state.asyncPeerIp, "127.0.0.1");
+    EXPECT_EQ(state.asyncPeerPort, port);
+    lock.unlock();
+
+    const std::string request = "async-loopback-packet";
+    ASSERT_EQ(client.Get()->Send(sessionId, RequestOpcode, request.data(), request.size()), LLBC_OK);
+
+    lock.lock();
+    ASSERT_TRUE(state.received.wait_for(lock, std::chrono::seconds(3), [&state]
+    {
+        return state.serverReceiveCount == 1 && state.clientReceiveCount == 1;
+    }));
+    EXPECT_EQ(state.serverPayload, request);
+    EXPECT_EQ(state.clientPayload, request);
+    EXPECT_EQ(state.serverSendResult, LLBC_OK);
+    lock.unlock();
+
+    EXPECT_EQ(client.Get()->Stop(true), LLBC_OK);
+    EXPECT_EQ(server.Get()->Stop(true), LLBC_OK);
+}
+
+// Reserving and then releasing a local ephemeral port gives AsyncConn a bounded
+// loopback refusal path without depending on an external service.
+TEST(ServiceTest, AsyncConnectReportsFailureForUnlistenedPort)
+{
+    LLBC_Socket reservedSocket;
+    ASSERT_TRUE(reservedSocket);
+    ASSERT_EQ(reservedSocket.BindTo("127.0.0.1", 0), LLBC_OK);
+    ASSERT_EQ(reservedSocket.UpdateLocalAddress(), LLBC_OK);
+    const uint16 reservedPort = reservedSocket.GetLocalAddress().GetPort();
+    ASSERT_NE(reservedPort, 0u);
+    ASSERT_EQ(reservedSocket.Close(), LLBC_OK);
+
+    LoopbackState state;
+    const LLBC_String clientName = LLBC_String().format(
+        "UnitTestCommAsyncFailureClient-%d", LLBC_GetCurrentProcessId());
+    ServiceGuard client(LLBC_Service::Create(clientName));
+    ASSERT_NE(client.Get(), nullptr);
+    ASSERT_EQ(client.Get()->AddComponent(new EchoClientComponent(state)), LLBC_OK);
+    ASSERT_EQ(client.Get()->Start(), LLBC_OK);
+
+    const int sessionId = client.Get()->AsyncConn("127.0.0.1", reservedPort);
+    ASSERT_NE(sessionId, 0);
+
+    std::unique_lock<std::mutex> lock(state.lock);
+    ASSERT_TRUE(state.received.wait_for(lock, std::chrono::seconds(3), [&state, sessionId]
+    {
+        return state.asyncResultSessionId == sessionId;
+    }));
+    EXPECT_FALSE(state.asyncConnected);
+    EXPECT_FALSE(state.asyncReason.empty());
+    EXPECT_EQ(state.asyncPeerIp, "127.0.0.1");
+    EXPECT_EQ(state.asyncPeerPort, reservedPort);
+    lock.unlock();
+
+    EXPECT_FALSE(client.Get()->IsSessionValidate(sessionId));
+    EXPECT_EQ(client.Get()->Stop(true), LLBC_OK);
+}

--- a/tests/unit_test/comm/UnitTest_Comm_Socket.cpp
+++ b/tests/unit_test/comm/UnitTest_Comm_Socket.cpp
@@ -1,0 +1,204 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/comm/Socket.cpp
+
+namespace
+{
+
+class SocketPair
+{
+public:
+    bool Connect()
+    {
+        if (listener.EnableAddressReusable() != LLBC_OK ||
+            listener.BindTo("127.0.0.1", 0) != LLBC_OK ||
+            listener.UpdateLocalAddress() != LLBC_OK ||
+            listener.Listen(1) != LLBC_OK)
+        {
+            return false;
+        }
+
+        if (client.Connect(listener.GetLocalAddress()) != LLBC_OK)
+            return false;
+
+        accepted.reset(listener.Accept());
+        return accepted != nullptr;
+    }
+
+    LLBC_Socket listener;
+    LLBC_Socket client;
+    std::unique_ptr<LLBC_Socket> accepted;
+};
+
+uint16 ReserveAndReleaseLoopbackPort()
+{
+    LLBC_Socket reserved;
+    if (!reserved || reserved.BindTo("127.0.0.1", 0) != LLBC_OK ||
+        reserved.UpdateLocalAddress() != LLBC_OK)
+    {
+        return 0;
+    }
+
+    const uint16 port = reserved.GetLocalPort();
+    return reserved.Close() == LLBC_OK ? port : 0;
+}
+
+} // namespace
+
+// Socket state and options are public contracts independent of a running service
+// or poller. Buffer sizes are OS-managed, so only their observable lower bounds
+// and successful option transitions are asserted.
+TEST(SocketTest, CreatesConfiguresQueuesAndCloses)
+{
+    LLBC_Socket socket;
+    ASSERT_TRUE(socket);
+    EXPECT_FALSE(socket.IsClosed());
+    EXPECT_FALSE(!socket);
+    EXPECT_NE(socket.Handle(), LLBC_INVALID_SOCKET_HANDLE);
+    EXPECT_EQ(socket.GetPollerType(), LLBC_PollerType::End);
+
+    socket.SetPollerType(LLBC_PollerType::SelectPoller);
+    EXPECT_EQ(socket.GetPollerType(), LLBC_PollerType::SelectPoller);
+    ASSERT_EQ(socket.EnableAddressReusable(), LLBC_OK);
+    ASSERT_EQ(socket.DisableAddressReusable(), LLBC_OK);
+
+    ASSERT_EQ(socket.SetNoDelay(true), LLBC_OK);
+    EXPECT_TRUE(socket.IsNoDelay());
+    ASSERT_EQ(socket.SetNoDelay(false), LLBC_OK);
+    EXPECT_FALSE(socket.IsNoDelay());
+    ASSERT_EQ(socket.SetNonBlocking(), LLBC_OK);
+    EXPECT_TRUE(socket.IsNonBlocking());
+
+    ASSERT_EQ(socket.SetSendBufSize(8192), LLBC_OK);
+    ASSERT_EQ(socket.SetRecvBufSize(8192), LLBC_OK);
+    EXPECT_GE(socket.GetSendBufSize(), 8192u);
+    EXPECT_GE(socket.GetRecvBufSize(), 8192u);
+
+    int keepAlive = 1;
+    ASSERT_EQ(socket.SetOption(SOL_SOCKET, SO_KEEPALIVE, &keepAlive, sizeof(keepAlive)), LLBC_OK);
+    keepAlive = 0;
+    LLBC_SocketLen optionLength = sizeof(keepAlive);
+    ASSERT_EQ(socket.GetOption(SOL_SOCKET, SO_KEEPALIVE, &keepAlive, &optionLength), LLBC_OK);
+    EXPECT_NE(keepAlive, 0);
+    EXPECT_EQ(optionLength, sizeof(keepAlive));
+
+    ASSERT_EQ(socket.SetMaxPacketSize(4096), LLBC_OK);
+    EXPECT_EQ(socket.GetMaxPacketSize(), 4096u);
+    ASSERT_EQ(socket.SetMaxPacketSize(0), LLBC_OK);
+    EXPECT_EQ(socket.GetMaxPacketSize(), static_cast<size_t>(LLBC_INFINITE));
+
+    ASSERT_EQ(socket.AsyncSend("queued", 6), LLBC_OK);
+    EXPECT_TRUE(socket.IsExistNoSendData());
+    EXPECT_EQ(socket.GetWillSendBuffer().GetSize(), 6u);
+
+    ASSERT_EQ(socket.Close(), LLBC_OK);
+    EXPECT_TRUE(socket.IsClosed());
+    EXPECT_FALSE(socket);
+    EXPECT_EQ(socket.Close(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+}
+
+// A listener and client must establish address caches on both endpoints, accept
+// a peer, exchange bytes in both directions, expose no pending error, and support
+// an orderly half-close without depending on service-owned session callbacks.
+TEST(SocketTest, ConnectsAcceptsExchangesAndShutsDownOverLoopback)
+{
+    SocketPair pair;
+    ASSERT_TRUE(pair.Connect()) << LLBC_FormatLastError();
+    ASSERT_NE(pair.listener.GetLocalPort(), 0u);
+    ASSERT_TRUE(pair.listener.IsListen());
+    ASSERT_NE(pair.accepted, nullptr);
+
+    ASSERT_EQ(pair.accepted->UpdateLocalAddress(), LLBC_OK);
+    ASSERT_EQ(pair.accepted->UpdatePeerAddress(), LLBC_OK);
+    EXPECT_EQ(pair.client.GetLocalHostname(), "127.0.0.1");
+    EXPECT_EQ(pair.client.GetPeerHostname(), "127.0.0.1");
+    EXPECT_EQ(pair.client.GetPeerPort(), pair.listener.GetLocalPort());
+    EXPECT_EQ(pair.accepted->GetLocalPort(), pair.listener.GetLocalPort());
+    EXPECT_EQ(pair.accepted->GetPeerPort(), pair.client.GetLocalPort());
+
+    int pendingError = -1;
+    ASSERT_EQ(pair.client.GetPendingError(pendingError), LLBC_OK);
+    EXPECT_EQ(pendingError, 0);
+
+    const std::string request = "socket-request";
+    ASSERT_EQ(pair.client.Send(request.data(), static_cast<int>(request.size())),
+              static_cast<int>(request.size()));
+    std::string received(request.size(), '\0');
+    ASSERT_EQ(pair.accepted->Recv(&received[0], static_cast<int>(received.size())),
+              static_cast<int>(received.size()));
+    EXPECT_EQ(received, request);
+
+    const std::string response = "socket-response";
+    ASSERT_EQ(pair.accepted->Send(response.data(), static_cast<int>(response.size())),
+              static_cast<int>(response.size()));
+    received.assign(response.size(), '\0');
+    ASSERT_EQ(pair.client.Recv(&received[0], static_cast<int>(received.size())),
+              static_cast<int>(received.size()));
+    EXPECT_EQ(received, response);
+
+    ASSERT_EQ(pair.client.ShutdownInput(), LLBC_OK);
+    ASSERT_EQ(pair.client.ShutdownOutput(), LLBC_OK);
+    char endOfStream = '\0';
+    EXPECT_EQ(pair.accepted->Recv(&endOfStream, 1), 0);
+
+    SocketPair shutdownPair;
+    ASSERT_TRUE(shutdownPair.Connect()) << LLBC_FormatLastError();
+    ASSERT_EQ(shutdownPair.client.ShutdownInputOutput(), LLBC_OK);
+    EXPECT_EQ(shutdownPair.accepted->Recv(&endOfStream, 1), 0);
+}
+
+// A released local port supplies an observable refusal path without involving an
+// external network service. Connect must report the operating-system failure.
+TEST(SocketTest, ReportsFailureWhenPeerDoesNotListen)
+{
+    const uint16 port = ReserveAndReleaseLoopbackPort();
+    ASSERT_NE(port, 0u);
+
+    LLBC_Socket client;
+    ASSERT_TRUE(client);
+    EXPECT_EQ(client.Connect(LLBC_SockAddr_IN("127.0.0.1", port)), LLBC_FAILED);
+    EXPECT_NE(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+}
+
+// A nonblocking listener with no queued peer must return immediately instead
+// of waiting for an incoming connection.
+TEST(SocketTest, NonBlockingAcceptReportsNoQueuedPeer)
+{
+    LLBC_Socket listener;
+    ASSERT_TRUE(listener);
+    ASSERT_EQ(listener.BindTo("127.0.0.1", 0), LLBC_OK);
+    ASSERT_EQ(listener.Listen(1), LLBC_OK);
+    ASSERT_EQ(listener.SetNonBlocking(), LLBC_OK);
+
+    EXPECT_EQ(listener.Accept(), nullptr);
+    EXPECT_NE(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+}


### PR DESCRIPTION
## 概述

覆盖通信组件、Packet、包头组装、Service 和 Socket 的正常及失败路径，并修复网络字节序与未对齐读取问题。

## 内容

### 单元测试

- 覆盖组件回调、Packet 所有权/编解码、分段包头组装。
- 覆盖本地回环同步/异步连接、收发、拒绝连接及非阻塞 accept。

### 库代码修正

- `Packet::WriteRawType`：`LLBC_Host2Net()` 返回转换后的值，原代码忽略返回值，网络序配置下仍写入主机序；保存返回值后再写入，往返测试验证所有标量类型。
- `PacketHeaderAssembler::SetToPacket`：包头字段位于字节缓冲区，`reinterpret_cast` 解引用不能保证对齐，UBSan 在 64 位扩展字段上报错；改用 `memcpy` 到对齐局部变量，字节内容和后续 Net2Host 语义不变。

## 质量保证

- 独立分支：116 tests passed（含 loopback）。
- 最终组合：329 passed，1 skipped。
- UBSan：327/327 passed。