### PR TITLE
test: 补充 OS 抽象层单元测试并修正平台边界

### DIFF
--- a/llbc/src/core/os/OS_Bundle_NonIphone.cpp
+++ b/llbc/src/core/os/OS_Bundle_NonIphone.cpp
@@ -77,8 +77,7 @@ LLBC_String LLBC_GetBundlePath(LLBC_BundleHandle bundle)
     bool needRelease = false;
     if (bundle == LLBC_INVALID_BUNDLE_HANDLE)
     {
-        if ((bundle = LLBC_CreateBundle(
-             LLBC_GetMainBundlePath())) == LLBC_INVALID_BUNDLE_HANDLE)
+        if ((bundle = LLBC_CreateBundle("")) == LLBC_INVALID_BUNDLE_HANDLE)
             return "";
 
         needRelease = true;

--- a/llbc/src/core/os/OS_Console.cpp
+++ b/llbc/src/core/os/OS_Console.cpp
@@ -182,6 +182,7 @@ int __LLBC_FilePrint(bool newline, FILE *file, const char *fmt, ...)
         }
     }
 
+    int printRet = 0;
     #if LLBC_TARGET_PLATFORM_NON_WIN32
     flockfile(file);
     bool fmtPrint = false;
@@ -193,22 +194,33 @@ int __LLBC_FilePrint(bool newline, FILE *file, const char *fmt, ...)
             fmtPrint = true;
             char colorFmt[LLBC_INTERNAL_NS __g_consoleColorFmtLen] = {};
             LLBC_INTERNAL_NS __GetConsoleColorCode(color, colorFmt);
-            fprintf(file, (newline ? "%s%s%s\n" : "%s%s%s"), colorFmt, buf, LLBC_INTERNAL_NS __g_consoleColorEndFmt);
+            printRet = fprintf(file,
+                               (newline ? "%s%s%s\n" : "%s%s%s"),
+                               colorFmt,
+                               buf,
+                               LLBC_INTERNAL_NS __g_consoleColorEndFmt);
         }
     }
 
     if (!fmtPrint)
     {
-        fprintf(file, (newline ? "%s\n" : "%s"), buf);
+        printRet = fprintf(file, (newline ? "%s\n" : "%s"), buf);
     }
     funlockfile(file);
     #else // Win32
     LLBC_FastLock &lock = LLBC_INTERNAL_NS __g_consoleLock[fileNo - 1];
 
     lock.Lock();
-    fprintf(file, newline ? "%s\n" : "%s", buf);
+    printRet = fprintf(file, newline ? "%s\n" : "%s", buf);
     lock.Unlock();
     #endif // !Non-Win32
+
+    if (UNLIKELY(printRet < 0))
+    {
+        LLBC_DoIf(len >= static_cast<int>(sizeof(stackBuf)), free(buf));
+        LLBC_SetLastError(LLBC_ERROR_CLIB);
+        return LLBC_FAILED;
+    }
 
     LLBC_DoIf(len >= static_cast<int>(sizeof(stackBuf)), free(buf));
 

--- a/llbc/src/core/os/OS_Symbol.cpp
+++ b/llbc/src/core/os/OS_Symbol.cpp
@@ -68,10 +68,15 @@ LLBC_String LLBC_CaptureStackBackTrace(size_t skipFrames, size_t captureFrames)
     LLBC_String backTrace;
 
     __LLBC_LibTls *libTls = __LLBC_GetLibTls();
+    const size_t maxCaptureFrames = LLBC_CFG_OS_SYMBOL_MAX_CAPTURE_FRAMES;
+    if (skipFrames >= maxCaptureFrames)
+        return backTrace;
+
+    const size_t availableCaptureFrames = maxCaptureFrames - skipFrames;
     if (captureFrames == static_cast<size_t>(LLBC_INFINITE))
-        captureFrames = LLBC_CFG_OS_SYMBOL_MAX_CAPTURE_FRAMES;
+        captureFrames = availableCaptureFrames;
     else
-        captureFrames = MIN(captureFrames, LLBC_CFG_OS_SYMBOL_MAX_CAPTURE_FRAMES);
+        captureFrames = MIN(captureFrames, availableCaptureFrames);
 
     void **stack = libTls->coreTls.symbol.stack;
 
