### PR TITLE
test: 补充 File 与 Directory 单元测试并修正文件系统边界

### DIFF
--- a/llbc/src/core/file/Directory_Com.cpp
+++ b/llbc/src/core/file/Directory_Com.cpp
@@ -92,18 +92,25 @@ int LLBC_Directory::Create(const LLBC_String &path)
             continue;
 
 #if LLBC_TARGET_PLATFORM_WIN32
-        if (!::CreateDirectoryA(toPath.c_str(), nullptr) &&
-            ::GetLastError() != ERROR_ALREADY_EXISTS)
+        if (!::CreateDirectoryA(toPath.c_str(), nullptr))
         {
-            LLBC_SetLastError(LLBC_ERROR_OSAPI);
-            return LLBC_FAILED;
+            const DWORD error = ::GetLastError();
+            if (error != ERROR_ALREADY_EXISTS || !Exists(toPath))
+            {
+                LLBC_SetLastError(LLBC_ERROR_OSAPI);
+                return LLBC_FAILED;
+            }
         }
 #else
-        if (mkdir(toPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0 &&
-            errno != EEXIST) // permission: rwxrwxr-x
+        if (mkdir(toPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) != 0)
         {
-            LLBC_SetLastError(LLBC_ERROR_CLIB);
-            return LLBC_FAILED;
+            const int error = errno;
+            if (error != EEXIST || !Exists(toPath)) // permission: rwxrwxr-x
+            {
+                errno = error;
+                LLBC_SetLastError(LLBC_ERROR_CLIB);
+                return LLBC_FAILED;
+            }
         }
 #endif
     }
@@ -404,7 +411,10 @@ int LLBC_Directory::GetFiles(const LLBC_String &path, LLBC_Strings &files, const
             if (!recursive ||
                 (strcmp(".", direntList[procIdx]->d_name) == 0 ||
                 strcmp("..", direntList[procIdx]->d_name) == 0))
+            {
+                free(direntList[procIdx]);
                 continue;
+            }
 
             if (GetFiles(fileName, files, recursive) != LLBC_OK)
             {

--- a/llbc/src/core/file/Directory_NonDarwin.cpp
+++ b/llbc/src/core/file/Directory_NonDarwin.cpp
@@ -169,7 +169,7 @@ LLBC_String LLBC_Directory::HomeDir()
     free(envVal);
 #else // Non-Win32
     char *envVal = getenv("HOME");
-    if (!envVal)
+    if (!envVal || envVal[0] == '\0')
     {
         LLBC_SetLastError(LLBC_ERROR_NOT_FOUND);
         return "";

--- a/llbc/src/core/file/File.cpp
+++ b/llbc/src/core/file/File.cpp
@@ -118,6 +118,25 @@ int LLBC_File::Open(const LLBC_String &path, int mode)
         return LLBC_FAILED;
     }
 
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    struct stat fileStat {};
+    int openErrno = 0;
+    if (fstat(fileno(_handle), &fileStat) != 0)
+        openErrno = errno;
+    else if (S_ISDIR(fileStat.st_mode))
+        openErrno = EISDIR;
+
+    if (openErrno != 0)
+    {
+        fclose(_handle);
+        _handle = LLBC_INVALID_FILE_HANDLE;
+
+        errno = openErrno;
+        LLBC_SetLastError(LLBC_ERROR_CLIB);
+        return LLBC_FAILED;
+    }
+#endif
+
     _mode = mode;
     _path.assign(path.c_str(), path.length());
 
@@ -288,28 +307,6 @@ sint64 LLBC_File::GetFileSize() const
         LLBC_SetLastError(LLBC_ERROR_NOT_OPEN);
         return -1;
     }
-
-#if LLBC_TARGET_PLATFORM_NON_WIN32
-    struct stat fileStat {};
-    const int fileNo = GetFileNo();
-    if (fileNo == -1)
-        return -1;
-
-    if (fstat(fileNo, &fileStat) != 0)
-    {
-        LLBC_SetLastError(LLBC_ERROR_CLIB);
-        return -1;
-    }
-
-    // Directory stream positions are opaque cookies on POSIX and can look like
-    // enormous file sizes. Reject them before ReadToEnd() sizes its buffer.
-    if (S_ISDIR(fileStat.st_mode))
-    {
-        errno = EISDIR;
-        LLBC_SetLastError(LLBC_ERROR_CLIB);
-        return -1;
-    }
-#endif
 
 #if LLBC_TARGET_PLATFORM_WIN32
     const sint64 oldPos = _ftelli64(_handle);
@@ -1008,13 +1005,13 @@ int LLBC_File::CopyFile(const LLBC_String &destFilePath, bool overlapped)
 
 int LLBC_File::CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destFilePath, bool overlapped)
 {
+#if LLBC_TARGET_PLATFORM_WIN32
     if (srcFilePath == destFilePath)
     {
         LLBC_SetLastError(LLBC_ERROR_ARG);
         return LLBC_FAILED;
     }
 
-#if LLBC_TARGET_PLATFORM_WIN32
     if (!::CopyFileA(srcFilePath.c_str(), destFilePath.c_str(), !overlapped))
     {
         LLBC_SetLastError(LLBC_ERROR_OSAPI);
@@ -1023,32 +1020,32 @@ int LLBC_File::CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destF
 
     return LLBC_OK;
 #else // Non_WIN32
-    if (!Exists(srcFilePath))
+    struct stat srcFileStat {};
+    if (stat(srcFilePath.c_str(), &srcFileStat) != 0)
     {
-        LLBC_SetLastError(LLBC_ERROR_NOT_FOUND);
+        LLBC_SetLastError(LLBC_ERROR_CLIB);
         return LLBC_FAILED;
     }
 
-#if LLBC_TARGET_PLATFORM_NON_WIN32
-    struct stat srcFileStat;
-    struct stat destFileStat;
-    if (stat(srcFilePath.c_str(), &srcFileStat) == 0 &&
-        stat(destFilePath.c_str(), &destFileStat) == 0 &&
-        srcFileStat.st_dev == destFileStat.st_dev &&
-        srcFileStat.st_ino == destFileStat.st_ino)
+    struct stat destFileStat {};
+    if (stat(destFilePath.c_str(), &destFileStat) == 0)
     {
-        LLBC_SetLastError(LLBC_ERROR_ARG);
-        return LLBC_FAILED;
+        if (srcFileStat.st_dev == destFileStat.st_dev &&
+            srcFileStat.st_ino == destFileStat.st_ino)
+        {
+            LLBC_SetLastError(LLBC_ERROR_ARG);
+            return LLBC_FAILED;
+        }
+
+        if (!overlapped)
+        {
+            LLBC_SetLastError(LLBC_ERROR_EXIST);
+            return LLBC_FAILED;
+        }
     }
-#endif
-
-    LLBC_FileAttributes srcFileAttrs {};
-    if (GetFileAttributes(srcFilePath, srcFileAttrs) != LLBC_OK)
-        return LLBC_FAILED;
-
-    if (srcFileAttrs.isDirectory)
+    else if (errno != ENOENT)
     {
-        LLBC_SetLastError(LLBC_ERROR_NOT_ALLOW);
+        LLBC_SetLastError(LLBC_ERROR_CLIB);
         return LLBC_FAILED;
     }
 
@@ -1060,13 +1057,6 @@ int LLBC_File::CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destF
     const sint64 srcFileSize = srcFile.GetFileSize();
     if (srcFileSize < 0)
         return LLBC_FAILED;
-
-    // Check dest file exist or not.
-    if (!overlapped && Exists(destFilePath))
-    {
-        LLBC_SetLastError(LLBC_ERROR_EXIST);
-        return LLBC_FAILED;
-    }
 
     // Open dest file with BinaryWrite mode.
     LLBC_File destFile(destFilePath, LLBC_FileMode::BinaryWrite);

--- a/llbc/src/core/file/File.cpp
+++ b/llbc/src/core/file/File.cpp
@@ -289,6 +289,28 @@ sint64 LLBC_File::GetFileSize() const
         return -1;
     }
 
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    struct stat fileStat {};
+    const int fileNo = GetFileNo();
+    if (fileNo == -1)
+        return -1;
+
+    if (fstat(fileNo, &fileStat) != 0)
+    {
+        LLBC_SetLastError(LLBC_ERROR_CLIB);
+        return -1;
+    }
+
+    // Directory stream positions are opaque cookies on POSIX and can look like
+    // enormous file sizes. Reject them before ReadToEnd() sizes its buffer.
+    if (S_ISDIR(fileStat.st_mode))
+    {
+        errno = EISDIR;
+        LLBC_SetLastError(LLBC_ERROR_CLIB);
+        return -1;
+    }
+#endif
+
 #if LLBC_TARGET_PLATFORM_WIN32
     const sint64 oldPos = _ftelli64(_handle);
     if (_fseeki64(_handle, 0, LLBC_FileSeekOrigin::End) != 0)
@@ -391,7 +413,10 @@ sint64 LLBC_File::OffsetFilePosition(sint64 offset)
     if (UNLIKELY(curPos == -1))
         return LLBC_FAILED;
 
-    return SetFilePosition(curPos + offset);
+    if (SetFilePosition(curPos + offset) != LLBC_OK)
+        return LLBC_FAILED;
+
+    return GetFilePosition();
 }
 
 sint64 LLBC_File::GetReadableSize() const
@@ -457,8 +482,16 @@ LLBC_Strings LLBC_File::ReadLns()
         return LLBC_Strings();
     }
 
