### PR TITLE
test: 补充 GUID 单元测试并统一跨平台布局

### DIFF
--- a/llbc/include/llbc/common/BasicDataType.h
+++ b/llbc/include/llbc/common/BasicDataType.h
@@ -240,10 +240,10 @@ extern "C"
 #if LLBC_TARGET_PLATFORM_NON_WIN32
 struct LLBC_GUID
 {
-    unsigned long Data1;
-    unsigned short Data2;
-    unsigned short Data3;
-    unsigned char Data4[8];
+    uint32 Data1;
+    uint16 Data2;
+    uint16 Data3;
+    uint8 Data4[8];
 };
 #else
 typedef GUID LLBC_GUID;

--- a/llbc/src/core/helper/GUIDHelper.cpp
+++ b/llbc/src/core/helper/GUIDHelper.cpp
@@ -35,7 +35,18 @@ LLBC_GUID LLBC_GUIDHelper::Gen()
     memset(&guid, 0, sizeof(LLBC_GUID));
 
 #if LLBC_TARGET_PLATFORM_NON_WIN32
-    uuid_generate(reinterpret_cast<unsigned char *>(&guid));
+    uuid_t uuid;
+    uuid_generate(uuid);
+
+    guid.Data1 = (static_cast<uint32>(uuid[0]) << 24) |
+                 (static_cast<uint32>(uuid[1]) << 16) |
+                 (static_cast<uint32>(uuid[2]) << 8) |
+                 static_cast<uint32>(uuid[3]);
+    guid.Data2 = static_cast<uint16>((static_cast<uint16>(uuid[4]) << 8) |
+                                     static_cast<uint16>(uuid[5]));
+    guid.Data3 = static_cast<uint16>((static_cast<uint16>(uuid[6]) << 8) |
+                                     static_cast<uint16>(uuid[7]));
+    memcpy(guid.Data4, uuid + 8, sizeof(guid.Data4));
 #else
     ::CoCreateGuid(&guid);
 #endif
@@ -47,17 +58,17 @@ LLBC_String LLBC_GUIDHelper::Format(LLBC_GUIDCRef guid)
 {
     LLBC_String str;
     str.format("%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", 
-            guid.Data1,
-            guid.Data2,
-            guid.Data3,
-            guid.Data4[0],
-            guid.Data4[1],
-            guid.Data4[2],
-            guid.Data4[3],
-            guid.Data4[4],
-            guid.Data4[5],
-            guid.Data4[6],
-            guid.Data4[7]);
+            static_cast<unsigned int>(guid.Data1),
+            static_cast<unsigned int>(guid.Data2),
+            static_cast<unsigned int>(guid.Data3),
+            static_cast<unsigned int>(guid.Data4[0]),
+            static_cast<unsigned int>(guid.Data4[1]),
+            static_cast<unsigned int>(guid.Data4[2]),
+            static_cast<unsigned int>(guid.Data4[3]),
+            static_cast<unsigned int>(guid.Data4[4]),
+            static_cast<unsigned int>(guid.Data4[5]),
+            static_cast<unsigned int>(guid.Data4[6]),
+            static_cast<unsigned int>(guid.Data4[7]));
 
     return str;
 }

--- a/llbc/src/core/helper/GUIDHelper.cpp
+++ b/llbc/src/core/helper/GUIDHelper.cpp
@@ -58,17 +58,17 @@ LLBC_String LLBC_GUIDHelper::Format(LLBC_GUIDCRef guid)
 {
     LLBC_String str;
     str.format("%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", 
-            static_cast<unsigned int>(guid.Data1),
-            static_cast<unsigned int>(guid.Data2),
-            static_cast<unsigned int>(guid.Data3),
-            static_cast<unsigned int>(guid.Data4[0]),
-            static_cast<unsigned int>(guid.Data4[1]),
-            static_cast<unsigned int>(guid.Data4[2]),
-            static_cast<unsigned int>(guid.Data4[3]),
-            static_cast<unsigned int>(guid.Data4[4]),
-            static_cast<unsigned int>(guid.Data4[5]),
-            static_cast<unsigned int>(guid.Data4[6]),
-            static_cast<unsigned int>(guid.Data4[7]));
+            guid.Data1,
+            guid.Data2,
+            guid.Data3,
+            guid.Data4[0],
+            guid.Data4[1],
+            guid.Data4[2],
+            guid.Data4[3],
+            guid.Data4[4],
+            guid.Data4[5],
+            guid.Data4[6],
+            guid.Data4[7]);
 
     return str;
 }