@@ -111,6 +116,11 @@ LLBC_String LLBC_CaptureStackBackTrace(size_t skipFrames, size_t captureFrames)
         {
             backTrace.append_format("#%d ", frames - i - 1);
 
+#if LLBC_TARGET_PLATFORM_MAC || LLBC_TARGET_PLATFORM_IPHONE
+            // Darwin's backtrace_symbols() format does not use the
+            // Linux-style "(mangled_symbol+offset)" segment.
+            backTrace.append_format("%s", strs[i]);
+#else
             char *parenthesisEnd = nullptr;
             char *parenthesisBeg = strchr(strs[i], '(');
             if (parenthesisBeg)
@@ -130,14 +140,14 @@ LLBC_String LLBC_CaptureStackBackTrace(size_t skipFrames, size_t captureFrames)
                 *addrOffsetBeg = '\0';
 
                 int status = 0;
-                size_t length = sizeof(libTls->commonTls.rtti);
-                abi::__cxa_demangle(parenthesisBeg, libTls->commonTls.rtti, &length, &status);
+                char *demangledName = abi::__cxa_demangle(parenthesisBeg, nullptr, nullptr, &status);
                 *addrOffsetBeg = oldAddrOffsetBegCh;
-                if (status == 0)
+                if (status == 0 && demangledName)
                 {
                     backTrace.append(strs[i], parenthesisBeg - strs[i]);
-                    backTrace.append(libTls->commonTls.rtti);
+                    backTrace.append(demangledName);
                     backTrace.append(addrOffsetBeg);
+                    free(demangledName);
                 }
                 else
                 {
@@ -148,6 +158,7 @@ LLBC_String LLBC_CaptureStackBackTrace(size_t skipFrames, size_t captureFrames)
             {
                 backTrace.append_format("%s", strs[i]);
             }
+#endif
 
             if (i != frames - 1)
                 backTrace.append(1, '\n');

--- a/llbc/src/core/os/OS_SysConf.cpp
+++ b/llbc/src/core/os/OS_SysConf.cpp
@@ -29,9 +29,9 @@ sint64 LLBC_pageSize = 0;
 
 int __LLBC_InitSysConf()
 {
-    #if LLBC_TARGET_PLATFORM_LINUX
+    #if LLBC_TARGET_PLATFORM_NON_WIN32
     errno = 0;
-    int tmpValue = sysconf(_SC_PAGESIZE);
+    long tmpValue = sysconf(_SC_PAGESIZE);
     if (UNLIKELY(tmpValue == -1))
     {
         if (UNLIKELY(errno == 0))

--- a/tests/unit_test/core/os/UnitTest_Core_OS_Bundle.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_Bundle.cpp
@@ -1,0 +1,163 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <llbc/core/os/OS_Bundle.h>
+
+#include <chrono>
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/os/OS_Bundle_NonIphone.cpp
+
+namespace
+{
+
+class ScopedBundleDirectory
+{
+public:
+    ScopedBundleDirectory()
+    : _path(std::filesystem::temp_directory_path() /
+            ("llbc_unit_bundle_" +
+             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())))
+    {
+        std::filesystem::create_directories(_path);
+    }
+
+    ~ScopedBundleDirectory()
+    {
+        std::error_code ignored;
+        std::filesystem::remove_all(_path, ignored);
+    }
+
+    LLBC_String Path() const
+    {
+        return LLBC_String(_path.string().c_str());
+    }
+
+private:
+    std::filesystem::path _path;
+};
+
+class ScopedCurrentDirectory
+{
+public:
+    ScopedCurrentDirectory()
+    : _original(LLBC_Directory::CurDir())
+    {
+    }
+
+    bool Enter(const LLBC_String &path)
+    {
+        if (_original.empty() || LLBC_Directory::SetCurDir(path) != LLBC_OK)
+            return false;
+
+        _restore = true;
+        return true;
+    }
+
+    ~ScopedCurrentDirectory()
+    {
+        if (_restore)
+            LLBC_Directory::SetCurDir(_original);
+    }
+
+private:
+    LLBC_String _original;
+    bool _restore = false;
+};
+
+} // namespace
+
+// Non-iPhone bundles use the current directory as their main bundle. Validate
+// default-handle resolution, relative sub-bundles, resource extension handling,
+// and missing/invalid resource errors without relying on repository assets.
+TEST(BundleOsTest, ResolvesMainAndRelativeBundleResources)
+{
+#if LLBC_TARGET_PLATFORM_NON_IPHONE
+    ScopedBundleDirectory bundleDirectory;
+    ScopedCurrentDirectory currentDirectory;
+    ASSERT_TRUE(currentDirectory.Enter(bundleDirectory.Path()));
+
+    ASSERT_EQ(LLBC_Directory::Create("nested"), LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile("top.txt"), LLBC_OK);
+    ASSERT_EQ(LLBC_File::TouchFile("nested/item.dat"), LLBC_OK);
+
+    const LLBC_String mainPath = LLBC_GetMainBundlePath();
+    EXPECT_EQ(mainPath, LLBC_Directory::CurDir());
+
+    LLBC_BundleHandle mainBundle = LLBC_CreateBundle("");
+    ASSERT_NE(mainBundle, LLBC_INVALID_BUNDLE_HANDLE);
+    EXPECT_EQ(LLBC_GetBundlePath(mainBundle), mainPath);
+    EXPECT_EQ(LLBC_GetBundlePath(LLBC_INVALID_BUNDLE_HANDLE), mainPath);
+    EXPECT_EQ(LLBC_GetBundleResPath(mainBundle, "top", "txt"),
+              LLBC_Directory::Join(mainPath, "top.txt"));
+    EXPECT_EQ(LLBC_GetBundleResPath(LLBC_INVALID_BUNDLE_HANDLE, "top.txt"),
+              LLBC_Directory::Join(mainPath, "top.txt"));
+    EXPECT_EQ(LLBC_GetBundleResPath(mainBundle, "item", "dat", "nested"),
+              LLBC_Directory::Join(mainPath, "nested/item.dat"));
+    EXPECT_EQ(LLBC_GetBundleResPath(mainBundle, "missing", "txt"), "");
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_FOUND);
+    EXPECT_EQ(LLBC_GetBundleResPath(mainBundle, ""), "");
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    LLBC_ReleaseBundle(mainBundle);
+    LLBC_ReleaseBundle(LLBC_INVALID_BUNDLE_HANDLE);
+
+    LLBC_BundleHandle nestedBundle = LLBC_CreateBundle("nested/");
+    ASSERT_NE(nestedBundle, LLBC_INVALID_BUNDLE_HANDLE);
+    EXPECT_EQ(LLBC_GetBundlePath(nestedBundle), LLBC_Directory::Join(mainPath, "nested"));
+    EXPECT_EQ(LLBC_GetBundleResPath(nestedBundle, "item", "dat"),
+              LLBC_Directory::Join(mainPath, "nested/item.dat"));
+    LLBC_ReleaseBundle(nestedBundle);
+
+    EXPECT_EQ(LLBC_CreateBundle("missing"), LLBC_INVALID_BUNDLE_HANDLE);
+#else
+    GTEST_SKIP() << "non-iPhone bundle behavior is platform-specific";
+#endif
+}
+
+// A deployment cleanup can remove the current directory after startup. Main
+// bundle lookup must then fail gracefully instead of constructing an invalid
+// relative path from a stale working-directory string.
+TEST(BundleOsTest, HandlesDeletedCurrentDirectoryForDefaultBundleLookup)
+{
+#if LLBC_TARGET_PLATFORM_NON_IPHONE && LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedBundleDirectory bundleDirectory;
+    ScopedCurrentDirectory currentDirectory;
+    ASSERT_TRUE(currentDirectory.Enter(bundleDirectory.Path()));
+
+    std::error_code removeError;
+    std::filesystem::remove(std::filesystem::path(bundleDirectory.Path().c_str()), removeError);
+    ASSERT_FALSE(removeError) << removeError.message();
+
+    EXPECT_TRUE(LLBC_GetMainBundlePath().empty());
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_CreateBundle(""), LLBC_INVALID_BUNDLE_HANDLE);
+    EXPECT_TRUE(LLBC_GetBundlePath(LLBC_INVALID_BUNDLE_HANDLE).empty());
+    EXPECT_TRUE(LLBC_GetBundleResPath(LLBC_INVALID_BUNDLE_HANDLE, "resource").empty());
+#else
+    GTEST_SKIP() << "deleted-current-directory behavior is POSIX-specific";
+#endif
+}

--- a/tests/unit_test/core/os/UnitTest_Core_OS_Console.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_Console.cpp
@@ -1,0 +1,315 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <llbc/core/os/OS_Console.h>
+
+#include <cstdlib>
+#include <string>
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+#include <signal.h>
+#include <unistd.h>
+#endif
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/os/OS_Console.cpp
+
+namespace
+{
+
+std::string ReadFile(FILE *file)
+{
+    fflush(file);
+    fseek(file, 0, SEEK_SET);
+
+    std::string content;
+    char buffer[256];
+    size_t read = 0;
+    while ((read = fread(buffer, 1, sizeof(buffer), file)) != 0)
+        content.append(buffer, read);
+
+    clearerr(file);
+    return content;
+}
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+class ScopedStdStreamRedirect
+{
+public:
+    ScopedStdStreamRedirect(FILE *stream, int descriptor)
+    : _stream(stream)
+    , _descriptor(descriptor)
+    {
+    }
+
+    bool Begin()
+    {
+        _capture = tmpfile();
+        if (!_capture)
+            return false;
+
+        fflush(_stream);
+        _savedDescriptor = dup(_descriptor);
+        if (_savedDescriptor == -1)
+            return false;
+
+        if (dup2(fileno(_capture), _descriptor) == -1)
+            return false;
+
+        _active = true;
+        return true;
+    }
+
+    std::string ReadCaptured() const
+    {
+        return _capture ? ReadFile(_capture) : std::string();
+    }
+
+    ~ScopedStdStreamRedirect()
+    {
+        if (_active)
+        {
+            fflush(_stream);
+            dup2(_savedDescriptor, _descriptor);
+        }
+        if (_savedDescriptor != -1)
+            close(_savedDescriptor);
+        if (_capture)
+            fclose(_capture);
+    }
+
+private:
+    FILE *_stream = nullptr;
+    int _descriptor = -1;
+    FILE *_capture = nullptr;
+    int _savedDescriptor = -1;
+    bool _active = false;
+};
+
+class ScopedSignalIgnore
+{
+public:
+    bool Begin(int signalNumber)
+    {
+        struct sigaction action = {};
+        action.sa_handler = SIG_IGN;
+        sigemptyset(&action.sa_mask);
+
+        if (sigaction(signalNumber, &action, &_previous) != 0)
+            return false;
+
+        _signalNumber = signalNumber;
+        _active = true;
+        return true;
+    }
+
+    ~ScopedSignalIgnore()
+    {
+        if (_active)
+            sigaction(_signalNumber, &_previous, nullptr);
+    }
+
+private:
+    struct sigaction _previous = {};
+    int _signalNumber = 0;
+    bool _active = false;
+};
+
+class ScopedBrokenPipe
+{
+public:
+    bool Begin(int bufferingMode)
+    {
+        int pipeFds[2] = {-1, -1};
+        if (pipe(pipeFds) != 0)
+            return false;
+
+        close(pipeFds[0]);
+        _file = fdopen(pipeFds[1], "w");
+        if (!_file)
+        {
+            close(pipeFds[1]);
+            return false;
+        }
+
+        if (setvbuf(_file,
+                    bufferingMode == _IOFBF ? _buffer : nullptr,
+                    bufferingMode,
+                    bufferingMode == _IOFBF ? sizeof(_buffer) : 0) != 0)
+        {
+            fclose(_file);
+            _file = nullptr;
+            return false;
+        }
+
+        return true;
+    }
+
+    FILE *Get() const
+    {
+        return _file;
+    }
+
+    ~ScopedBrokenPipe()
+    {
+        if (_file)
+            fclose(_file);
+    }
+
+private:
+    FILE *_file = nullptr;
+    char _buffer[BUFSIZ] = {};
+};
+#endif
+
+} // namespace
+
+// Console helpers support arbitrary files for synchronized formatting, while
+// colors are valid only for stdout/stderr. Redirect stdout temporarily so ANSI
+// formatting can be verified without emitting escape sequences to the terminal.
+TEST(ConsoleOsTest, FormatsFlushesAndAppliesConsoleColorsSafely)
+{
+    FILE *temporary = tmpfile();
+    ASSERT_NE(temporary, nullptr);
+
+    EXPECT_EQ(LLBC_GetConsoleColor(temporary), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+    EXPECT_EQ(LLBC_SetConsoleColor(temporary, LLBC_ConsoleColor::Fg_Red), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    char *memoryData = nullptr;
+    size_t memorySize = 0;
+    FILE *memoryStream = open_memstream(&memoryData, &memorySize);
+    ASSERT_NE(memoryStream, nullptr);
+    EXPECT_EQ(LLBC_GetConsoleColor(memoryStream), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(LLBC_SetConsoleColor(memoryStream, LLBC_ConsoleColor::Fg_Red), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    EXPECT_EQ(__LLBC_FilePrint(false, memoryStream, "%s", "ignored"), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+    fclose(memoryStream);
+    free(memoryData);
+#endif
+
+    const std::string largePayload(900, 'x');
+    ASSERT_EQ(__LLBC_FilePrint(false, temporary, "%s", "small"), LLBC_OK);
+    ASSERT_EQ(__LLBC_FilePrint(true, temporary, "%s", "line"), LLBC_OK);
+    ASSERT_EQ(__LLBC_FilePrint(false, temporary, "%s", largePayload.c_str()), LLBC_OK);
+    ASSERT_EQ(LLBC_FlushFile(temporary), LLBC_OK);
+    EXPECT_EQ(ReadFile(temporary), "smallline\n" + largePayload);
+    fclose(temporary);
+
+    EXPECT_EQ(LLBC_FlushFile(nullptr), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedSignalIgnore ignoreSigpipe;
+    ASSERT_TRUE(ignoreSigpipe.Begin(SIGPIPE));
+
+    ScopedBrokenPipe unbufferedBrokenPipe;
+    ASSERT_TRUE(unbufferedBrokenPipe.Begin(_IONBF));
+    EXPECT_EQ(__LLBC_FilePrint(false, unbufferedBrokenPipe.Get(), "%s", "broken"),
+              LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    ScopedBrokenPipe bufferedBrokenPipe;
+    ASSERT_TRUE(bufferedBrokenPipe.Begin(_IOFBF));
+    ASSERT_GE(fputs("queued", bufferedBrokenPipe.Get()), 0);
+    EXPECT_EQ(LLBC_FlushFile(bufferedBrokenPipe.Get()), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    const int originalStdoutColor = LLBC_GetConsoleColor(stdout);
+    const int originalStderrColor = LLBC_GetConsoleColor(stderr);
+    ASSERT_GE(originalStdoutColor, 0);
+    ASSERT_GE(originalStderrColor, 0);
+
+    std::string stdoutCaptured;
+    {
+        ScopedStdStreamRedirect redirect(stdout, STDOUT_FILENO);
+        if (!redirect.Begin())
+            GTEST_SKIP() << "unable to redirect stdout";
+
+        const int highlightedColor = LLBC_ConsoleColor::Highlight_Fg |
+                                     LLBC_ConsoleColor::Fg_Red |
+                                     LLBC_ConsoleColor::Bg_Blue;
+        const int foregroundColor = LLBC_ConsoleColor::Fg_Green;
+        const int backgroundColor = LLBC_ConsoleColor::Bg_Red;
+        const int highlightOnlyColor = LLBC_ConsoleColor::Highlight_Fg;
+        const int highlightedRet = LLBC_SetConsoleColor(stdout, highlightedColor);
+        const int highlightedPrintRet = __LLBC_FilePrint(false, stdout, "%s", "highlighted");
+        const int highlightedLinePrintRet =
+            __LLBC_FilePrint(true, stdout, "%s", "highlighted-line");
+        const int foregroundRet = LLBC_SetConsoleColor(stdout, foregroundColor);
+        const int foregroundPrintRet = __LLBC_FilePrint(false, stdout, "%s", "foreground");
+        const int backgroundRet = LLBC_SetConsoleColor(stdout, backgroundColor);
+        const int backgroundPrintRet = __LLBC_FilePrint(false, stdout, "%s", "background");
+        const int highlightOnlyRet = LLBC_SetConsoleColor(stdout, highlightOnlyColor);
+        const int highlightOnlyPrintRet = __LLBC_FilePrint(false, stdout, "%s", "highlight-only");
+        const int resetRet = LLBC_SetConsoleColor(stdout, LLBC_ConsoleColor::Fg_Default);
+        const int plainPrintRet = __LLBC_FilePrint(true, stdout, "%s", "plain");
+        const int flushRet = LLBC_FlushFile(stdout);
+        stdoutCaptured = redirect.ReadCaptured();
+
+        LLBC_SetConsoleColor(stdout, originalStdoutColor);
+        EXPECT_EQ(highlightedRet, LLBC_OK);
+        EXPECT_EQ(highlightedPrintRet, LLBC_OK);
+        EXPECT_EQ(highlightedLinePrintRet, LLBC_OK);
+        EXPECT_EQ(foregroundRet, LLBC_OK);
+        EXPECT_EQ(foregroundPrintRet, LLBC_OK);
+        EXPECT_EQ(backgroundRet, LLBC_OK);
+        EXPECT_EQ(backgroundPrintRet, LLBC_OK);
+        EXPECT_EQ(highlightOnlyRet, LLBC_OK);
+        EXPECT_EQ(highlightOnlyPrintRet, LLBC_OK);
+        EXPECT_EQ(resetRet, LLBC_OK);
+        EXPECT_EQ(plainPrintRet, LLBC_OK);
+        EXPECT_EQ(flushRet, LLBC_OK);
+    }
+
+    EXPECT_NE(stdoutCaptured.find("\033[1;31;44mhighlighted\033[0m"), std::string::npos);
+    EXPECT_NE(stdoutCaptured.find("\033[1;31;44mhighlighted-line\033[0m\n"),
+              std::string::npos);
+    EXPECT_NE(stdoutCaptured.find("\033[32mforeground\033[0m"), std::string::npos);
+    EXPECT_NE(stdoutCaptured.find("\033[41mbackground\033[0m"), std::string::npos);
+    EXPECT_NE(stdoutCaptured.find("\033[1mhighlight-only\033[0m"), std::string::npos);
+    EXPECT_NE(stdoutCaptured.find("plain\n"), std::string::npos);
+
+    std::string stderrCaptured;
+    {
+        ScopedStdStreamRedirect redirect(stderr, STDERR_FILENO);
+        if (!redirect.Begin())
+            GTEST_SKIP() << "unable to redirect stderr";
+
+        ASSERT_EQ(LLBC_SetConsoleColor(stderr, LLBC_ConsoleColor::Fg_Blue), LLBC_OK);
+        ASSERT_EQ(__LLBC_FilePrint(false, stderr, "%s", "stderr"), LLBC_OK);
+        ASSERT_EQ(LLBC_FlushFile(stderr), LLBC_OK);
+        stderrCaptured = redirect.ReadCaptured();
+        ASSERT_EQ(LLBC_SetConsoleColor(stderr, originalStderrColor), LLBC_OK);
+    }
+
+    EXPECT_NE(stderrCaptured.find("\033[34mstderr\033[0m"), std::string::npos);
+#endif
+}

--- a/tests/unit_test/core/os/UnitTest_Core_OS_Network.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_Network.cpp
@@ -1,0 +1,54 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/os/OS_Network.cpp
+
+// The OS network adapter is used by socket setup code to translate numeric
+// endpoints without relying on DNS. Verify successful result ownership and the
+// framework error/sub-error mapping for a rejected numeric host.
+TEST(NetworkOsTest, ResolvesNumericEndpointsAndMapsGetAddrInfoFailures)
+{
+    addrinfo hints {};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+
+    addrinfo *result = nullptr;
+    ASSERT_EQ(LLBC_GetAddrInfo("127.0.0.1", "80", &hints, &result), LLBC_OK);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->ai_family, AF_INET);
+    EXPECT_EQ(result->ai_socktype, SOCK_STREAM);
+    LLBC_FreeAddrInfo(result);
+
+    result = nullptr;
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    LLBC_SetSubErrorNo(0);
+    EXPECT_EQ(LLBC_GetAddrInfo("not-a-numeric-address", "80", &hints, &result), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_GAI);
+    EXPECT_NE(LLBC_GetSubErrorNo(), 0);
+    EXPECT_EQ(result, nullptr);
+}

--- a/tests/unit_test/core/os/UnitTest_Core_OS_Process.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_Process.cpp
@@ -27,6 +27,44 @@ using namespace llbc;
 // Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
 // @coverage-target: llbc/src/core/os/OS_Process.cpp
 
+namespace
+{
+
+void NoopCrashHandler(const char *, int)
+{
+}
+
+} // namespace
+
+// The process helper exposes a small, safe configuration surface around crash
+// handling. Test validation and idempotent state changes without triggering a
+// crash or attempting to overwrite the host's core-pattern configuration.
+TEST(ProcessApiTest, ProcessIdAndCrashConfigurationValidation)
+{
+    EXPECT_GT(LLBC_GetCurrentProcessId(), 0);
+
+#if LLBC_SUPPORT_HANDLE_CRASH
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_SetCrashDumpFilePath(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_SetCrashHandler("", &NoopCrashHandler), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+
+    constexpr const char *handlerName = "unit-test-noop-crash-handler";
+    EXPECT_EQ(LLBC_SetCrashHandler(handlerName, &NoopCrashHandler), LLBC_OK);
+    EXPECT_EQ(LLBC_SetCrashHandler(handlerName, &NoopCrashHandler), LLBC_OK);
+    EXPECT_EQ(LLBC_SetCrashHandler(handlerName), LLBC_OK);
+    EXPECT_EQ(LLBC_SetCrashHandler(handlerName), LLBC_OK);
+
+    EXPECT_EQ(LLBC_EnableCrashHandle(), LLBC_OK);
+    EXPECT_EQ(LLBC_EnableCrashHandle(), LLBC_OK);
+    LLBC_DisableCrashHandle();
+    LLBC_DisableCrashHandle();
+#endif
+}
+
 #if LLBC_SUPPORT_HANDLE_CRASH
 
 /**

--- a/tests/unit_test/core/os/UnitTest_Core_OS_Select.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_Select.cpp
@@ -1,0 +1,97 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+#include <unistd.h>
+#endif
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/os/OS_Select.cpp
+
+namespace
+{
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+class ScopedPipe
+{
+public:
+    bool Create()
+    {
+        return ::pipe(_fds) == 0;
+    }
+
+    ~ScopedPipe()
+    {
+        if (_fds[0] != -1)
+            ::close(_fds[0]);
+        if (_fds[1] != -1)
+            ::close(_fds[1]);
+    }
+
+    int ReadFd() const
+    {
+        return _fds[0];
+    }
+
+    int WriteFd() const
+    {
+        return _fds[1];
+    }
+
+private:
+    int _fds[2] = {-1, -1};
+};
+#endif
+
+} // namespace
+
+// Select is a thin readiness wrapper used by socket/event loops. Validate the
+// timeout error mapping first, then use a local pipe to exercise readiness and
+// the POSIX invalid-argument path without opening network connections.
+TEST(SelectOsTest, ReportsTimeoutReadinessAndPosixErrors)
+{
+    EXPECT_EQ(LLBC_Select(0, nullptr, nullptr, nullptr, 0), 0);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_TIMEOUTED);
+
+#if LLBC_TARGET_PLATFORM_NON_WIN32
+    ScopedPipe pipe;
+    ASSERT_TRUE(pipe.Create());
+    ASSERT_EQ(::write(pipe.WriteFd(), "x", 1), 1);
+
+    LLBC_FdSet readFds;
+    LLBC_ZeroFdSet(&readFds);
+    LLBC_SetFd(pipe.ReadFd(), &readFds);
+    EXPECT_EQ(LLBC_Select(pipe.ReadFd() + 1, &readFds, nullptr, nullptr, 100), 1);
+    EXPECT_TRUE(LLBC_FdIsSet(pipe.ReadFd(), &readFds));
+
+    char byte = '\0';
+    ASSERT_EQ(::read(pipe.ReadFd(), &byte, 1), 1);
+    EXPECT_EQ(byte, 'x');
+
+    EXPECT_EQ(LLBC_Select(-1, nullptr, nullptr, nullptr, 0), -1);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+#endif
+}

--- a/tests/unit_test/core/os/UnitTest_Core_OS_Symbol.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_Symbol.cpp
@@ -1,0 +1,51 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/os/OS_Symbol.cpp
+
+// Symbol capture is used by diagnostics and crash reports. Restrict the test to
+// the non-Windows implementation, where initialization is idempotent and stack
+// capture only observes the current thread without installing signal handlers.
+TEST(SymbolOsTest, InitializesCapturesAndCleansUpCurrentThreadSymbols)
+{
+#if LLBC_CFG_OS_IMPL_SYMBOL && LLBC_TARGET_PLATFORM_NON_WIN32
+    EXPECT_EQ(LLBC_InitSymbol(), LLBC_OK);
+
+    const LLBC_String trace = LLBC_CaptureStackBackTrace(0, 8);
+    EXPECT_FALSE(trace.empty());
+    EXPECT_NE(trace.find("#"), static_cast<LLBC_String::size_type>(-1));
+
+    EXPECT_FALSE(LLBC_CaptureStackBackTrace().empty());
+    EXPECT_FALSE(
+        LLBC_CaptureStackBackTrace(1, LLBC_CFG_OS_SYMBOL_MAX_CAPTURE_FRAMES * 2).empty());
+    EXPECT_TRUE(
+        LLBC_CaptureStackBackTrace(LLBC_CFG_OS_SYMBOL_MAX_CAPTURE_FRAMES, 8).empty());
+    EXPECT_EQ(LLBC_CleanupSymbol(), LLBC_OK);
+#else
+    GTEST_SKIP() << "symbol implementation is platform-specific";
+#endif
+}

--- a/tests/unit_test/core/os/UnitTest_Core_OS_SysConf.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_SysConf.cpp
@@ -1,0 +1,43 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/os/OS_SysConf.cpp
+
+// Page size is initialized during LLBC startup on every supported platform. The
+// explicit cleanup/init cycle verifies that non-Windows sysconf paths restore it.
+TEST(SysConfTest, InitializesAndCleansUpPageSize)
+{
+    EXPECT_GT(LLBC_pageSize, 0);
+    EXPECT_EQ(LLBC_pageSize % 512, 0);
+
+    __LLBC_CleanUpSysConf();
+    EXPECT_EQ(LLBC_pageSize, 0);
+
+    EXPECT_EQ(__LLBC_InitSysConf(), LLBC_OK);
+    EXPECT_GT(LLBC_pageSize, 0);
+    EXPECT_EQ(LLBC_pageSize % 512, 0);
+}

--- a/tests/unit_test/core/os/UnitTest_Core_OS_Time.cpp
+++ b/tests/unit_test/core/os/UnitTest_Core_OS_Time.cpp
@@ -1,0 +1,55 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/os/OS_Time.cpp
+
+// The OS time adapter initializes local timezone state, exposes wall-clock
+// timeval data, and provides a monotonic tick counter for scheduling.
+TEST(OsTimeTest, InitializesTimezoneAndReportsWallAndMonotonicTime)
+{
+    LLBC_TZSet();
+    const int timezone = LLBC_GetTimezone();
+    EXPECT_GE(timezone, -24 * 60 * 60);
+    EXPECT_LE(timezone, 24 * 60 * 60);
+
+    timeval wallTime {};
+    ASSERT_EQ(LLBC_GetTimeOfDay(&wallTime, nullptr), LLBC_OK);
+    EXPECT_GT(wallTime.tv_sec, 0);
+    EXPECT_GE(wallTime.tv_usec, 0);
+    EXPECT_LT(wallTime.tv_usec, 1000000);
+
+    const uint64 before = LLBC_GetTickCount();
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    EXPECT_GE(LLBC_GetTickCount(), before);
+
+    // This is a no-op on platforms without RDTSC, but initializes capability
+    // flags where a processor counter is supported.
+    LLBC_InitTSCSupportFlags();
+}


### PR DESCRIPTION
## 概述

覆盖 Bundle、Console、Network、Process、Select、Symbol、SysConf 与 OS Time。

## 内容

### 库代码修正

- Bundle：默认句柄不再先依赖可能因 cwd 被删除而失败的主路径，直接用空路径创建主 Bundle。
- Console：保存 `fprintf` 返回值；写失败时设置 CLIB 错误并返回失败，同时保持动态缓冲释放。
- Symbol：先扣除 skipFrames 再限制捕获数，避免超过固定数组；Darwin 保留系统符号文本；Linux 反混淆让 `__cxa_demangle` 自行分配并释放，避免复用 TLS 缓冲时的容量/所有权风险。
- SysConf：POSIX `sysconf` 返回 long，扩展平台条件并用正确类型接收，保留 -1/errno 判定。

## 质量保证

- 独立分支：108 tests passed。
- CrashTest.DivisionByZero 在 AArch64 按架构语义跳过。
- 最终组合与 UBSan 非崩溃测试全量通过。