-    // File position check.
-    if (UNLIKELY(GetFilePosition() == GetFileSize()))
+    // File position/size check.
+    const sint64 filePosition = GetFilePosition();
+    if (UNLIKELY(filePosition == -1))
+        return LLBC_Strings();
+
+    const sint64 fileSize = GetFileSize();
+    if (UNLIKELY(fileSize == -1))
+        return LLBC_Strings();
+
+    if (UNLIKELY(filePosition == fileSize))
     {
         LLBC_SetLastError(LLBC_ERROR_TRUNCATED);
         return LLBC_Strings();
@@ -975,6 +1008,12 @@ int LLBC_File::CopyFile(const LLBC_String &destFilePath, bool overlapped)
 
 int LLBC_File::CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destFilePath, bool overlapped)
 {
+    if (srcFilePath == destFilePath)
+    {
+        LLBC_SetLastError(LLBC_ERROR_ARG);
+        return LLBC_FAILED;
+    }
+
 #if LLBC_TARGET_PLATFORM_WIN32
     if (!::CopyFileA(srcFilePath.c_str(), destFilePath.c_str(), !overlapped))
     {
@@ -990,9 +1029,36 @@ int LLBC_File::CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destF
         return LLBC_FAILED;
     }
 
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    struct stat srcFileStat;
+    struct stat destFileStat;
+    if (stat(srcFilePath.c_str(), &srcFileStat) == 0 &&
+        stat(destFilePath.c_str(), &destFileStat) == 0 &&
+        srcFileStat.st_dev == destFileStat.st_dev &&
+        srcFileStat.st_ino == destFileStat.st_ino)
+    {
+        LLBC_SetLastError(LLBC_ERROR_ARG);
+        return LLBC_FAILED;
+    }
+#endif
+
+    LLBC_FileAttributes srcFileAttrs {};
+    if (GetFileAttributes(srcFilePath, srcFileAttrs) != LLBC_OK)
+        return LLBC_FAILED;
+
+    if (srcFileAttrs.isDirectory)
+    {
+        LLBC_SetLastError(LLBC_ERROR_NOT_ALLOW);
+        return LLBC_FAILED;
+    }
+
     // Open source file with BinaryRead mode.
     LLBC_File srcFile(srcFilePath, LLBC_FileMode::BinaryRead);
     if (!srcFile.IsOpened())
+        return LLBC_FAILED;
+
+    const sint64 srcFileSize = srcFile.GetFileSize();
+    if (srcFileSize < 0)
         return LLBC_FAILED;
 
     // Check dest file exist or not.
@@ -1007,7 +1073,6 @@ int LLBC_File::CopyFile(const LLBC_String &srcFilePath, const LLBC_String &destF
     if (!destFile.IsOpened())
         return LLBC_FAILED;
 
-    sint64 srcFileSize = srcFile.GetFileSize();
     if (srcFileSize == 0)
         return LLBC_OK;
 
@@ -1108,8 +1173,9 @@ int LLBC_File::DeleteFile()
         return LLBC_FAILED;
     }
 
+    const LLBC_String filePath(_path);
     Close();
-    return DeleteFile(_path);
+    return DeleteFile(filePath);
 }
 
 int LLBC_File::DeleteFile(const LLBC_String &filePath)