--- a/tests/unit_test/core/helper/UnitTest_Core_Helper_GUID.cpp
+++ b/tests/unit_test/core/helper/UnitTest_Core_Helper_GUID.cpp
@@ -1,0 +1,95 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <cctype>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/helper/GUIDHelper.cpp
+
+namespace
+{
+
+bool IsCanonicalGuid(const LLBC_String &guid)
+{
+    if (guid.size() != 36)
+        return false;
+
+    for (size_t i = 0; i < guid.size(); ++i)
+    {
+        if (i == 8 || i == 13 || i == 18 || i == 23)
+        {
+            if (guid[i] != '-')
+                return false;
+        }
+        else if (!std::isxdigit(static_cast<unsigned char>(guid[i])) ||
+                 std::islower(static_cast<unsigned char>(guid[i])))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace
+
+// Format uses the standard 8-4-4-4-12 uppercase GUID layout and must not depend
+// on platform-specific integer widths.
+TEST(GUIDHelperTest, FormatsKnownGuidWithCanonicalFieldOrder)
+{
+    EXPECT_EQ(sizeof(LLBC_GUID), 16lu);
+
+    LLBC_GUID guid {};
+    guid.Data1 = 0x01234567u;
+    guid.Data2 = 0x89abu;
+    guid.Data3 = 0xcdefu;
+    guid.Data4[0] = 0x01u;
+    guid.Data4[1] = 0x23u;
+    guid.Data4[2] = 0x45u;
+    guid.Data4[3] = 0x67u;
+    guid.Data4[4] = 0x89u;
+    guid.Data4[5] = 0xabu;
+    guid.Data4[6] = 0xcdu;
+    guid.Data4[7] = 0xefu;
+
+    EXPECT_EQ(LLBC_GUIDHelper::Format(guid), "01234567-89AB-CDEF-0123-456789ABCDEF");
+}
+
+// Generated GUIDs must have a stable printable representation, and GenStr() is
+// equivalent to formatting the generated structure.
+TEST(GUIDHelperTest, GeneratesCanonicalNonEmptyGuidStrings)
+{
+    const LLBC_GUID first = LLBC_GUIDHelper::Gen();
+    const LLBC_GUID second = LLBC_GUIDHelper::Gen();
+    const LLBC_String firstString = LLBC_GUIDHelper::Format(first);
+    const LLBC_String secondString = LLBC_GUIDHelper::Format(second);
+
+    EXPECT_TRUE(IsCanonicalGuid(firstString));
+    EXPECT_TRUE(IsCanonicalGuid(secondString));
+    EXPECT_NE(firstString, "00000000-0000-0000-0000-000000000000");
+    EXPECT_NE(firstString, secondString);
+    EXPECT_TRUE(IsCanonicalGuid(LLBC_GUIDHelper::GenStr()));
+}


### PR DESCRIPTION
## 概述

验证 GUID 的规范格式和随机生成，并修复 LP64 平台上的字段布局/字节序问题。

## 内容

### 库代码修正

- 将 `LLBC_GUID` 字段由平台相关的 unsigned long/short/char 改为 uint32/uint16/uint8，确保结构对应标准 4-2-2-8 字段宽度；Windows 宽度保持等价。
- POSIX `uuid_t` 是网络顺序字节数组，不能直接覆盖宿主结构；现在逐字段按大端字节组装并复制 Data4。
- 格式化直接使用固定宽度字段；较窄的 Data2/Data3/Data4 参数由可变参数默认提升处理。

已知向量测试验证字段顺序，生成测试验证规范 36 字符格式。

## 质量保证

- GUID 定向测试：2 tests passed。
- 全量单元测试：103 tests passed，1 test skipped（ARM64 整数除零行为差异）。
- `make core_lib config=debug64 -j4` 通过。
- `make func_test config=debug64 -j4` 通过。
- `git diff --check` 通过。