--- a/tests/unit_test/core/file/UnitTest_Core_File_Directory.cpp
+++ b/tests/unit_test/core/file/UnitTest_Core_File_Directory.cpp
@@ -1,0 +1,502 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+#include <unistd.h>
+#endif
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/file/Directory_*
+
+namespace
+{
+
+class ScopedDirectoryTree
+{
+public:
+    ScopedDirectoryTree()
+    : _root(std::filesystem::temp_directory_path() /
+            ("llbc_unit_directory_" +
+             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())))
+    {
+    }
+
+    ~ScopedDirectoryTree()
+    {
+        std::error_code ignored;
+        std::filesystem::remove_all(_root, ignored);
+    }
+
+    LLBC_String Root() const
+    {
+        return LLBC_String(_root.string().c_str());
+    }
+
+    LLBC_String Path(const LLBC_String &child) const
+    {
+        return LLBC_Directory::Join(Root(), child);
+    }
+
+private:
+    std::filesystem::path _root;
+};
+
+class ScopedPermissions
+{
+public:
+    explicit ScopedPermissions(const std::filesystem::path &path)
+    : _path(path)
+    {
+        std::error_code error;
+        _original = std::filesystem::status(_path, error).permissions();
+        _valid = !error;
+    }
+
+    bool Set(std::filesystem::perms permissions, std::error_code &error)
+    {
+        if (!_valid)
+        {
+            error = std::make_error_code(std::errc::invalid_argument);
+            return false;
+        }
+
+        std::filesystem::permissions(
+            _path, permissions, std::filesystem::perm_options::replace, error);
+        _restore = !error;
+        return !error;
+    }
+
+    ~ScopedPermissions()
+    {
+        if (!_restore)
+            return;
+
+        std::error_code ignored;
+        std::filesystem::permissions(
+            _path, _original, std::filesystem::perm_options::replace, ignored);
+    }
+
+private:
+    std::filesystem::path _path;
+    std::filesystem::perms _original {};
+    bool _valid = false;
+    bool _restore = false;
+};
+
+class ScopedCurrentDirectory
+{
+public:
+    ScopedCurrentDirectory()
+    : _original(LLBC_Directory::CurDir())
+    {
+    }
+
+    bool Enter(const LLBC_String &path)
+    {
+        if (_original.empty() || LLBC_Directory::SetCurDir(path) != LLBC_OK)
+            return false;
+
+        _restore = true;
+        return true;
+    }
+
+    ~ScopedCurrentDirectory()
+    {
+        if (_restore)
+            LLBC_Directory::SetCurDir(_original);
+    }
+
+private:
+    LLBC_String _original;
+    bool _restore = false;
+};
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+class ScopedEnvironmentVariable
+{
+public:
+    explicit ScopedEnvironmentVariable(const char *name)
+    : _name(name)
+    {
+        if (const char *value = std::getenv(_name.c_str()))
+        {
+            _hadValue = true;
+            _value = value;
+        }
+    }
+
+    ~ScopedEnvironmentVariable()
+    {
+        if (_hadValue)
+            ::setenv(_name.c_str(), _value.c_str(), 1);
+        else
+            ::unsetenv(_name.c_str());
+    }
+
+    int Set(const char *value) const
+    {
+        return ::setenv(_name.c_str(), value, 1);
+    }
+
+    int Unset() const
+    {
+        return ::unsetenv(_name.c_str());
+    }
+
+private:
+    std::string _name;
+    std::string _value;
+    bool _hadValue = false;
+};
+#endif
+
+void SortStrings(LLBC_Strings &values)
+{
+    std::sort(values.begin(), values.end());
+}
+
+std::vector<std::string> ToStdStrings(const LLBC_Strings &values)
+{
+    std::vector<std::string> converted;
+    converted.reserve(values.size());
+    for (const auto &value : values)
+        converted.emplace_back(value.c_str(), value.size());
+
+    return converted;
+}
+
+} // namespace
+
+// Path helpers are used across file/configuration APIs. Verify their lexical
+// behavior without depending on the contents of the host working directory.
+TEST(DirectoryTest, NormalizesJoinsSplitsAndReportsRuntimeDirectories)
+{
+    const LLBC_String current = LLBC_Directory::CurDir();
+    ASSERT_FALSE(current.empty());
+    EXPECT_TRUE(LLBC_Directory::Exists(current));
+    EXPECT_FALSE(LLBC_Directory::IsAbsPath(""));
+    EXPECT_TRUE(LLBC_Directory::IsAbsPath("/"));
+    EXPECT_EQ(LLBC_Directory::AbsPath(""), current);
+    EXPECT_EQ(LLBC_Directory::AbsPath("/"), "/");
+    EXPECT_EQ(LLBC_Directory::AbsPath("alpha/./beta/../gamma"),
+              LLBC_Directory::Join(current, "alpha/gamma"));
+    EXPECT_EQ(LLBC_Directory::AbsPath("/tmp///"), "/tmp");
+
+    EXPECT_EQ(LLBC_Directory::Join("", "beta"), "beta");
+    EXPECT_EQ(LLBC_Directory::Join("alpha", "beta"), "alpha/beta");
+    EXPECT_EQ(LLBC_Directory::Join("alpha/", "/beta"), "alpha/beta");
+    EXPECT_EQ(LLBC_Directory::Join(LLBC_Strings {"alpha", "beta", "gamma"}),
+              "alpha/beta/gamma");
+    EXPECT_EQ(LLBC_Directory::Join("alpha", "beta", "gamma", "delta"),
+              "alpha/beta/gamma/delta");
+
+    const auto split = LLBC_Directory::SplitExt("/tmp/archive.tar.gz");
+    ASSERT_EQ(split.size(), 2lu);
+    EXPECT_EQ(split[0], "/tmp/archive.tar");
+    EXPECT_EQ(split[1], ".gz");
+    const auto noExtension = LLBC_Directory::SplitExt("README");
+    ASSERT_EQ(noExtension.size(), 2lu);
+    EXPECT_EQ(noExtension[0], "README");
+    EXPECT_TRUE(noExtension[1].empty());
+    EXPECT_EQ(LLBC_Directory::DirName("/"), "/");
+    EXPECT_TRUE(LLBC_Directory::BaseName("/").empty());
+    EXPECT_EQ(LLBC_Directory::DirName("/usr/local/bin/tool"), "/usr/local/bin");
+    EXPECT_EQ(LLBC_Directory::BaseName("/usr/local/bin/tool"), "tool");
+    EXPECT_EQ(LLBC_Directory::DirName("plain"), "");
+    EXPECT_EQ(LLBC_Directory::BaseName("plain"), "plain");
+
+    const LLBC_String rawModulePath = LLBC_Directory::ModuleFilePath(false);
+    const LLBC_String modulePath = LLBC_Directory::ModuleFilePath();
+    const LLBC_String moduleDir = LLBC_Directory::ModuleFileDir();
+    const LLBC_String moduleName = LLBC_Directory::ModuleFileName();
+    EXPECT_FALSE(rawModulePath.empty());
+    EXPECT_FALSE(modulePath.empty());
+    EXPECT_FALSE(moduleDir.empty());
+    EXPECT_FALSE(moduleName.empty());
+    EXPECT_EQ(LLBC_Directory::Join(moduleDir, moduleName), modulePath);
+
+    EXPECT_FALSE(LLBC_Directory::HomeDir().empty());
+    EXPECT_FALSE(LLBC_Directory::TempDir().empty());
+    EXPECT_FALSE(LLBC_Directory::CacheDir().empty());
+    EXPECT_FALSE(LLBC_Directory::DocDir().empty());
+    EXPECT_EQ(LLBC_Directory::SetCurDir(current), LLBC_OK);
+    EXPECT_EQ(LLBC_Directory::SetCurDir(""), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+    EXPECT_EQ(LLBC_Directory::SetCurDir("/definitely/not/a/real/llbc-directory"), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+}
+
+// Recursive create/list/remove is the common deployment and cache-cleanup
+// workflow. Directory::Create must reject a pre-existing regular file rather
+// than reporting a nonexistent directory as successfully created.
+TEST(DirectoryTest, CreatesEnumeratesFiltersAndRecursivelyRemovesTrees)
+{
+    ScopedDirectoryTree tree;
+    const LLBC_String root = tree.Root();
+    const LLBC_String nested = tree.Path("nested/inner");
+
+    EXPECT_EQ(LLBC_Directory::Create(""), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+    EXPECT_EQ(LLBC_Directory::Create(root + "//invalid"), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+    ASSERT_EQ(LLBC_Directory::Create(nested), LLBC_OK);
+    EXPECT_TRUE(LLBC_Directory::Exists(root));
+    EXPECT_TRUE(LLBC_Directory::Exists(nested));
+
+    LLBC_Strings files;
+    ASSERT_EQ(LLBC_Directory::GetFiles(root, files, ".txt"), LLBC_OK);
+    EXPECT_TRUE(files.empty());
+    LLBC_Strings directories;
+    ASSERT_EQ(LLBC_Directory::GetDirectories(root, directories), LLBC_OK);
+    ASSERT_EQ(directories.size(), 1lu);
+    EXPECT_EQ(directories[0], tree.Path("nested"));
+
+    const LLBC_String filePath = tree.Path("regular-file");
+    ASSERT_EQ(LLBC_File::TouchFile(filePath), LLBC_OK);
+    EXPECT_EQ(LLBC_Directory::Create(filePath), LLBC_FAILED);
+    EXPECT_FALSE(LLBC_Directory::Exists(filePath));
+
+    const LLBC_String rootText = tree.Path("root.txt");
+    const LLBC_String rootLog = tree.Path("root.log");
+    const LLBC_String nestedText = tree.Path("nested/child.txt");
+    const LLBC_String nestedLog = tree.Path("nested/inner/child.log");
+    ASSERT_EQ(LLBC_File::TouchFile(rootText), LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile(rootLog), LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile(nestedText), LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile(nestedLog), LLBC_OK);
+
+    files.clear();
+    ASSERT_EQ(LLBC_Directory::GetFiles(root, files), LLBC_OK);
+    SortStrings(files);
+    EXPECT_EQ(ToStdStrings(files),
+              std::vector<std::string>({filePath.c_str(), rootLog.c_str(), rootText.c_str()}));
+
+    files.clear();
+    ASSERT_EQ(LLBC_Directory::GetFiles(root, files, true), LLBC_OK);
+    SortStrings(files);
+    EXPECT_EQ(ToStdStrings(files),
+              std::vector<std::string>({
+                  nestedText.c_str(), nestedLog.c_str(), filePath.c_str(), rootLog.c_str(), rootText.c_str()}));
+
+    files.clear();
+    ASSERT_EQ(LLBC_Directory::GetFiles(root, files, ".txt", true), LLBC_OK);
+    SortStrings(files);
+    EXPECT_EQ(ToStdStrings(files), std::vector<std::string>({nestedText.c_str(), rootText.c_str()}));
+
+    directories.clear();
+    ASSERT_EQ(LLBC_Directory::GetDirectories(root, directories), LLBC_OK);
+    ASSERT_EQ(directories.size(), 1lu);
+    EXPECT_EQ(directories[0], tree.Path("nested"));
+
+    directories.clear();
+    ASSERT_EQ(LLBC_Directory::GetDirectories(root, directories, true), LLBC_OK);
+    SortStrings(directories);
+    EXPECT_EQ(ToStdStrings(directories),
+              std::vector<std::string>({tree.Path("nested").c_str(), nested.c_str()}));
+
+    files.clear();
+    EXPECT_EQ(LLBC_Directory::GetFiles(tree.Path("missing"), files, true), LLBC_FAILED);
+    EXPECT_TRUE(files.empty());
+    EXPECT_EQ(LLBC_Directory::Remove(tree.Path("missing")), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+
+    ASSERT_EQ(LLBC_Directory::Remove(root), LLBC_OK);
+    EXPECT_FALSE(LLBC_Directory::Exists(root));
+}
+
+// Directory enumeration must fail transactionally if an entry disappears or
+// cannot be stat'ed during traversal. A dangling symlink models this common
+// deployment race without mutating paths outside the test-owned tree.
+TEST(DirectoryTest, ClearsEnumerationResultsForDanglingEntriesAndInvalidRoots)
+{
+    ScopedDirectoryTree tree;
+    const LLBC_String root = tree.Root();
+    ASSERT_EQ(LLBC_Directory::Create(root), LLBC_OK);
+
+    const auto danglingPath = std::filesystem::path(root.c_str()) / "a-dangling";
+    const LLBC_String directSurvivor = tree.Path("z-survivor");
+    std::error_code symlinkError;
+    std::filesystem::create_symlink("missing-target", danglingPath, symlinkError);
+    if (symlinkError)
+        GTEST_SKIP() << "unable to create dangling symlink: " << symlinkError.message();
+    ASSERT_EQ(LLBC_File::TouchFile(directSurvivor), LLBC_OK);
+
+    LLBC_Strings files {"stale"};
+    EXPECT_EQ(LLBC_Directory::GetFiles(root, files, true), LLBC_FAILED);
+    EXPECT_TRUE(files.empty());
+
+    LLBC_Strings directories {"stale"};
+    EXPECT_EQ(LLBC_Directory::GetDirectories(root, directories, true), LLBC_FAILED);
+    EXPECT_TRUE(directories.empty());
+
+    EXPECT_EQ(LLBC_Directory::Remove(root), LLBC_FAILED);
+    EXPECT_TRUE(LLBC_Directory::Exists(root));
+
+    std::filesystem::remove(danglingPath, symlinkError);
+    ASSERT_FALSE(symlinkError);
+    ASSERT_EQ(LLBC_File::DeleteFile(directSurvivor), LLBC_OK);
+
+    const LLBC_String nested = tree.Path("nested");
+    ASSERT_EQ(LLBC_Directory::Create(nested), LLBC_OK);
+    const auto nestedDanglingPath = std::filesystem::path(nested.c_str()) / "a-dangling";
+    const LLBC_String nestedSurvivor = LLBC_Directory::Join(nested, "z-survivor");
+    std::filesystem::create_symlink("missing-target", nestedDanglingPath, symlinkError);
+    ASSERT_FALSE(symlinkError);
+    ASSERT_EQ(LLBC_File::TouchFile(nestedSurvivor), LLBC_OK);
+
+    files = {"stale"};
+    EXPECT_EQ(LLBC_Directory::GetFiles(root, files, true), LLBC_FAILED);
+    EXPECT_TRUE(files.empty());
+    directories = {"stale"};
+    EXPECT_EQ(LLBC_Directory::GetDirectories(root, directories, true), LLBC_FAILED);
+    EXPECT_TRUE(directories.empty());
+
+    std::filesystem::remove(nestedDanglingPath, symlinkError);
+    ASSERT_FALSE(symlinkError);
+    ASSERT_EQ(LLBC_File::DeleteFile(nestedSurvivor), LLBC_OK);
+
+    const LLBC_String regularFile = tree.Path("not-a-directory");
+    ASSERT_EQ(LLBC_File::TouchFile(regularFile), LLBC_OK);
+    LLBC_Strings invalidRootDirectories;
+    EXPECT_EQ(LLBC_Directory::GetDirectories(regularFile, invalidRootDirectories), LLBC_FAILED);
+    EXPECT_TRUE(invalidRootDirectories.empty());
+
+    ASSERT_EQ(LLBC_Directory::Remove(root), LLBC_OK);
+}
+
+// Recursive cleanup must surface the operation that cannot mutate the
+// test-owned tree. Permission scopes are restored automatically so the test
+// leaves no inaccessible temporary paths behind.
+TEST(DirectoryTest, ReportsPermissionFailuresDuringRecursiveRemoval)
+{
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    if (::geteuid() == 0)
+        GTEST_SKIP() << "root bypasses directory permission checks";
+
+    ScopedDirectoryTree tree;
+    const LLBC_String root = tree.Root();
+    ASSERT_EQ(LLBC_Directory::Create(root), LLBC_OK);
+
+    const LLBC_String nestedTarget = tree.Path("nested-target");
+    ASSERT_EQ(LLBC_Directory::Create(LLBC_Directory::Join(nestedTarget, "child")), LLBC_OK);
+    {
+        ScopedPermissions permissions(std::filesystem::path(nestedTarget.c_str()));
+        std::error_code error;
+        ASSERT_TRUE(permissions.Set(std::filesystem::perms::owner_read |
+                                        std::filesystem::perms::owner_exec,
+                                    error))
+            << error.message();
+        EXPECT_EQ(LLBC_Directory::Remove(nestedTarget), LLBC_FAILED);
+        EXPECT_TRUE(LLBC_Directory::Exists(nestedTarget));
+    }
+    ASSERT_EQ(LLBC_Directory::Remove(nestedTarget), LLBC_OK);
+
+    const LLBC_String emptyTarget = tree.Path("empty-target");
+    ASSERT_EQ(LLBC_Directory::Create(emptyTarget), LLBC_OK);
+    {
+        ScopedPermissions permissions(std::filesystem::path(root.c_str()));
+        std::error_code error;
+        ASSERT_TRUE(permissions.Set(std::filesystem::perms::owner_read |
+                                        std::filesystem::perms::owner_exec,
+                                    error))
+            << error.message();
+        EXPECT_EQ(LLBC_Directory::Remove(emptyTarget), LLBC_FAILED);
+        EXPECT_TRUE(LLBC_Directory::Exists(emptyTarget));
+    }
+    ASSERT_EQ(LLBC_Directory::Remove(emptyTarget), LLBC_OK);
+
+    const LLBC_String fileTarget = tree.Path("file-target");
+    ASSERT_EQ(LLBC_Directory::Create(fileTarget), LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile(LLBC_Directory::Join(fileTarget, "locked-file")), LLBC_OK);
+    {
+        ScopedPermissions permissions(std::filesystem::path(fileTarget.c_str()));
+        std::error_code error;
+        ASSERT_TRUE(permissions.Set(std::filesystem::perms::owner_read |
+                                        std::filesystem::perms::owner_exec,
+                                    error))
+            << error.message();
+        EXPECT_EQ(LLBC_Directory::Remove(fileTarget), LLBC_FAILED);
+        EXPECT_TRUE(LLBC_Directory::Exists(fileTarget));
+    }
+    ASSERT_EQ(LLBC_Directory::Remove(fileTarget), LLBC_OK);
+#else
+    GTEST_SKIP() << "permission semantics are platform-specific";
+#endif
+}
+
+// getcwd() can fail when a process remains in a directory that has been
+// removed by a deployment cleanup. Restore the original process directory via
+// RAII so this host-global condition is contained to the test.
+TEST(DirectoryTest, ReportsDeletedCurrentDirectory)
+{
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedDirectoryTree tree;
+    const LLBC_String removedCwd = tree.Path("removed-cwd");
+    ASSERT_EQ(LLBC_Directory::Create(removedCwd), LLBC_OK);
+
+    ScopedCurrentDirectory currentDirectory;
+    ASSERT_TRUE(currentDirectory.Enter(removedCwd));
+
+    std::error_code error;
+    std::filesystem::remove(std::filesystem::path(removedCwd.c_str()), error);
+    ASSERT_FALSE(error) << error.message();
+    EXPECT_TRUE(LLBC_Directory::CurDir().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+#else
+    GTEST_SKIP() << "deleted-current-directory behavior is POSIX-specific";
+#endif
+}
+
+// HOME may be absent in services, containers, and sandboxed processes. Empty
+// values must be handled as absent before normalizing a trailing separator.
+TEST(DirectoryTest, HandlesMissingEmptyAndTrailingSlashHomeEnvironment)
+{
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedEnvironmentVariable home("HOME");
+
+    ASSERT_EQ(home.Unset(), 0);
+    EXPECT_TRUE(LLBC_Directory::HomeDir().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+
+    ASSERT_EQ(home.Set(""), 0);
+    EXPECT_TRUE(LLBC_Directory::HomeDir().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+
+    ASSERT_EQ(home.Set("/tmp/llbc-home/"), 0);
+    EXPECT_EQ(LLBC_Directory::HomeDir(), "/tmp/llbc-home");
+    ASSERT_EQ(home.Set("/"), 0);
+    EXPECT_EQ(LLBC_Directory::HomeDir(), "/");
+#else
+    GTEST_SKIP() << "HOME environment semantics are POSIX-specific";
+#endif
+}

--- a/tests/unit_test/core/file/UnitTest_Core_File_File.cpp
+++ b/tests/unit_test/core/file/UnitTest_Core_File_File.cpp
@@ -1,0 +1,1068 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/file/File.cpp
+// @coverage-target: llbc/include/llbc/core/file/FileInl.h
+
+namespace
+{
+
+class ScopedTempFiles
+{
+public:
+    ScopedTempFiles()
+    : _base(std::filesystem::temp_directory_path() /
+            ("llbc_unit_file_" +
+             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())))
+    {
+    }
+
+    ~ScopedTempFiles()
+    {
+        std::error_code ignored;
+        static const char *suffixes[] = {
+            "",
+            ".copy",
+            ".moved",
+            ".touch",
+            ".text",
+            ".reopen",
+            ".raw",
+            ".crlf",
+            ".empty",
+            ".format",
+            ".append",
+            ".instance-copy",
+            ".instance-moved",
+            ".empty-copy",
+            ".move-source",
+            ".move-destination",
+            ".auto",
+            ".auto-binary",
+            ".readonly",
+            ".writeonly",
+            ".append-binary",
+            ".directory-copy",
+            ".restricted-copy-source",
+            ".restricted-copy-destination",
+            ".hard-link-source",
+            ".hard-link-destination",
+        };
+
+        for (const char *suffix : suffixes)
+            std::filesystem::remove(_base.string() + suffix, ignored);
+
+        std::filesystem::remove(_base.parent_path() /
+                                    ("." + _base.filename().string() + ".hidden"),
+                                ignored);
+    }
+
+    LLBC_String Path(const char *suffix = "") const
+    {
+        return LLBC_String((_base.string() + suffix).c_str());
+    }
+
+    LLBC_String HiddenPath() const
+    {
+        const auto path = _base.parent_path() /
+                          ("." + _base.filename().string() + ".hidden");
+        return LLBC_String(path.string().c_str());
+    }
+
+private:
+    std::filesystem::path _base;
+};
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+class ScopedPipe
+{
+public:
+    bool Create()
+    {
+        return ::pipe(_fds) == 0;
+    }
+
+    ~ScopedPipe()
+    {
+        if (_fds[0] != -1)
+            ::close(_fds[0]);
+        if (_fds[1] != -1)
+            ::close(_fds[1]);
+    }
+
+    int ReadFd() const
+    {
+        return _fds[0];
+    }
+
+    int WriteFd() const
+    {
+        return _fds[1];
+    }
+
+    void CloseWrite()
+    {
+        if (_fds[1] != -1)
+        {
+            ::close(_fds[1]);
+            _fds[1] = -1;
+        }
+    }
+
+private:
+    int _fds[2] = {-1, -1};
+};
+
+class ScopedSignalIgnore
+{
+public:
+    bool Begin(int signalNumber)
+    {
+        struct sigaction action = {};
+        action.sa_handler = SIG_IGN;
+        sigemptyset(&action.sa_mask);
+
+        if (sigaction(signalNumber, &action, &_previous) != 0)
+            return false;
+
+        _signalNumber = signalNumber;
+        _active = true;
+        return true;
+    }
+
+    ~ScopedSignalIgnore()
+    {
+        if (_active)
+            sigaction(_signalNumber, &_previous, nullptr);
+    }
+
+private:
+    struct sigaction _previous = {};
+    int _signalNumber = 0;
+    bool _active = false;
+};
+
+class ScopedFifo
+{
+public:
+    bool Begin(const LLBC_String &path)
+    {
+        if (mkfifo(path.c_str(), S_IRUSR | S_IWUSR) != 0)
+            return false;
+
+        _path = path.c_str();
+        _readFd = open(_path.c_str(), O_RDONLY | O_NONBLOCK);
+        if (_readFd != -1)
+            return true;
+
+        unlink(_path.c_str());
+        _path.clear();
+        return false;
+    }
+
+    void CloseRead()
+    {
+        if (_readFd != -1)
+        {
+            close(_readFd);
+            _readFd = -1;
+        }
+    }
+
+    bool OpenWrite()
+    {
+        _writeFd = open(_path.c_str(), O_WRONLY | O_NONBLOCK);
+        return _writeFd != -1;
+    }
+
+    ~ScopedFifo()
+    {
+        CloseRead();
+        if (_writeFd != -1)
+            close(_writeFd);
+        if (!_path.empty())
+            unlink(_path.c_str());
+    }
+
+private:
+    std::string _path;
+    int _readFd = -1;
+    int _writeFd = -1;
+};
+
+class ScopedFilePermissions
+{
+public:
+    explicit ScopedFilePermissions(const std::filesystem::path &path)
+    : _path(path)
+    {
+        std::error_code error;
+        _original = std::filesystem::status(_path, error).permissions();
+        _valid = !error;
+    }
+
+    bool Set(std::filesystem::perms permissions, std::error_code &error)
+    {
+        if (!_valid)
+        {
+            error = std::make_error_code(std::errc::invalid_argument);
+            return false;
+        }
+
+        std::filesystem::permissions(
+            _path, permissions, std::filesystem::perm_options::replace, error);
+        _restore = !error;
+        return !error;
+    }
+
+    ~ScopedFilePermissions()
+    {
+        if (!_restore)
+            return;
+
+        std::error_code ignored;
+        std::filesystem::permissions(
+            _path, _original, std::filesystem::perm_options::replace, ignored);
+    }
+
+private:
+    std::filesystem::path _path;
+    std::filesystem::perms _original {};
+    bool _valid = false;
+    bool _restore = false;
+};
+#endif
+
+} // namespace
+
+// File modes and unopened-handle errors define the basic API contract before a
+// file is opened.
+TEST(FileTest, DescribesModesAndRejectsUnopenedOrInvalidOperations)
+{
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::TextRead), "TextRead");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::BinaryRead), "BinaryRead");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::TextWrite), "TextWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::BinaryWrite), "BinaryWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::TextReadWrite), "TextReadWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::BinaryReadWrite), "BinaryReadWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::TextAppendWrite), "TextAppendWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::BinaryAppendWrite), "BinaryAppendWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::TextAppendReadWrite),
+              "TextAppendReadWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::BinaryAppendReadWrite),
+              "BinaryAppendReadWrite");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(LLBC_FileMode::LastestMode), "LastestMode");
+    EXPECT_EQ(LLBC_FileMode::GetFileModeDesc(-1), "UnknownFileMode");
+
+    LLBC_File file;
+    EXPECT_FALSE(file.IsOpened());
+    EXPECT_TRUE(file.GetFilePath().empty());
+    EXPECT_EQ(file.GetFileMode(), LLBC_FileMode::Read);
+    EXPECT_EQ(file.GetFileNo(), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.GetFileHandle(), LLBC_INVALID_FILE_HANDLE);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.Flush(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.ReOpen(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.SetBufferMode(LLBC_FileBufferMode::FullBuf, 64), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.DiscardPageCache(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.CopyFile("unused"), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.MoveFile("unused"), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.DeleteFile(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.GetFileSize(), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.Seek(LLBC_FileSeekOrigin::Begin, 0), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.GetFilePosition(), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.SetFilePosition(0), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.OffsetFilePosition(1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.GetReadableSize(), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    char byte = '\0';
+    EXPECT_EQ(file.Read(&byte, 1), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.Write(&byte, 1), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.ReadLn(), "");
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.ReadToEnd(), "");
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.FormatWrite("%s", "unused"), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_EQ(file.Truncate(0), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+
+    ScopedTempFiles paths;
+    EXPECT_EQ(file.Open(paths.Path().c_str(), 0), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+}
+
+// Opening establishes the path/handle/mode contract. ReOpen() owns the old
+// handle, preserves the path, and validates the requested buffering policy.
+TEST(FileTest, OpensReopensConfiguresBuffersAndExposesHandleMetadata)
+{
+    ScopedTempFiles paths;
+    const auto path = paths.Path(".reopen");
+    LLBC_File file(path, LLBC_FileMode::TextWrite);
+    ASSERT_TRUE(file.IsOpened());
+
+    EXPECT_EQ(file.GetFilePath(), path);
+    EXPECT_EQ(file.GetFileMode(), LLBC_FileMode::TextWrite);
+    EXPECT_NE(file.GetFileHandle(), LLBC_INVALID_FILE_HANDLE);
+    EXPECT_GE(file.GetFileNo(), 0);
+    EXPECT_EQ(file.Open(path, LLBC_FileMode::TextWrite), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_OPENED);
+
+    EXPECT_EQ(file.SetBufferMode(LLBC_FileBufferMode::FullBuf, 1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(file.SetBufferMode(12345, 64), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(file.SetBufferMode(LLBC_FileBufferMode::LineBuf, 64), LLBC_OK);
+    EXPECT_EQ(file.SetBufferMode(LLBC_FileBufferMode::NoBuf, 0), LLBC_OK);
+    EXPECT_EQ(file.Write("first"), LLBC_OK);
+
+    ASSERT_EQ(file.ReOpen(), LLBC_OK);
+    EXPECT_EQ(file.GetFilePath(), path);
+    EXPECT_EQ(file.GetFileMode(), LLBC_FileMode::TextWrite);
+    EXPECT_EQ(file.GetFileSize(), 0);
+    ASSERT_EQ(file.ReOpen(LLBC_FileMode::TextRead), LLBC_OK);
+    EXPECT_EQ(file.GetFileMode(), LLBC_FileMode::TextRead);
+    EXPECT_EQ(file.Truncate(0), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_ALLOW);
+
+#if LLBC_TARGET_PLATFORM_LINUX
+    EXPECT_EQ(file.DiscardPageCache(), LLBC_OK);
+#else
+    EXPECT_EQ(file.DiscardPageCache(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_SUPPORT);
+#endif
+
+    file.Close();
+    EXPECT_FALSE(file.IsOpened());
+    EXPECT_TRUE(file.GetFilePath().empty());
+    EXPECT_EQ(file.GetFileMode(), LLBC_FileMode::Read);
+}
+
+// Binary reads/writes must preserve scalar representations, embedded NUL bytes,
+// seek positions, readable size, and truncate behavior.
+TEST(FileTest, ReadsWritesSeeksAndTruncatesBinaryData)
+{
+    ScopedTempFiles paths;
+    LLBC_File file(paths.Path(), LLBC_FileMode::BinaryReadWrite);
+    ASSERT_TRUE(file.IsOpened());
+
+    const bool boolValue = true;
+    const sint32 intValue = -123456;
+    const double doubleValue = 3.25;
+    const char payload[] = {'A', '\0', 'B', '\x7f'};
+    const sint64 expectedSize = sizeof(boolValue) + sizeof(intValue) + sizeof(doubleValue) + sizeof(payload);
+
+    EXPECT_EQ(file.Write(boolValue), LLBC_OK);
+    EXPECT_EQ(file.Write(intValue), LLBC_OK);
+    EXPECT_EQ(file.Write(doubleValue), LLBC_OK);
+    EXPECT_EQ(file.Write(payload, sizeof(payload)), static_cast<sint64>(sizeof(payload)));
+    EXPECT_EQ(file.Flush(), LLBC_OK);
+    EXPECT_EQ(file.GetFilePosition(), expectedSize);
+    EXPECT_EQ(file.GetFileSize(), expectedSize);
+    EXPECT_EQ(file.GetReadableSize(), 0);
+
+    ASSERT_EQ(file.SetFilePosition(0), LLBC_OK);
+    bool readBool = false;
+    sint32 readInt = 0;
+    double readDouble = 0.0;
+    char readPayload[sizeof(payload)] {};
+    EXPECT_EQ(file.Read(readBool), LLBC_OK);
+    EXPECT_EQ(file.Read(readInt), LLBC_OK);
+    EXPECT_EQ(file.Read(readDouble), LLBC_OK);
+    EXPECT_EQ(file.Read(readPayload, sizeof(readPayload)), static_cast<sint64>(sizeof(readPayload)));
+    EXPECT_EQ(readBool, boolValue);
+    EXPECT_EQ(readInt, intValue);
+    EXPECT_DOUBLE_EQ(readDouble, doubleValue);
+    EXPECT_EQ(::memcmp(readPayload, payload, sizeof(payload)), 0);
+
+    ASSERT_EQ(file.Seek(LLBC_FileSeekOrigin::End, -static_cast<sint64>(sizeof(payload))), LLBC_OK);
+    EXPECT_EQ(file.GetFilePosition(), expectedSize - static_cast<sint64>(sizeof(payload)));
+    EXPECT_EQ(file.OffsetFilePosition(2), expectedSize - 2);
+    EXPECT_EQ(file.Truncate(static_cast<size_t>(expectedSize - 1)), LLBC_OK);
+    EXPECT_EQ(file.GetFileSize(), expectedSize - 1);
+    EXPECT_EQ(LLBC_File::ReadToEnd(paths.Path()).size(), static_cast<size_t>(expectedSize - 1));
+}
+
+// Scalar overloads are intentionally thin binary helpers. Exercise every
+// supported primitive type plus the string overload so serialization callers
+// receive a stable round-trip contract.
+TEST(FileTest, RoundTripsAllScalarAndStringWriteReadOverloads)
+{
+    ScopedTempFiles paths;
+    LLBC_File file(paths.Path(), LLBC_FileMode::BinaryReadWrite);
+    ASSERT_TRUE(file.IsOpened());
+
+    const bool boolValue = true;
+    const sint8 sint8Value = -8;
+    const uint8 uint8Value = 8;
+    const sint16 sint16Value = -1600;
+    const uint16 uint16Value = 1600;
+    const sint32 sint32Value = -320000;
+    const uint32 uint32Value = 320000;
+    const long longValue = -640000L;
+    const ulong ulongValue = 640000UL;
+    const sint64 sint64Value = -6400000000LL;
+    const uint64 uint64Value = 6400000000ULL;
+    const float floatValue = 1.25f;
+    const double doubleValue = -2.5;
+    const ldouble longDoubleValue = 3.75L;
+    const LLBC_String stringValue("binary-string");
+
+    EXPECT_EQ(file.Write(boolValue), LLBC_OK);
+    EXPECT_EQ(file.Write(sint8Value), LLBC_OK);
+    EXPECT_EQ(file.Write(uint8Value), LLBC_OK);
+    EXPECT_EQ(file.Write(sint16Value), LLBC_OK);
+    EXPECT_EQ(file.Write(uint16Value), LLBC_OK);
+    EXPECT_EQ(file.Write(sint32Value), LLBC_OK);
+    EXPECT_EQ(file.Write(uint32Value), LLBC_OK);
+    EXPECT_EQ(file.Write(longValue), LLBC_OK);
+    EXPECT_EQ(file.Write(ulongValue), LLBC_OK);
+    EXPECT_EQ(file.Write(sint64Value), LLBC_OK);
+    EXPECT_EQ(file.Write(uint64Value), LLBC_OK);
+    EXPECT_EQ(file.Write(floatValue), LLBC_OK);
+    EXPECT_EQ(file.Write(doubleValue), LLBC_OK);
+    EXPECT_EQ(file.Write(longDoubleValue), LLBC_OK);
+    EXPECT_EQ(file.Write(stringValue), LLBC_OK);
+
+    ASSERT_EQ(file.SetFilePosition(0), LLBC_OK);
+    bool readBool = false;
+    sint8 readSint8 = 0;
+    uint8 readUint8 = 0;
+    sint16 readSint16 = 0;
+    uint16 readUint16 = 0;
+    sint32 readSint32 = 0;
+    uint32 readUint32 = 0;
+    long readLong = 0;
+    ulong readUlong = 0;
+    sint64 readSint64 = 0;
+    uint64 readUint64 = 0;
+    float readFloat = 0;
+    double readDouble = 0;
+    ldouble readLongDouble = 0;
+    char readString[32] {};
+
+    EXPECT_EQ(file.Read(readBool), LLBC_OK);
+    EXPECT_EQ(file.Read(readSint8), LLBC_OK);
+    EXPECT_EQ(file.Read(readUint8), LLBC_OK);
+    EXPECT_EQ(file.Read(readSint16), LLBC_OK);
+    EXPECT_EQ(file.Read(readUint16), LLBC_OK);
+    EXPECT_EQ(file.Read(readSint32), LLBC_OK);
+    EXPECT_EQ(file.Read(readUint32), LLBC_OK);
+    EXPECT_EQ(file.Read(readLong), LLBC_OK);
+    EXPECT_EQ(file.Read(readUlong), LLBC_OK);
+    EXPECT_EQ(file.Read(readSint64), LLBC_OK);
+    EXPECT_EQ(file.Read(readUint64), LLBC_OK);
+    EXPECT_EQ(file.Read(readFloat), LLBC_OK);
+    EXPECT_EQ(file.Read(readDouble), LLBC_OK);
+    EXPECT_EQ(file.Read(readLongDouble), LLBC_OK);
+    EXPECT_EQ(file.Read(readString, stringValue.size()), static_cast<sint64>(stringValue.size()));
+
+    EXPECT_EQ(readBool, boolValue);
+    EXPECT_EQ(readSint8, sint8Value);
+    EXPECT_EQ(readUint8, uint8Value);
+    EXPECT_EQ(readSint16, sint16Value);
+    EXPECT_EQ(readUint16, uint16Value);
+    EXPECT_EQ(readSint32, sint32Value);
+    EXPECT_EQ(readUint32, uint32Value);
+    EXPECT_EQ(readLong, longValue);
+    EXPECT_EQ(readUlong, ulongValue);
+    EXPECT_EQ(readSint64, sint64Value);
+    EXPECT_EQ(readUint64, uint64Value);
+    EXPECT_FLOAT_EQ(readFloat, floatValue);
+    EXPECT_DOUBLE_EQ(readDouble, doubleValue);
+    EXPECT_EQ(readLongDouble, longDoubleValue);
+    EXPECT_EQ(LLBC_String(readString, stringValue.size()), stringValue);
+}
+
+// Line-oriented readers accept LF, CRLF, and a lone CR without losing the
+// following byte. They also distinguish an empty final read from a valid empty
+// line and report truncation for short binary reads.
+TEST(FileTest, HandlesLineEndingAndEndOfFileEdgeCases)
+{
+    ScopedTempFiles paths;
+    const auto rawPath = paths.Path(".raw");
+    const auto crlfPath = paths.Path(".crlf");
+    const auto emptyPath = paths.Path(".empty");
+
+    {
+        LLBC_File rawFile(rawPath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(rawFile.IsOpened());
+        static const char contents[] = "alpha\rbeta\ncharlie\r\ndelta";
+        ASSERT_EQ(rawFile.Write(contents, sizeof(contents) - 1),
+                  static_cast<sint64>(sizeof(contents) - 1));
+    }
+
+    {
+        LLBC_File rawFile(rawPath, LLBC_FileMode::BinaryRead);
+        ASSERT_TRUE(rawFile.IsOpened());
+        EXPECT_EQ(rawFile.ReadLn(), "alpha");
+        EXPECT_EQ(rawFile.ReadLn(), "beta");
+        EXPECT_EQ(rawFile.ReadLn(), "charlie");
+        EXPECT_EQ(rawFile.ReadLn(), "delta");
+        EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+        EXPECT_EQ(rawFile.ReadLn(), "");
+        EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_TRUNCATED);
+
+        ASSERT_EQ(rawFile.SetFilePosition(rawFile.GetFileSize() - 1), LLBC_OK);
+        sint64 shortRead = 0;
+        EXPECT_EQ(rawFile.Read(shortRead), LLBC_FAILED);
+        EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_TRUNCATED);
+    }
+
+    {
+        LLBC_File crlfFile(crlfPath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(crlfFile.IsOpened());
+        EXPECT_EQ(crlfFile.Write("one\r\ntwo\r\n"), LLBC_OK);
+    }
+    {
+        LLBC_File crlfFile(crlfPath, LLBC_FileMode::BinaryRead);
+        ASSERT_TRUE(crlfFile.IsOpened());
+        const auto lines = crlfFile.ReadLns();
+        ASSERT_EQ(lines.size(), 3lu);
+        EXPECT_EQ(lines[0], "one");
+        EXPECT_EQ(lines[1], "two");
+        EXPECT_EQ(lines[2], "");
+    }
+
+    LLBC_File emptyFile(emptyPath, LLBC_FileMode::BinaryWrite);
+    ASSERT_TRUE(emptyFile.IsOpened());
+    emptyFile.Close();
+    ASSERT_EQ(emptyFile.Open(emptyPath, LLBC_FileMode::BinaryRead), LLBC_OK);
+    EXPECT_EQ(emptyFile.ReadToEnd(), "");
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+    EXPECT_TRUE(emptyFile.ReadLns().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_TRUNCATED);
+
+    LLBC_File unopened;
+    EXPECT_TRUE(unopened.ReadLns().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_OPEN);
+    EXPECT_TRUE(LLBC_File::ReadToEnd(paths.Path(".missing")).empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+}
+
+// Text line helpers normalize line endings while static file operations provide
+// copy, move, attributes, touch, and deletion workflows.
+TEST(FileTest, HandlesTextLinesAndStaticFileOperations)
+{
+    ScopedTempFiles paths;
+    const auto sourcePath = paths.Path();
+    const auto textPath = paths.Path(".text");
+    const auto copyPath = paths.Path(".copy");
+    const auto movedPath = paths.Path(".moved");
+    const auto touchPath = paths.Path(".touch");
+
+    {
+        LLBC_File textFile(textPath, LLBC_FileMode::TextWrite);
+        ASSERT_TRUE(textFile.IsOpened());
+        EXPECT_EQ(textFile.WriteLn("first", LLBC_FileNewLineFormat::UnixStyle), LLBC_OK);
+        EXPECT_EQ(textFile.WriteLn("second", LLBC_FileNewLineFormat::WindowsStyle), LLBC_OK);
+        EXPECT_EQ(textFile.WriteLns(LLBC_Strings {"third", "fourth"}, LLBC_FileNewLineFormat::UnixStyle),
+                  LLBC_OK);
+    }
+
+    {
+        LLBC_File textFile(textPath, LLBC_FileMode::TextRead);
+        ASSERT_TRUE(textFile.IsOpened());
+        EXPECT_EQ(textFile.ReadLn(), "first");
+        EXPECT_EQ(textFile.ReadLn(), "second");
+        const auto remaining = textFile.ReadLns();
+        ASSERT_EQ(remaining.size(), 3lu);
+        EXPECT_EQ(remaining[0], "third");
+        EXPECT_EQ(remaining[1], "fourth");
+        EXPECT_EQ(remaining[2], "");
+    }
+
+    {
+        LLBC_File source(sourcePath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(source.IsOpened());
+        EXPECT_EQ(source.FormatWrite("%s:%d", "llbc", 42), LLBC_OK);
+    }
+    EXPECT_TRUE(LLBC_File::Exists(sourcePath));
+
+    LLBC_FileAttributes attrs {};
+    ASSERT_EQ(LLBC_File::GetFileAttributes(sourcePath, attrs), LLBC_OK);
+    EXPECT_FALSE(attrs.isDirectory);
+    EXPECT_EQ(attrs.fileSize, 7);
+
+    EXPECT_EQ(LLBC_File::CopyFile(sourcePath, copyPath), LLBC_OK);
+    EXPECT_EQ(LLBC_File::CopyFile(sourcePath, copyPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_EXIST);
+    EXPECT_EQ(LLBC_File::CopyFile(sourcePath, copyPath, true), LLBC_OK);
+    EXPECT_EQ(LLBC_File::MoveFile(copyPath, movedPath), LLBC_OK);
+    EXPECT_FALSE(LLBC_File::Exists(copyPath));
+    EXPECT_TRUE(LLBC_File::Exists(movedPath));
+
+    EXPECT_EQ(LLBC_File::TouchFile(touchPath), LLBC_OK);
+    EXPECT_TRUE(LLBC_File::Exists(touchPath));
+
+    LLBC_File openedMoved(movedPath, LLBC_FileMode::BinaryRead);
+    ASSERT_TRUE(openedMoved.IsOpened());
+    EXPECT_EQ(openedMoved.DeleteFile(), LLBC_OK);
+    EXPECT_FALSE(LLBC_File::Exists(movedPath));
+    EXPECT_EQ(LLBC_File::DeleteFile(sourcePath), LLBC_OK);
+    EXPECT_EQ(LLBC_File::DeleteFile(touchPath), LLBC_OK);
+}
+
+// Auto newline selection follows the file mode/platform policy, while an empty
+// line list is a valid no-op for generated text output.
+TEST(FileTest, UsesAutoNewlinePoliciesForTextAndBinaryFiles)
+{
+    ScopedTempFiles paths;
+    const auto textPath = paths.Path(".auto");
+    const auto binaryPath = paths.Path(".auto-binary");
+
+    {
+        LLBC_File textFile(textPath, LLBC_FileMode::TextWrite);
+        ASSERT_TRUE(textFile.IsOpened());
+        EXPECT_EQ(textFile.WriteLn("text", LLBC_FileNewLineFormat::AutoMatch), LLBC_OK);
+        EXPECT_EQ(textFile.WriteLns(LLBC_Strings(), LLBC_FileNewLineFormat::AutoMatch), LLBC_OK);
+    }
+    EXPECT_EQ(LLBC_File::ReadToEnd(textPath), "text\n");
+
+    {
+        LLBC_File binaryFile(binaryPath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(binaryFile.IsOpened());
+        EXPECT_EQ(binaryFile.WriteLn("binary", LLBC_FileNewLineFormat::AutoMatch), LLBC_OK);
+    }
+#if LLBC_TARGET_PLATFORM_WIN32
+    EXPECT_EQ(LLBC_File::ReadToEnd(binaryPath), "binary\r\n");
+#else
+    EXPECT_EQ(LLBC_File::ReadToEnd(binaryPath), "binary\n");
+#endif
+}
+
+// C-string and printf-style writers support no-op, stack-buffer, and heap-buffer
+// formatting paths. Append mode and the instance copy/move helpers preserve the
+// expected ownership and file contents.
+TEST(FileTest, WritesFormatsAppendsAndUsesInstanceCopyMoveOperations)
+{
+    ScopedTempFiles paths;
+    const auto formatPath = paths.Path(".format");
+    const auto copyPath = paths.Path(".instance-copy");
+    const auto movedPath = paths.Path(".instance-moved");
+    const std::string largePayload(9000, 'x');
+    const std::string expectedPayload = "prefix:7|" + largePayload + "|tail";
+
+    {
+        LLBC_File writer(formatPath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(writer.IsOpened());
+        EXPECT_EQ(writer.Write(static_cast<const char *>(nullptr)), LLBC_OK);
+        EXPECT_EQ(writer.Write(""), LLBC_OK);
+        EXPECT_EQ(writer.Write("prefix"), LLBC_OK);
+        EXPECT_EQ(writer.FormatWrite("%s", ""), LLBC_OK);
+        EXPECT_EQ(writer.FormatWrite(":%d|", 7), LLBC_OK);
+        EXPECT_EQ(writer.FormatWrite("%s|", largePayload.c_str()), LLBC_OK);
+    }
+
+    {
+        LLBC_File appendFile(formatPath, LLBC_FileMode::BinaryAppendReadWrite);
+        ASSERT_TRUE(appendFile.IsOpened());
+        EXPECT_EQ(appendFile.GetFileMode(), LLBC_FileMode::BinaryAppendReadWrite);
+        EXPECT_EQ(appendFile.Write("tail"), LLBC_OK);
+        EXPECT_EQ(appendFile.Flush(), LLBC_OK);
+        ASSERT_EQ(appendFile.SetFilePosition(0), LLBC_OK);
+        const auto content = appendFile.ReadToEnd();
+        EXPECT_EQ(std::string(content.c_str(), content.size()), expectedPayload);
+    }
+
+    {
+        LLBC_File source(formatPath, LLBC_FileMode::BinaryAppendReadWrite);
+        ASSERT_TRUE(source.IsOpened());
+        ASSERT_EQ(source.CopyFile(copyPath), LLBC_OK);
+        EXPECT_TRUE(LLBC_File::Exists(copyPath));
+        ASSERT_EQ(source.MoveFile(movedPath), LLBC_OK);
+        EXPECT_FALSE(source.IsOpened());
+        EXPECT_TRUE(source.GetFilePath().empty());
+    }
+    EXPECT_FALSE(LLBC_File::Exists(formatPath));
+    const auto copiedContent = LLBC_File::ReadToEnd(copyPath);
+    const auto movedContent = LLBC_File::ReadToEnd(movedPath);
+    EXPECT_EQ(std::string(copiedContent.c_str(), copiedContent.size()), expectedPayload);
+    EXPECT_EQ(std::string(movedContent.c_str(), movedContent.size()), expectedPayload);
+
+    const auto emptyPath = paths.Path(".empty");
+    const auto emptyCopyPath = paths.Path(".empty-copy");
+    {
+        LLBC_File emptyFile(emptyPath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(emptyFile.IsOpened());
+    }
+    EXPECT_EQ(LLBC_File::CopyFile(emptyPath, emptyCopyPath), LLBC_OK);
+    EXPECT_TRUE(LLBC_File::ReadToEnd(emptyCopyPath).empty());
+    EXPECT_EQ(LLBC_File::CopyFile(paths.Path(".missing"), paths.Path(".copy")), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+
+    const auto moveSourcePath = paths.Path(".move-source");
+    const auto moveDestPath = paths.Path(".move-destination");
+    {
+        LLBC_File source(moveSourcePath, LLBC_FileMode::BinaryWrite);
+        LLBC_File destination(moveDestPath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(source.IsOpened());
+        ASSERT_TRUE(destination.IsOpened());
+        ASSERT_EQ(source.Write("from"), LLBC_OK);
+        ASSERT_EQ(destination.Write("to"), LLBC_OK);
+    }
+    EXPECT_EQ(LLBC_File::MoveFile(moveSourcePath, moveDestPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_EXIST);
+    EXPECT_EQ(LLBC_File::MoveFile(moveSourcePath, moveDestPath, true), LLBC_OK);
+    EXPECT_EQ(LLBC_File::ReadToEnd(moveDestPath), "from");
+}
+
+// Attribute and touch helpers are used by configuration, cache, and deployment
+// code to reason about ordinary files, hidden files, and directory entries.
+TEST(FileTest, ReportsAttributesAndUpdatesExistingFileTimestamps)
+{
+    ScopedTempFiles paths;
+    const auto hiddenPath = paths.HiddenPath();
+    const auto touchPath = paths.Path(".touch");
+
+    {
+        LLBC_File hiddenFile(hiddenPath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(hiddenFile.IsOpened());
+        ASSERT_EQ(hiddenFile.Write("hidden"), LLBC_OK);
+        ASSERT_EQ(hiddenFile.Flush(), LLBC_OK);
+
+        LLBC_FileAttributes attrs {};
+        ASSERT_EQ(hiddenFile.GetFileAttributes(attrs), LLBC_OK);
+        EXPECT_TRUE(attrs.readable);
+        EXPECT_TRUE(attrs.writable);
+        EXPECT_TRUE(attrs.hidden);
+        EXPECT_FALSE(attrs.isDirectory);
+        EXPECT_EQ(attrs.fileSize, 6);
+    }
+
+    LLBC_FileAttributes directoryAttrs {};
+    ASSERT_EQ(LLBC_File::GetFileAttributes(
+                  LLBC_String(std::filesystem::temp_directory_path().string().c_str()),
+                  directoryAttrs),
+              LLBC_OK);
+    EXPECT_TRUE(directoryAttrs.isDirectory);
+    EXPECT_EQ(directoryAttrs.fileSize, 0);
+
+    LLBC_FileAttributes missingAttrs {};
+    EXPECT_EQ(LLBC_File::GetFileAttributes(paths.Path(".missing"), missingAttrs), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    ASSERT_EQ(LLBC_File::TouchFile(touchPath), LLBC_OK);
+    ASSERT_TRUE(LLBC_File::Exists(touchPath));
+    const timespec knownTime {1700000000, 0};
+    ASSERT_EQ(LLBC_File::TouchFile(touchPath,
+                                   true,
+                                   &knownTime,
+                                   true,
+                                   &knownTime),
+              LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile(touchPath,
+                                   true,
+                                   &knownTime,
+                                   true,
+                                   nullptr),
+              LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile(touchPath, false, nullptr, false, nullptr), LLBC_OK);
+
+    LLBC_FileAttributes touchedAttrs {};
+    ASSERT_EQ(LLBC_File::GetFileAttributes(touchPath, touchedAttrs), LLBC_OK);
+    EXPECT_FALSE(touchedAttrs.isDirectory);
+    EXPECT_GE(touchedAttrs.lastModifyTime.tv_sec, 0);
+}
+
+// Read-only/write-only streams must surface C-library failures instead of
+// silently reporting success. Exercise invalid positioning, platform cache
+// advice, append-only modes, and safe static filesystem failure paths.
+TEST(FileTest, ReportsDirectionalIoAndStaticFilesystemFailurePaths)
+{
+    ScopedTempFiles paths;
+    const auto sourcePath = paths.Path(".readonly");
+    const auto writeOnlyPath = paths.Path(".writeonly");
+    const auto appendTextPath = paths.Path(".append");
+    const auto appendBinaryPath = paths.Path(".append-binary");
+
+    {
+        LLBC_File source(sourcePath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(source.IsOpened());
+        ASSERT_EQ(source.Write("payload"), LLBC_OK);
+    }
+
+    LLBC_File readOnly(sourcePath, LLBC_FileMode::BinaryRead);
+    ASSERT_TRUE(readOnly.IsOpened());
+    EXPECT_EQ(readOnly.Write("x"), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(readOnly.WriteLn("x"), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(readOnly.WriteLns(LLBC_Strings {"x", "y"}), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    const sint32 typedWriteValue = 7;
+    EXPECT_EQ(readOnly.Write(typedWriteValue), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(readOnly.Write(LLBC_String("typed")), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    EXPECT_EQ(LLBC_File::CopyFile(sourcePath, sourcePath, true), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(LLBC_File::ReadToEnd(sourcePath), "payload");
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    const LLBC_String tempDirectory(
+        std::filesystem::temp_directory_path().string().c_str());
+    LLBC_File directoryFile(tempDirectory, LLBC_FileMode::BinaryRead);
+    ASSERT_TRUE(directoryFile.IsOpened());
+    EXPECT_TRUE(directoryFile.ReadLns().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    const LLBC_String directoryCopyPath = paths.Path(".directory-copy");
+    EXPECT_EQ(LLBC_File::CopyFile(tempDirectory, directoryCopyPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_ALLOW);
+    EXPECT_FALSE(LLBC_File::Exists(directoryCopyPath));
+
+    if (::geteuid() != 0)
+    {
+        const LLBC_String restrictedSourcePath = paths.Path(".restricted-copy-source");
+        const LLBC_String restrictedDestinationPath =
+            paths.Path(".restricted-copy-destination");
+        {
+            LLBC_File restrictedSource(restrictedSourcePath, LLBC_FileMode::BinaryWrite);
+            ASSERT_TRUE(restrictedSource.IsOpened());
+            ASSERT_EQ(restrictedSource.Write("locked"), LLBC_OK);
+        }
+
+        ScopedFilePermissions permissions(
+            std::filesystem::path(restrictedSourcePath.c_str()));
+        std::error_code permissionError;
+        ASSERT_TRUE(permissions.Set(std::filesystem::perms::none, permissionError))
+            << permissionError.message();
+
+        EXPECT_EQ(LLBC_File::CopyFile(restrictedSourcePath, restrictedDestinationPath),
+                  LLBC_FAILED);
+        EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+        EXPECT_FALSE(LLBC_File::Exists(restrictedDestinationPath));
+    }
+#endif
+
+    LLBC_File seekFile(sourcePath, LLBC_FileMode::BinaryRead);
+    ASSERT_TRUE(seekFile.IsOpened());
+    EXPECT_EQ(seekFile.Seek(LLBC_FileSeekOrigin::Begin, -1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(seekFile.SetFilePosition(-1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    ASSERT_EQ(seekFile.SetFilePosition(0), LLBC_OK);
+    EXPECT_EQ(seekFile.OffsetFilePosition(-1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    LLBC_File writeOnly(writeOnlyPath, LLBC_FileMode::BinaryWrite);
+    ASSERT_TRUE(writeOnly.IsOpened());
+    ASSERT_EQ(writeOnly.Write("payload"), LLBC_OK);
+
+#if LLBC_TARGET_PLATFORM_LINUX
+    EXPECT_EQ(writeOnly.DiscardPageCache(), LLBC_OK);
+#else
+    EXPECT_EQ(writeOnly.DiscardPageCache(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_SUPPORT);
+#endif
+
+    ASSERT_EQ(writeOnly.SetFilePosition(0), LLBC_OK);
+    EXPECT_TRUE(writeOnly.ReadToEnd().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    ASSERT_EQ(writeOnly.SetFilePosition(0), LLBC_OK);
+    EXPECT_TRUE(writeOnly.ReadLns().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    ASSERT_EQ(writeOnly.SetFilePosition(0), LLBC_OK);
+    sint32 typedReadValue = 0;
+    EXPECT_EQ(writeOnly.Read(typedReadValue), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    {
+        LLBC_File appendText(appendTextPath, LLBC_FileMode::TextAppendWrite);
+        ASSERT_TRUE(appendText.IsOpened());
+        EXPECT_EQ(appendText.Write("one"), LLBC_OK);
+    }
+    {
+        LLBC_File appendText(appendTextPath, LLBC_FileMode::TextAppendWrite);
+        ASSERT_TRUE(appendText.IsOpened());
+        EXPECT_EQ(appendText.Write("two"), LLBC_OK);
+    }
+    EXPECT_EQ(LLBC_File::ReadToEnd(appendTextPath), "onetwo");
+
+    {
+        LLBC_File appendBinary(appendBinaryPath, LLBC_FileMode::BinaryAppendWrite);
+        ASSERT_TRUE(appendBinary.IsOpened());
+        EXPECT_EQ(appendBinary.Write("bin"), LLBC_OK);
+    }
+    EXPECT_EQ(LLBC_File::ReadToEnd(appendBinaryPath), "bin");
+
+    const LLBC_String missingPath("/definitely/not/a/real/llbc-file");
+    EXPECT_EQ(LLBC_File::CopyFile(sourcePath, missingPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_File::MoveFile(missingPath, paths.Path(".moved"), true), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_File::DeleteFile(missingPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_File::TouchFile(missingPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+}
+
+// Distinct paths can still refer to the same file through a hard link. Copying
+// over that alias must fail before the destination is opened and truncates data.
+TEST(FileTest, RejectsHardLinkedDestinationThatAliasesSource)
+{
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedTempFiles paths;
+    const LLBC_String sourcePath = paths.Path(".hard-link-source");
+    const LLBC_String hardLinkPath = paths.Path(".hard-link-destination");
+    {
+        LLBC_File source(sourcePath, LLBC_FileMode::BinaryWrite);
+        ASSERT_TRUE(source.IsOpened());
+        ASSERT_EQ(source.Write("hard-link-payload"), LLBC_OK);
+    }
+
+    std::error_code linkError;
+    std::filesystem::create_hard_link(
+        std::filesystem::path(sourcePath.c_str()),
+        std::filesystem::path(hardLinkPath.c_str()),
+        linkError);
+    if (linkError)
+        GTEST_SKIP() << "unable to create hard link: " << linkError.message();
+
+    EXPECT_EQ(LLBC_File::CopyFile(sourcePath, hardLinkPath, true), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(LLBC_File::ReadToEnd(sourcePath), "hard-link-payload");
+    EXPECT_EQ(LLBC_File::ReadToEnd(hardLinkPath), "hard-link-payload");
+#else
+    GTEST_SKIP() << "hard-link alias detection is POSIX-specific";
+#endif
+}
+
+// Pipes are readable streams but not seekable files. Position/size helpers and
+// ReadLns() must preserve the C-library error instead of confusing two failed
+// position queries with a normal end-of-file condition.
+TEST(FileTest, ReportsNonSeekableHandleErrorsWithoutLosingReadableData)
+{
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedTempFiles paths;
+    ScopedPipe pipe;
+    ASSERT_TRUE(pipe.Create());
+    ASSERT_EQ(::write(pipe.WriteFd(), "line\n", 5), 5);
+    pipe.CloseWrite();
+
+    const LLBC_String pipePath = LLBC_String().format("/dev/fd/%d", pipe.ReadFd());
+    LLBC_File file(pipePath, LLBC_FileMode::BinaryRead);
+    ASSERT_TRUE(file.IsOpened());
+
+    EXPECT_EQ(file.GetFileSize(), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(file.GetFilePosition(), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(file.GetReadableSize(), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(file.Seek(LLBC_FileSeekOrigin::Begin, 0), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(file.SetFilePosition(0), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(file.OffsetFilePosition(1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_TRUE(file.ReadLns().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    const LLBC_String copyPath = paths.Path(".copy");
+    EXPECT_EQ(LLBC_File::CopyFile(pipePath, copyPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_FALSE(LLBC_File::Exists(copyPath));
+
+    char data[6] {};
+    EXPECT_EQ(file.Read(data, 5), 5);
+    EXPECT_EQ(std::string(data, 5), "line\n");
+#else
+    GTEST_SKIP() << "/dev/fd pipe semantics are POSIX-specific";
+#endif
+}
+
+// FIFO-backed streams expose real POSIX write failures without modifying
+// filesystem permissions. LLBC_File must surface formatted-output and flush
+// failures instead of reporting buffered operations as OK.
+TEST(FileTest, ReportsFifoBackedOutputFailures)
+{
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedSignalIgnore ignoreSigpipe;
+    ASSERT_TRUE(ignoreSigpipe.Begin(SIGPIPE));
+
+    ScopedTempFiles paths;
+
+    ScopedFifo formatFifo;
+    const LLBC_String formatPath = paths.Path(".format-fifo");
+    ASSERT_TRUE(formatFifo.Begin(formatPath));
+    LLBC_File formatFile(formatPath, LLBC_FileMode::BinaryWrite);
+    ASSERT_TRUE(formatFile.IsOpened());
+    ASSERT_EQ(formatFile.SetBufferMode(LLBC_FileBufferMode::NoBuf, 0), LLBC_OK);
+    formatFifo.CloseRead();
+    EXPECT_EQ(formatFile.FormatWrite("format-%d", 7), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    ScopedFifo flushFifo;
+    const LLBC_String flushPath = paths.Path(".flush-fifo");
+    ASSERT_TRUE(flushFifo.Begin(flushPath));
+    LLBC_File flushFile(flushPath, LLBC_FileMode::BinaryWrite);
+    ASSERT_TRUE(flushFile.IsOpened());
+    ASSERT_EQ(flushFile.SetBufferMode(LLBC_FileBufferMode::FullBuf, 64), LLBC_OK);
+    flushFifo.CloseRead();
+    ASSERT_EQ(flushFile.Write("queued"), LLBC_OK);
+    EXPECT_EQ(flushFile.Flush(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    ScopedFifo copySourceFifo;
+    const LLBC_String copySourcePath = paths.Path(".copy-source-fifo");
+    const LLBC_String copyDestinationPath = paths.Path(".copy-destination");
+    ASSERT_TRUE(copySourceFifo.Begin(copySourcePath));
+    ASSERT_TRUE(copySourceFifo.OpenWrite());
+    EXPECT_EQ(LLBC_File::CopyFile(copySourcePath, copyDestinationPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_FALSE(LLBC_File::Exists(copyDestinationPath));
+#else
+    GTEST_SKIP() << "pipe-backed failure paths are POSIX-specific";
+#endif
+}

--- a/tests/unit_test/core/file/UnitTest_Core_File_File.cpp
+++ b/tests/unit_test/core/file/UnitTest_Core_File_File.cpp
@@ -739,7 +739,12 @@ TEST(FileTest, WritesFormatsAppendsAndUsesInstanceCopyMoveOperations)
     EXPECT_EQ(LLBC_File::CopyFile(emptyPath, emptyCopyPath), LLBC_OK);
     EXPECT_TRUE(LLBC_File::ReadToEnd(emptyCopyPath).empty());
     EXPECT_EQ(LLBC_File::CopyFile(paths.Path(".missing"), paths.Path(".copy")), LLBC_FAILED);
-    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_GetSubErrorNo(), ENOENT);
+#else
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_OSAPI);
+#endif
 
     const auto moveSourcePath = paths.Path(".move-source");
     const auto moveDestPath = paths.Path(".move-destination");
@@ -854,13 +859,20 @@ TEST(FileTest, ReportsDirectionalIoAndStaticFilesystemFailurePaths)
     const LLBC_String tempDirectory(
         std::filesystem::temp_directory_path().string().c_str());
     LLBC_File directoryFile(tempDirectory, LLBC_FileMode::BinaryRead);
-    ASSERT_TRUE(directoryFile.IsOpened());
-    EXPECT_TRUE(directoryFile.ReadLns().empty());
+    EXPECT_FALSE(directoryFile.IsOpened());
     EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_GetSubErrorNo(), EISDIR);
+    EXPECT_TRUE(directoryFile.GetFilePath().empty());
     const LLBC_String directoryCopyPath = paths.Path(".directory-copy");
     EXPECT_EQ(LLBC_File::CopyFile(tempDirectory, directoryCopyPath), LLBC_FAILED);
-    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_ALLOW);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_GetSubErrorNo(), EISDIR);
     EXPECT_FALSE(LLBC_File::Exists(directoryCopyPath));
+
+    const LLBC_String invalidDestinationPath = sourcePath + "/child";
+    EXPECT_EQ(LLBC_File::CopyFile(sourcePath, invalidDestinationPath), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_GetSubErrorNo(), ENOTDIR);
 
     if (::geteuid() != 0)
     {


### PR DESCRIPTION
## 概述

覆盖目录创建/枚举/删除及文件读写、定位、复制、属性和故障路径。

## 内容

### 库代码修正

- 目录创建：遇到 EEXIST/ERROR_ALREADY_EXISTS 时再确认目标确为目录，避免把同名文件当作成功；保存原 errno。
- POSIX 枚举：跳过 `.`/`..` 前释放 `scandir` 分配项，消除泄漏。
- HomeDir：空 HOME 与未设置等价，进入系统回退逻辑。
- 文件定位/读取：`OffsetFilePosition` 返回实际新位置；`ReadLns` 分别传播 position/size 查询失败。
- POSIX 文件大小：目录也可能被 `fopen` 打开，且 `ftell` 返回的是目录流 cookie，并非字节数；`GetFileSize` 现在先以 `fstat` 识别并用 EISDIR/CLIB 拒绝目录，避免 `ReadToEnd` 按巨大伪长度分配，普通文件路径不变。
- 文件复制：拒绝相同路径、POSIX 同 inode 硬链接及目录源；在创建目标前确认源大小可读，防止自截断与错误对象复制。
- 实例删除：Close 会清空 `_path`，因此先保存路径再删除。

每一项均有对应边界或故障注入用例。

## 质量保证

- 独立分支：118 tests passed。
- 最终组合：330/330 tests passed（Ubuntu 24.04 / Clang coverage）。
- CentOS 8 / GCC 8、macOS、Windows 构建全部真实执行并通过：[组合验证](https://github.com/reckfullol/llbc/actions/runs/30164371701)。
- Linux GCC 8 的 filesystem 链接支持由先行 PR #584 提供。

