### PR TITLE
test: 补充线程同步与 Task 单元测试

### DIFF
--- a/llbc/src/core/thread/RWLock.cpp
+++ b/llbc/src/core/thread/RWLock.cpp
@@ -79,6 +79,7 @@ void LLBC_RWLock::ReadLock()
         {
             _holder.readCond.Wait(_holder.lock);
         }
+        --_holder.r_wait;
     }
 
     _holder.r_active ++;

--- a/llbc/src/core/thread/Semaphore.cpp
+++ b/llbc/src/core/thread/Semaphore.cpp
@@ -40,9 +40,11 @@ LLBC_Semaphore::LLBC_Semaphore(int initVal)
  #else
     LLBC_GUID guid = LLBC_GUIDHelper::Gen();
     LLBC_String str = LLBC_GUIDHelper::Format(guid);
-    str = str.substr(0, 20);
+    str = LLBC_String("/").append(str.substr(0, 20));
 
-    _sem = sem_open(str.c_str(), O_CREAT | O_EXCL, 0644, 0);
+    _sem = sem_open(str.c_str(), O_CREAT | O_EXCL, 0644, initVal);
+    if (_sem != SEM_FAILED)
+        sem_unlink(str.c_str());
  #endif
 #else
     _sem = ::CreateSemaphore(nullptr,
@@ -104,7 +106,7 @@ bool LLBC_Semaphore::TryWait()
 
 bool LLBC_Semaphore::TimedWait(int milliSeconds)
 {
-#if LLBC_TARGET_PLATFORM_LINUX || LLB_TARGET_PLATFORM_ANDROID
+#if LLBC_TARGET_PLATFORM_LINUX || LLBC_TARGET_PLATFORM_ANDROID
     struct timeval tvStart, tvEnd;
     struct timespec ts;
 

--- a/llbc/src/core/thread/Task.cpp
+++ b/llbc/src/core/thread/Task.cpp
@@ -100,9 +100,6 @@ int LLBC_Task::Activate(int threadNum,
     // Incr activate times.
     ++_activateTimes;
 
-    // Unlock
-    _lock.Unlock();
-
     return LLBC_OK;
 }
 

--- a/tests/unit_test/core/thread/UnitTest_Core_Thread_ConditionVariable.cpp
+++ b/tests/unit_test/core/thread/UnitTest_Core_Thread_ConditionVariable.cpp
@@ -1,0 +1,177 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/thread/ConditionVariable.cpp
+// @coverage-target: llbc/src/core/thread/SimpleLock.cpp
+
+namespace
+{
+
+bool WaitUntil(const std::atomic<int> &value, int expected)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (value.load(std::memory_order_acquire) != expected)
+    {
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    return true;
+}
+
+} // namespace
+
+// Timed waits preserve the caller's lock ownership and distinguish invalid
+// negative waits from normal timeout behavior.
+TEST(ConditionVariableTest, RejectsInvalidTimeoutAndReportsTimeout)
+{
+    LLBC_ConditionVariable condition;
+    LLBC_SimpleLock lock;
+
+    lock.Lock();
+    EXPECT_EQ(condition.TimedWait(lock, -2), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(condition.TimedWait(lock, 20), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_TIMEOUTED);
+    lock.Unlock();
+}
+
+// Notify releases exactly one waiter after the shared predicate is made true.
+TEST(ConditionVariableTest, NotifyUnblocksAWaitingThread)
+{
+    LLBC_ConditionVariable condition;
+    LLBC_SimpleLock lock;
+    std::atomic<int> waiters {0};
+    std::atomic<int> awakened {0};
+    std::atomic<bool> ready {false};
+
+    std::thread worker([&] {
+        lock.Lock();
+        waiters.fetch_add(1, std::memory_order_release);
+        while (!ready.load(std::memory_order_acquire))
+            condition.Wait(lock);
+        awakened.fetch_add(1, std::memory_order_release);
+        lock.Unlock();
+    });
+
+    ASSERT_TRUE(WaitUntil(waiters, 1));
+    lock.Lock();
+    ready.store(true, std::memory_order_release);
+    lock.Unlock();
+    condition.Notify();
+
+    worker.join();
+    EXPECT_EQ(awakened.load(std::memory_order_acquire), 1);
+}
+
+// Timed waits share the same predicate discipline as indefinite waits, but
+// must return success rather than timeout when a notifier arrives before the
+// deadline.
+TEST(ConditionVariableTest, TimedWaitSucceedsWhenNotifierArrivesBeforeDeadline)
+{
+    LLBC_ConditionVariable condition;
+    LLBC_SimpleLock lock;
+    std::atomic<int> waiters {0};
+    std::atomic<bool> completed {false};
+    std::atomic<int> waitResult {LLBC_FAILED};
+    std::atomic<bool> ready {false};
+
+    std::thread worker([&] {
+        lock.Lock();
+        waiters.fetch_add(1, std::memory_order_release);
+        while (!ready.load(std::memory_order_acquire))
+        {
+            const int result = condition.TimedWait(lock, 500);
+            waitResult.store(result, std::memory_order_release);
+            if (result != LLBC_OK)
+                break;
+        }
+        completed.store(ready.load(std::memory_order_acquire), std::memory_order_release);
+        lock.Unlock();
+    });
+
+    ASSERT_TRUE(WaitUntil(waiters, 1));
+    lock.Lock();
+    ready.store(true, std::memory_order_release);
+    lock.Unlock();
+    condition.Notify();
+
+    worker.join();
+    EXPECT_EQ(waitResult.load(std::memory_order_acquire), LLBC_OK);
+    EXPECT_TRUE(completed.load(std::memory_order_acquire));
+}
+
+// Broadcast must release all waiters, which is the coordination pattern used by
+// shutdown and global state transitions.
+TEST(ConditionVariableTest, BroadcastUnblocksAllWaitingThreads)
+{
+    LLBC_ConditionVariable condition;
+    LLBC_SimpleLock lock;
+    std::atomic<int> waiters {0};
+    std::atomic<int> awakened {0};
+    std::atomic<bool> ready {false};
+
+    auto worker = [&] {
+        lock.Lock();
+        waiters.fetch_add(1, std::memory_order_release);
+        while (!ready.load(std::memory_order_acquire))
+            condition.Wait(lock);
+        awakened.fetch_add(1, std::memory_order_release);
+        lock.Unlock();
+    };
+
+    std::thread first(worker);
+    std::thread second(worker);
+    ASSERT_TRUE(WaitUntil(waiters, 2));
+    lock.Lock();
+    ready.store(true, std::memory_order_release);
+    lock.Unlock();
+    condition.Broadcast();
+
+    first.join();
+    second.join();
+    EXPECT_EQ(awakened.load(std::memory_order_acquire), 2);
+}
+
+// Basic mutex semantics underpin condition-variable use: the non-recursive
+// simple lock must expose TryLock and IsDummyLock consistently.
+TEST(ConditionVariableTest, SimpleLockExposesExpectedMutexBehavior)
+{
+    LLBC_SimpleLock lock;
+    EXPECT_FALSE(lock.IsDummyLock());
+    EXPECT_TRUE(lock.TryLock());
+    lock.Unlock();
+
+    lock.Lock();
+    EXPECT_FALSE(lock.TryLock());
+    lock.Unlock();
+}

--- a/tests/unit_test/core/thread/UnitTest_Core_Thread_Locks.cpp
+++ b/tests/unit_test/core/thread/UnitTest_Core_Thread_Locks.cpp
@@ -1,0 +1,291 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/thread/RWLock.cpp
+// @coverage-target: llbc/src/core/thread/RecursiveLock.cpp
+// @coverage-target: llbc/src/core/thread/SpinLock.cpp
+// @coverage-target: llbc/src/core/thread/FastLock.cpp
+// @coverage-target: llbc/src/core/thread/Guard.cpp
+// @coverage-target: llbc/include/llbc/core/thread/GuardInl.h
+
+namespace
+{
+
+bool WaitFor(const std::atomic<bool> &value)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!value.load(std::memory_order_acquire))
+    {
+        if (std::chrono::steady_clock::now() >= deadline)
+            return false;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    return true;
+}
+
+template <typename LockType>
+void VerifyNonRecursiveLock(LockType &lock)
+{
+    EXPECT_FALSE(lock.IsDummyLock());
+    EXPECT_TRUE(lock.TryLock());
+
+    std::atomic<bool> otherThreadCouldLock {true};
+    std::thread contender([&] {
+        otherThreadCouldLock.store(lock.TryLock(), std::memory_order_release);
+        if (otherThreadCouldLock.load(std::memory_order_acquire))
+            lock.Unlock();
+    });
+    contender.join();
+    EXPECT_FALSE(otherThreadCouldLock.load(std::memory_order_acquire));
+
+    lock.Unlock();
+    EXPECT_TRUE(lock.TryLock());
+    lock.Unlock();
+}
+
+struct GuardTrackedObject
+{
+    ~GuardTrackedObject()
+    {
+        ++destructions;
+    }
+
+    static inline int destructions = 0;
+};
+
+struct GuardMemberReceiver
+{
+    void Add(int value)
+    {
+        sum += value;
+    }
+
+    int sum = 0;
+};
+
+} // namespace
+
+// Recursive locks allow a single owner to acquire repeatedly and release the
+// matching number of times, unlike the simple, fast, and spin lock variants.
+TEST(LockTest, RecursiveLockSupportsReentrantAcquisition)
+{
+    LLBC_RecursiveLock lock;
+    EXPECT_FALSE(lock.IsDummyLock());
+    lock.Lock();
+    lock.Lock();
+    EXPECT_TRUE(lock.TryLock());
+    lock.Unlock();
+    lock.Unlock();
+    lock.Unlock();
+    EXPECT_TRUE(lock.TryLock());
+    lock.Unlock();
+}
+
+TEST(LockTest, SpinAndFastLocksExcludeOtherThreads)
+{
+    LLBC_SpinLock spinLock;
+    VerifyNonRecursiveLock(spinLock);
+
+    LLBC_FastLock fastLock;
+    VerifyNonRecursiveLock(fastLock);
+}
+
+// FastLock also exposes a blocking Lock() path on platforms where its normal
+// fast path is backed by a mutex. A waiting caller must enter only after the
+// current owner releases the lock.
+TEST(LockTest, FastLockBlockingLockWaitsForOwnerRelease)
+{
+    LLBC_FastLock lock;
+    lock.Lock();
+
+    std::atomic<bool> waiterEntered {false};
+    std::thread waiter([&] {
+        lock.Lock();
+        waiterEntered.store(true, std::memory_order_release);
+        lock.Unlock();
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    EXPECT_FALSE(waiterEntered.load(std::memory_order_acquire));
+    lock.Unlock();
+    ASSERT_TRUE(WaitFor(waiterEntered));
+    waiter.join();
+}
+
+// Read/write locks allow concurrent readers but exclude writers. Waiting reader
+// and writer paths are exercised with coordinated worker threads.
+TEST(LockTest, ReadWriteLockCoordinatesReadersAndWriters)
+{
+    LLBC_RWLock lock;
+    lock.ReadLock();
+    EXPECT_TRUE(lock.ReadTryLock());
+    EXPECT_FALSE(lock.WriteTryLock());
+    lock.ReadUnlock();
+    lock.ReadUnlock();
+
+    EXPECT_TRUE(lock.WriteTryLock());
+    EXPECT_FALSE(lock.ReadTryLock());
+    lock.WriteUnlock();
+
+    std::atomic<bool> readerEntered {false};
+    lock.WriteLock();
+    std::thread reader([&] {
+        lock.ReadLock();
+        readerEntered.store(true, std::memory_order_release);
+        lock.ReadUnlock();
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    EXPECT_FALSE(readerEntered.load(std::memory_order_acquire));
+    lock.WriteUnlock();
+    ASSERT_TRUE(WaitFor(readerEntered));
+    reader.join();
+
+    std::atomic<bool> writerEntered {false};
+    lock.ReadLock();
+    std::thread writer([&] {
+        lock.WriteLock();
+        writerEntered.store(true, std::memory_order_release);
+        lock.WriteUnlock();
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    EXPECT_FALSE(writerEntered.load(std::memory_order_acquire));
+    lock.ReadUnlock();
+    ASSERT_TRUE(WaitFor(writerEntered));
+    writer.join();
+}
+
+// A writer queued behind an active writer takes the writer-notification path
+// when the owner releases. This preserves writer progress instead of waking
+// readers first and leaving the queued writer blocked indefinitely.
+TEST(LockTest, ReadWriteLockWakesQueuedWriterAfterWriterRelease)
+{
+    LLBC_RWLock lock;
+    lock.WriteLock();
+
+    std::atomic<bool> writerAttempting {false};
+    std::atomic<bool> writerEntered {false};
+    std::thread writer([&] {
+        writerAttempting.store(true, std::memory_order_release);
+        lock.WriteLock();
+        writerEntered.store(true, std::memory_order_release);
+        lock.WriteUnlock();
+    });
+
+    ASSERT_TRUE(WaitFor(writerAttempting));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    EXPECT_FALSE(writerEntered.load(std::memory_order_acquire));
+    lock.WriteUnlock();
+    ASSERT_TRUE(WaitFor(writerEntered));
+    writer.join();
+}
+
+// Scope guards pair locking and cleanup operations even in early-return paths.
+TEST(LockTest, GuardsLockUnlockDeleteFreeAndInvokeAtScopeExit)
+{
+    LLBC_SimpleLock lock;
+    {
+        LLBC_LockGuard guard(lock);
+        EXPECT_FALSE(lock.TryLock());
+    }
+    EXPECT_TRUE(lock.TryLock());
+    lock.Unlock();
+
+    lock.Lock();
+    {
+        LLBC_LockGuard reverseGuard(lock, true);
+        EXPECT_TRUE(lock.TryLock());
+        lock.Unlock();
+    }
+    EXPECT_FALSE(lock.TryLock());
+    lock.Unlock();
+
+    int *single = new int(1);
+    {
+        LLBC_DeleteGuard<int> guard(single);
+    }
+    EXPECT_EQ(single, nullptr);
+
+    int *array = new int[2] {1, 2};
+    {
+        LLBC_DeletesGuard<int> guard(array);
+    }
+    EXPECT_EQ(array, nullptr);
+
+    int *memory = LLBC_Malloc(int, 2);
+    {
+        LLBC_FreeGuard<int> guard(memory);
+    }
+    EXPECT_EQ(memory, nullptr);
+
+    int invoked = 0;
+    {
+        LLBC_InvokeGuard guard([&] { ++invoked; });
+        EXPECT_EQ(invoked, 0);
+    }
+    EXPECT_EQ(invoked, 1);
+}
+
+// Callers can retain their pointer variables after a guard releases storage.
+// This is useful when the pointer is embedded in a larger ownership record;
+// destruction still happens exactly once, but nulling is intentionally opted
+// out. Member callback guards follow the same scope-exit contract.
+TEST(LockTest, GuardsSupportNonNullingCleanupAndMemberCallbacks)
+{
+    GuardTrackedObject::destructions = 0;
+    GuardTrackedObject *single = new GuardTrackedObject;
+    {
+        LLBC_DeleteGuard<GuardTrackedObject> guard(single, false);
+    }
+    EXPECT_EQ(GuardTrackedObject::destructions, 1);
+    single = nullptr;
+
+    GuardTrackedObject::destructions = 0;
+    GuardTrackedObject *array = new GuardTrackedObject[2];
+    {
+        LLBC_DeletesGuard<GuardTrackedObject> guard(array, false);
+    }
+    EXPECT_EQ(GuardTrackedObject::destructions, 2);
+    array = nullptr;
+
+    int *memory = LLBC_Malloc(int, 2);
+    {
+        LLBC_FreeGuard<int> guard(memory, false);
+    }
+    memory = nullptr;
+
+    GuardMemberReceiver receiver;
+    {
+        LLBC_InvokeGuard guard(&receiver, &GuardMemberReceiver::Add, 7);
+        EXPECT_EQ(receiver.sum, 0);
+    }
+    EXPECT_EQ(receiver.sum, 7);
+}

--- a/tests/unit_test/core/thread/UnitTest_Core_Thread_MessageQueue.cpp
+++ b/tests/unit_test/core/thread/UnitTest_Core_Thread_MessageQueue.cpp
@@ -1,0 +1,432 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/thread/MessageQueue.cpp
+// @coverage-target: llbc/include/llbc/core/thread/MessageQueueInl.h
+// @coverage-target: llbc/include/llbc/core/thread/MessageBlockInl.h
+// @coverage-target: llbc/src/core/thread/MessageBuffer.cpp
+
+namespace
+{
+
+LLBC_MessageBlock *MakeBlock(const std::string &text)
+{
+    auto *block = new LLBC_MessageBlock(text.size());
+    EXPECT_EQ(block->Write(text.data(), text.size()), LLBC_OK);
+    return block;
+}
+
+std::string ReadBlock(LLBC_MessageBlock *block)
+{
+    std::string result(block->GetReadableSize(), '\0');
+    EXPECT_EQ(block->Read(result.data(), result.size()), LLBC_OK);
+    return result;
+}
+
+void DeleteChain(LLBC_MessageBlock *block)
+{
+    while (block)
+    {
+        auto *next = block->GetNext();
+        delete block;
+        block = next;
+    }
+}
+
+} // namespace
+
+// Message blocks own or attach buffers, grow on write, expose positional APIs,
+// and clone payload state without aliasing owned data.
+TEST(MessageQueueTest, MessageBlockReadsWritesResizesAndClones)
+{
+    LLBC_MessageBlock block(2);
+    EXPECT_NE(block.GetData(), nullptr);
+    EXPECT_EQ(block.GetReadableSize(), 0lu);
+    EXPECT_EQ(block.GetWritableSize(), 2lu);
+    EXPECT_EQ(block.Write(nullptr, 0), LLBC_OK);
+    EXPECT_EQ(block.Write(nullptr, 1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(block.Write("abcd", 4), LLBC_OK);
+    EXPECT_GE(block.GetSize(), 4lu);
+    EXPECT_EQ(block.GetReadableSize(), 4lu);
+    EXPECT_NE(block.GetDataStartWithReadPos(), nullptr);
+    EXPECT_NE(block.GetDataStartWithWritePos(), nullptr);
+
+    char read[3] {};
+    EXPECT_EQ(block.Read(read, 2), LLBC_OK);
+    EXPECT_EQ(std::string(read, 2), "ab");
+    EXPECT_EQ(block.GetReadableSize(), 2lu);
+    EXPECT_EQ(block.Read(nullptr, 1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_LIMIT);
+    EXPECT_EQ(block.Read(read, 3), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_LIMIT);
+    EXPECT_EQ(block.SetReadPos(LLBC_MessageBlock::npos), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_RANGE);
+    EXPECT_EQ(block.SetReadPos(1), LLBC_OK);
+    EXPECT_EQ(block.ShiftReadPos(1), LLBC_OK);
+    EXPECT_EQ(block.GetReadPos(), 2lu);
+    EXPECT_EQ(block.ShiftWritePos(-100), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_RANGE);
+    EXPECT_EQ(block.SetWritePos(4), LLBC_OK);
+    EXPECT_EQ(block.ShiftWritePos(-1), LLBC_OK);
+    EXPECT_EQ(block.GetWritePos(), 3lu);
+    EXPECT_EQ(block.Allocate(4), LLBC_OK);
+    EXPECT_GE(block.GetSize(), 8lu);
+
+    LLBC_MessageBlock *clone = block.Clone();
+    ASSERT_NE(clone, nullptr);
+    EXPECT_EQ(clone->GetReadableSize(), block.GetReadableSize());
+    EXPECT_EQ(ReadBlock(clone), "c");
+    delete clone;
+
+    char external[] = "xyz";
+    LLBC_MessageBlock attached(external, sizeof(external) - 1, true);
+    EXPECT_TRUE(attached.IsAttach());
+    EXPECT_EQ(attached.SetWritePos(3), LLBC_OK);
+    EXPECT_EQ(attached.Allocate(1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+    LLBC_MessageBlock *attachedClone = attached.Clone();
+    ASSERT_NE(attachedClone, nullptr);
+    EXPECT_TRUE(attachedClone->IsAttach());
+    delete attachedClone;
+    attached.Release();
+    EXPECT_EQ(attached.GetSize(), 0lu);
+    EXPECT_EQ(std::string(external), "xyz");
+
+    LLBC_MessageBlock swapLeft;
+    LLBC_MessageBlock swapRight;
+    ASSERT_EQ(swapLeft.Write("left", 4), LLBC_OK);
+    ASSERT_EQ(swapRight.Write("right", 5), LLBC_OK);
+    swapLeft.Swap(&swapRight);
+    EXPECT_EQ(ReadBlock(&swapLeft), "right");
+    EXPECT_EQ(ReadBlock(&swapRight), "left");
+}
+
+// Reused blocks must detach attached storage without freeing caller-owned
+// memory, while owned storage can be released explicitly. Cursor setters are
+// intentionally range checked because queue/buffer code uses them for partial
+// consumption and direct writes.
+TEST(MessageQueueTest, MessageBlockReleasesOwnedBuffersAndValidatesCursorRanges)
+{
+    LLBC_MessageBlock owned(4);
+    owned.SetTypedObjPool(nullptr);
+    EXPECT_EQ(owned.GetTypedObjPool(), nullptr);
+    ASSERT_EQ(owned.Write("xy", 2), LLBC_OK);
+    EXPECT_EQ(owned.SetReadPos(5), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_RANGE);
+    EXPECT_EQ(owned.ShiftReadPos(-1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_RANGE);
+    EXPECT_EQ(owned.ShiftReadPos(5), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_RANGE);
+    EXPECT_EQ(owned.SetWritePos(LLBC_MessageBlock::npos), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_RANGE);
+    EXPECT_EQ(owned.SetWritePos(5), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_RANGE);
+
+    owned.Release();
+    EXPECT_EQ(owned.GetData(), nullptr);
+    EXPECT_EQ(owned.GetSize(), 0lu);
+    EXPECT_EQ(owned.GetReadPos(), 0lu);
+    EXPECT_EQ(owned.GetWritePos(), 0lu);
+    owned.Release();
+
+    char external[] = "abc";
+    LLBC_MessageBlock attached(external, sizeof(external) - 1, true);
+    LLBC_MessageBlock previous;
+    LLBC_MessageBlock next;
+    attached.SetPrev(&previous);
+    attached.SetNext(&next);
+    ASSERT_EQ(attached.SetReadPos(1), LLBC_OK);
+    ASSERT_EQ(attached.SetWritePos(3), LLBC_OK);
+    attached.Clear();
+
+    EXPECT_FALSE(attached.IsAttach());
+    EXPECT_EQ(attached.GetData(), nullptr);
+    EXPECT_EQ(attached.GetSize(), 0lu);
+    EXPECT_EQ(attached.GetReadPos(), 0lu);
+    EXPECT_EQ(attached.GetWritePos(), 0lu);
+    EXPECT_EQ(attached.GetPrev(), nullptr);
+    EXPECT_EQ(attached.GetNext(), nullptr);
+    EXPECT_STREQ(external, "abc");
+}
+
+// Queue operations preserve front/back ordering, return a linked chain for
+// PopAll, and clean up unconsumed blocks when requested.
+TEST(MessageQueueTest, PushPopOrderPopAllAndCleanup)
+{
+    LLBC_MessageQueue queue;
+    LLBC_MessageBlock *block = nullptr;
+    EXPECT_FALSE(queue.TryPopFront(block));
+    EXPECT_FALSE(queue.TryPopBack(block));
+
+    queue.PushBack(MakeBlock("middle"));
+    queue.PushFront(MakeBlock("front"));
+    queue.PushBack(MakeBlock("back"));
+    EXPECT_EQ(queue.GetSize(), 3lu);
+
+    ASSERT_TRUE(queue.TryPopFront(block));
+    EXPECT_EQ(ReadBlock(block), "front");
+    delete block;
+    ASSERT_TRUE(queue.TryPopBack(block));
+    EXPECT_EQ(ReadBlock(block), "back");
+    delete block;
+    EXPECT_EQ(queue.GetSize(), 1lu);
+
+    LLBC_MessageBlock *all = nullptr;
+    ASSERT_TRUE(queue.PopAll(all));
+    ASSERT_NE(all, nullptr);
+    EXPECT_EQ(ReadBlock(all), "middle");
+    EXPECT_EQ(all->GetNext(), nullptr);
+    DeleteChain(all);
+    EXPECT_EQ(queue.GetSize(), 0lu);
+    EXPECT_FALSE(queue.PopAll(all));
+
+    queue.PushBack(MakeBlock("cleanup-one"));
+    queue.PushBack(MakeBlock("cleanup-two"));
+    queue.Cleanup();
+    EXPECT_EQ(queue.GetSize(), 0lu);
+}
+
+// Timed and blocking pops are the producer/consumer path used by task queues.
+TEST(MessageQueueTest, TimedAndBlockingPopsSynchronizeWithProducer)
+{
+    LLBC_MessageQueue queue;
+    LLBC_MessageBlock *block = nullptr;
+    EXPECT_FALSE(queue.TimedPopFront(block, 20));
+
+    std::atomic<bool> consumerStarted {false};
+    std::atomic<bool> readSucceeded {false};
+    std::string consumed;
+    std::thread consumer([&] {
+        consumerStarted.store(true, std::memory_order_release);
+        LLBC_MessageBlock *received = nullptr;
+        queue.PopFront(received);
+        if (received)
+        {
+            consumed.assign(received->GetReadableSize(), '\0');
+            readSucceeded.store(
+                received->Read(consumed.data(), consumed.size()) == LLBC_OK,
+                std::memory_order_release);
+        }
+        delete received;
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!consumerStarted.load(std::memory_order_acquire))
+    {
+        if (std::chrono::steady_clock::now() >= deadline)
+        {
+            queue.PushBack(MakeBlock("abort"));
+            consumer.join();
+            FAIL() << "consumer did not start before deadline";
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    queue.PushBack(MakeBlock("from-producer"));
+    consumer.join();
+    EXPECT_TRUE(readSucceeded.load(std::memory_order_acquire));
+    EXPECT_EQ(consumed, "from-producer");
+}
+
+// Back-oriented helpers share the queue's blocking core but must preserve the
+// same single-element and producer/consumer semantics as front-oriented calls.
+TEST(MessageQueueTest, SupportsBackOrientedTimedAndBlockingPops)
+{
+    LLBC_MessageQueue queue;
+    LLBC_MessageBlock *block = nullptr;
+    EXPECT_FALSE(queue.TimedPopBack(block, 10));
+
+    queue.PushFront(MakeBlock("only"));
+    ASSERT_TRUE(queue.TryPopBack(block));
+    ASSERT_NE(block, nullptr);
+    EXPECT_EQ(ReadBlock(block), "only");
+    delete block;
+    EXPECT_EQ(queue.GetSize(), 0lu);
+
+    std::atomic<bool> consumerStarted {false};
+    std::string consumed;
+    std::thread consumer([&] {
+        consumerStarted.store(true, std::memory_order_release);
+        LLBC_MessageBlock *received = nullptr;
+        queue.PopBack(received);
+        if (received)
+        {
+            consumed.assign(received->GetReadableSize(), '\0');
+            received->Read(consumed.data(), consumed.size());
+            delete received;
+        }
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!consumerStarted.load(std::memory_order_acquire))
+    {
+        if (std::chrono::steady_clock::now() >= deadline)
+        {
+            queue.PushBack(MakeBlock("abort"));
+            consumer.join();
+            FAIL() << "back-oriented consumer did not start before deadline";
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    queue.PushFront(MakeBlock("from-front"));
+    consumer.join();
+    EXPECT_EQ(consumed, "from-front");
+}
+
+// Message buffers coalesce writes into blocks, allow partial consumption and
+// removal, and can detach either the first block or a merged contiguous block.
+TEST(MessageQueueTest, MessageBufferReadsWritesAppendsDetachesAndMerges)
+{
+    LLBC_MessageBuffer buffer;
+    EXPECT_EQ(buffer.Write(nullptr, 1), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(buffer.Write("unused", 0), LLBC_OK);
+    EXPECT_EQ(buffer.GetSize(), 0lu);
+
+    ASSERT_EQ(buffer.Write("abc", 3), LLBC_OK);
+    char partial[3] {};
+    EXPECT_EQ(buffer.Read(partial, 2), 2lu);
+    EXPECT_EQ(std::string(partial, 2), "ab");
+    EXPECT_EQ(buffer.GetSize(), 1lu);
+    EXPECT_EQ(buffer.Remove(0), 0lu);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+
+    ASSERT_EQ(buffer.Write("def", 3), LLBC_OK);
+    ASSERT_EQ(buffer.Append(MakeBlock("ghi")), LLBC_OK);
+    EXPECT_EQ(buffer.GetSize(), 7lu);
+    EXPECT_NE(buffer.FirstBlock(), nullptr);
+
+    char all[8] {};
+    EXPECT_EQ(buffer.Read(all, 7), 7lu);
+    EXPECT_EQ(std::string(all, 7), "cdefghi");
+    EXPECT_EQ(buffer.GetSize(), 0lu);
+    EXPECT_EQ(buffer.Read(all, 1), 0lu);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NO_SUCH);
+
+    ASSERT_EQ(buffer.Append(MakeBlock("first")), LLBC_OK);
+    ASSERT_EQ(buffer.Append(MakeBlock("second")), LLBC_OK);
+    LLBC_MessageBlock *first = buffer.DetachFirstBlock();
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(ReadBlock(first), "first");
+    delete first;
+    EXPECT_EQ(buffer.GetSize(), 6lu);
+
+    LLBC_MessageBlock *merged = buffer.MergeBlocksAndDetach();
+    ASSERT_NE(merged, nullptr);
+    EXPECT_EQ(ReadBlock(merged), "second");
+    delete merged;
+    EXPECT_EQ(buffer.GetSize(), 0lu);
+    EXPECT_EQ(buffer.DetachFirstBlock(), nullptr);
+    EXPECT_EQ(buffer.MergeBlocksAndDetach(), nullptr);
+
+    ASSERT_EQ(buffer.Append(nullptr), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    buffer.Cleanup();
+}
+
+// Message buffers coalesce into spare tail capacity where possible, preserve
+// chained blocks once the resize limit is reached, and support partial/full
+// removal without exposing stale ownership to callers.
+TEST(MessageQueueTest, MessageBufferCoversCapacityChainAndRemovalEdgeCases)
+{
+    LLBC_MessageBuffer buffer;
+    char byte = '\0';
+    EXPECT_EQ(buffer.Read(nullptr, 1), 0lu);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(buffer.Read(&byte, 0), 0lu);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+
+    auto *spacious = new LLBC_MessageBlock(16);
+    ASSERT_EQ(spacious->Write("abc", 3), LLBC_OK);
+    ASSERT_EQ(buffer.Append(spacious), LLBC_OK);
+    EXPECT_EQ(buffer.Write("de", 2), LLBC_OK);
+    auto *coalesced = MakeBlock("fg");
+    ASSERT_EQ(buffer.Append(coalesced), LLBC_OK);
+    EXPECT_EQ(buffer.GetSize(), 7lu);
+
+    char compact[8] {};
+    EXPECT_EQ(buffer.Read(compact, 7), 7lu);
+    EXPECT_EQ(std::string(compact, 7), "abcdefg");
+    EXPECT_EQ(buffer.GetSize(), 0lu);
+
+    auto *empty = new LLBC_MessageBlock(0);
+    EXPECT_EQ(buffer.Append(empty), LLBC_OK);
+    EXPECT_EQ(buffer.GetSize(), 0lu);
+
+    LLBC_MessageBuffer removal;
+    ASSERT_EQ(removal.Write("abcdef", 6), LLBC_OK);
+    EXPECT_EQ(removal.Remove(2), 2lu);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(removal.GetSize(), 4lu);
+    EXPECT_EQ(removal.Remove(4), 4lu);
+    EXPECT_EQ(removal.GetSize(), 0lu);
+    EXPECT_EQ(removal.Remove(1), 0lu);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NO_SUCH);
+
+    LLBC_MessageBuffer crossBlockRemoval;
+    ASSERT_EQ(crossBlockRemoval.Append(MakeBlock("abc")), LLBC_OK);
+    ASSERT_EQ(crossBlockRemoval.Append(MakeBlock("def")), LLBC_OK);
+    EXPECT_EQ(crossBlockRemoval.Remove(4), 4lu);
+    EXPECT_EQ(crossBlockRemoval.GetSize(), 2lu);
+    char remaining[3] {};
+    EXPECT_EQ(crossBlockRemoval.Read(remaining, 2), 2lu);
+    EXPECT_EQ(std::string(remaining, 2), "ef");
+
+    ASSERT_EQ(removal.Write("cleanup", 7), LLBC_OK);
+    removal.Cleanup();
+    EXPECT_EQ(removal.GetSize(), 0lu);
+    EXPECT_EQ(removal.FirstBlock(), nullptr);
+
+    LLBC_MessageBuffer detachedBuffer;
+    ASSERT_EQ(detachedBuffer.Write("z", 1), LLBC_OK);
+    LLBC_MessageBlock *detached = detachedBuffer.DetachFirstBlock();
+    ASSERT_NE(detached, nullptr);
+    EXPECT_EQ(detachedBuffer.GetSize(), 0lu);
+    EXPECT_EQ(detachedBuffer.FirstBlock(), nullptr);
+    delete detached;
+
+    LLBC_MessageBuffer chained;
+    const std::string fullBlock(LLBC_CFG_COMM_MSG_BUFFER_ELEM_RESIZE_LIMIT, 'a');
+    ASSERT_EQ(chained.Write(fullBlock.data(), fullBlock.size()), LLBC_OK);
+    ASSERT_EQ(chained.Write("b", 1), LLBC_OK);
+    ASSERT_NE(chained.FirstBlock(), nullptr);
+    ASSERT_NE(chained.FirstBlock()->GetNext(), nullptr);
+    LLBC_MessageBlock *merged = chained.MergeBlocksAndDetach();
+    ASSERT_NE(merged, nullptr);
+    EXPECT_EQ(merged->GetReadableSize(), fullBlock.size() + 1);
+    delete merged;
+}

--- a/tests/unit_test/core/thread/UnitTest_Core_Thread_Semaphore.cpp
+++ b/tests/unit_test/core/thread/UnitTest_Core_Thread_Semaphore.cpp
@@ -1,0 +1,99 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/thread/Semaphore.cpp
+
+// Semaphores provide counting permits. Try/timed waits must not consume a
+// nonexistent permit, while nonpositive post counts still contribute one permit.
+TEST(SemaphoreTest, SupportsTryTimedAndCountingPermits)
+{
+    LLBC_Semaphore semaphore;
+    EXPECT_FALSE(semaphore.TryWait());
+    EXPECT_FALSE(semaphore.TimedWait(0));
+
+    semaphore.Post(-1);
+    EXPECT_TRUE(semaphore.TryWait());
+    EXPECT_FALSE(semaphore.TryWait());
+
+    semaphore.Post(2);
+    EXPECT_TRUE(semaphore.TryWait());
+    EXPECT_TRUE(semaphore.TryWait());
+    EXPECT_FALSE(semaphore.TryWait());
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_FALSE(semaphore.TimedWait(20));
+    EXPECT_NE(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+}
+
+// A waiter in another thread must unblock exactly after a post, establishing the
+// synchronization scenario used by worker queues and timers.
+TEST(SemaphoreTest, WaitUnblocksAfterAnotherThreadPosts)
+{
+    LLBC_Semaphore semaphore;
+    std::atomic<bool> acquired {false};
+
+    std::thread waiter([&] {
+        semaphore.Wait();
+        acquired.store(true, std::memory_order_release);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    EXPECT_FALSE(acquired.load(std::memory_order_acquire));
+    semaphore.Post();
+    waiter.join();
+    EXPECT_TRUE(acquired.load(std::memory_order_acquire));
+}
+
+// Constructor permits are immediately available and must be consumed in order.
+TEST(SemaphoreTest, HonorsInitialPermitCount)
+{
+    LLBC_Semaphore semaphore(2);
+    EXPECT_TRUE(semaphore.TryWait());
+    EXPECT_TRUE(semaphore.TryWait());
+    EXPECT_FALSE(semaphore.TryWait());
+}
+
+// TimedWait must consume both a permit that is already present and one posted
+// while it is polling/waiting. These are distinct success paths on macOS.
+TEST(SemaphoreTest, TimedWaitConsumesImmediateAndDelayedPermits)
+{
+    LLBC_Semaphore semaphore;
+    semaphore.Post();
+    EXPECT_TRUE(semaphore.TimedWait(50));
+
+    std::thread poster([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(15));
+        semaphore.Post();
+    });
+    EXPECT_TRUE(semaphore.TimedWait(100));
+    poster.join();
+    EXPECT_FALSE(semaphore.TryWait());
+}

--- a/tests/unit_test/core/thread/UnitTest_Core_Thread_Task.cpp
+++ b/tests/unit_test/core/thread/UnitTest_Core_Thread_Task.cpp
@@ -1,0 +1,254 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/thread/Task.cpp
+// @coverage-target: llbc/include/llbc/core/thread/TaskInl.h
+
+namespace
+{
+
+class OneShotTask final : public LLBC_Task
+{
+public:
+    explicit OneShotTask(LLBC_ThreadMgr *threadMgr = nullptr)
+    : LLBC_Task(threadMgr)
+    {
+    }
+
+    std::atomic<int> svcCalls {0};
+    std::atomic<int> cleanupCalls {0};
+    std::string consumed;
+
+    void Svc() override
+    {
+        LLBC_MessageBlock *block = nullptr;
+        if (TryPop(block) == LLBC_OK)
+        {
+            consumed.assign(block->GetReadableSize(), '\0');
+            block->Read(consumed.data(), consumed.size());
+            delete block;
+        }
+
+        svcCalls.fetch_add(1, std::memory_order_release);
+    }
+
+    void Cleanup() override
+    {
+        cleanupCalls.fetch_add(1, std::memory_order_release);
+    }
+};
+
+class BlockingTask final : public LLBC_Task
+{
+public:
+    LLBC_Semaphore gate;
+    std::atomic<int> svcCalls {0};
+    std::atomic<int> cleanupCalls {0};
+
+    void Svc() override
+    {
+        svcCalls.fetch_add(1, std::memory_order_release);
+        gate.Wait();
+    }
+
+    void Cleanup() override
+    {
+        cleanupCalls.fetch_add(1, std::memory_order_release);
+    }
+
+    void ReleaseWorker()
+    {
+        gate.Post();
+    }
+};
+
+LLBC_MessageBlock *MakeTaskBlock(const char *text)
+{
+    const size_t size = ::strlen(text);
+    auto *block = new LLBC_MessageBlock(size);
+    block->Write(text, size);
+    return block;
+}
+
+void DeleteTaskBlockChain(LLBC_MessageBlock *block)
+{
+    while (block)
+    {
+        LLBC_MessageBlock *next = block->GetNext();
+        delete block;
+        block = next;
+    }
+}
+
+} // namespace
+
+// Task exposes its internal queue before activation, which lets callers stage
+// work safely. The helper APIs also report all lifecycle descriptions and honor
+// an explicitly supplied thread manager.
+TEST(TaskTest, SupportsQueueHelpersAndInjectedThreadManager)
+{
+    EXPECT_STREQ(LLBC_TaskState::GetDesc(LLBC_TaskState::Activating), "Activating");
+    EXPECT_STREQ(LLBC_TaskState::GetDesc(LLBC_TaskState::Deactivating), "Deactivating");
+
+    LLBC_ThreadMgr threadMgr;
+    OneShotTask task(&threadMgr);
+    EXPECT_EQ(task.GetThreadMgr(), &threadMgr);
+
+    ASSERT_EQ(task.Push(MakeTaskBlock("front")), LLBC_OK);
+    ASSERT_EQ(task.Push(MakeTaskBlock("back")), LLBC_OK);
+    EXPECT_EQ(task.GetMessageSize(), 2lu);
+
+    LLBC_MessageBlock *block = nullptr;
+    ASSERT_EQ(task.Pop(block), LLBC_OK);
+    ASSERT_NE(block, nullptr);
+    EXPECT_EQ(block->GetReadableSize(), 5lu);
+    delete block;
+
+    block = nullptr;
+    ASSERT_EQ(task.TryPop(block), LLBC_OK);
+    ASSERT_NE(block, nullptr);
+    EXPECT_EQ(block->GetReadableSize(), 4lu);
+    delete block;
+    EXPECT_EQ(task.GetMessageSize(), 0lu);
+
+    block = nullptr;
+    EXPECT_EQ(task.TryPop(block), LLBC_FAILED);
+    EXPECT_EQ(task.TimedPop(block, 1), LLBC_FAILED);
+
+    ASSERT_EQ(task.Push(MakeTaskBlock("one")), LLBC_OK);
+    ASSERT_EQ(task.Push(MakeTaskBlock("two")), LLBC_OK);
+    LLBC_MessageBlock *all = nullptr;
+    ASSERT_EQ(task.PopAll(all), LLBC_OK);
+    ASSERT_NE(all, nullptr);
+    EXPECT_EQ(all->GetReadableSize(), 3lu);
+    ASSERT_NE(all->GetNext(), nullptr);
+    EXPECT_EQ(all->GetNext()->GetReadableSize(), 3lu);
+    DeleteTaskBlockChain(all);
+    EXPECT_EQ(task.PopAll(all), LLBC_FAILED);
+}
+
+// TimedPop delegates to the task queue's timed producer/consumer path and
+// succeeds when another thread supplies a message before the deadline.
+TEST(TaskTest, TimedPopConsumesMessagePostedBeforeDeadline)
+{
+    OneShotTask task;
+    std::thread producer([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(15));
+        task.Push(MakeTaskBlock("delayed"));
+    });
+
+    LLBC_MessageBlock *block = nullptr;
+    const int timedPopResult = task.TimedPop(block, 200);
+    producer.join();
+    ASSERT_EQ(timedPopResult, LLBC_OK);
+    ASSERT_NE(block, nullptr);
+    EXPECT_EQ(block->GetReadableSize(), 7lu);
+    delete block;
+    EXPECT_EQ(task.GetMessageSize(), 0lu);
+}
+
+// State descriptions, idle waits, message delivery, worker execution, and
+// cleanup form the core Task lifecycle.
+TEST(TaskTest, ActivatesConsumesMessageWaitsAndCleansUp)
+{
+    EXPECT_STREQ(LLBC_TaskState::GetDesc(LLBC_TaskState::NotActivated), "NotActivated");
+    EXPECT_STREQ(LLBC_TaskState::GetDesc(LLBC_TaskState::Activated), "Activated");
+    EXPECT_STREQ(LLBC_TaskState::GetDesc(999), "UnknownTaskState");
+
+    OneShotTask task;
+    EXPECT_FALSE(task.IsActivated());
+    EXPECT_EQ(task.GetTaskState(), LLBC_TaskState::NotActivated);
+    EXPECT_EQ(task.Wait(), LLBC_OK);
+    EXPECT_EQ(task.Activate(0), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_EQ(task.Activate(1, LLBC_ThreadPriority::End), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_ARG);
+    EXPECT_FALSE(task.IsActivated());
+    EXPECT_EQ(task.GetTaskState(), LLBC_TaskState::NotActivated);
+
+    ASSERT_EQ(task.Push(MakeTaskBlock("task-message")), LLBC_OK);
+    EXPECT_EQ(task.GetMessageSize(), 1lu);
+    ASSERT_EQ(task.Activate(), LLBC_OK);
+    EXPECT_EQ(task.Wait(), LLBC_OK);
+
+    EXPECT_EQ(task.svcCalls.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(task.cleanupCalls.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(task.consumed, "task-message");
+    EXPECT_FALSE(task.IsActivated());
+    EXPECT_EQ(task.GetTaskState(), LLBC_TaskState::NotActivated);
+    EXPECT_EQ(task.GetThreadGroupHandle(), LLBC_INVALID_HANDLE);
+}
+
+// A task that remains in Svc() rejects reentrant activation. Once released, the
+// activating thread can Wait() for cleanup and return to NotActivated.
+TEST(TaskTest, RejectsReentrantActivationAndWaitsForWorkerExit)
+{
+    BlockingTask task;
+    ASSERT_EQ(task.Activate(), LLBC_OK);
+    EXPECT_TRUE(task.IsActivated());
+    EXPECT_EQ(task.Activate(), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_NOT_ALLOW);
+
+    task.ReleaseWorker();
+    EXPECT_EQ(task.Wait(), LLBC_OK);
+    EXPECT_EQ(task.svcCalls.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(task.cleanupCalls.load(std::memory_order_acquire), 1);
+    EXPECT_FALSE(task.IsActivated());
+}
+
+// Multi-worker tasks exercise the coordination path where the first worker
+// waits for the other Svc() calls to leave. Only the activation thread may wait
+// for completion, preventing an unrelated thread from stealing lifecycle control.
+TEST(TaskTest, CoordinatesMultipleWorkersAndRejectsWaitFromAnotherThread)
+{
+    BlockingTask task;
+    ASSERT_EQ(task.Activate(2), LLBC_OK);
+    EXPECT_TRUE(task.IsActivated());
+    EXPECT_NE(task.GetThreadGroupHandle(), LLBC_INVALID_HANDLE);
+
+    std::atomic<int> otherWaitRet {LLBC_OK};
+    std::atomic<int> otherWaitError {LLBC_ERROR_SUCCESS};
+    std::thread otherThread([&] {
+        otherWaitRet.store(task.Wait(), std::memory_order_release);
+        otherWaitError.store(LLBC_GetLastError(), std::memory_order_release);
+    });
+    otherThread.join();
+    EXPECT_EQ(otherWaitRet.load(std::memory_order_acquire), LLBC_FAILED);
+    EXPECT_EQ(otherWaitError.load(std::memory_order_acquire), LLBC_ERROR_NOT_ALLOW);
+
+    task.ReleaseWorker();
+    task.ReleaseWorker();
+    EXPECT_EQ(task.Wait(), LLBC_OK);
+    EXPECT_EQ(task.svcCalls.load(std::memory_order_acquire), 2);
+    EXPECT_EQ(task.cleanupCalls.load(std::memory_order_acquire), 1);
+    EXPECT_FALSE(task.IsActivated());
+}


### PR DESCRIPTION
## 概述

覆盖条件变量、递归/自旋/快速/读写锁、消息队列、信号量和 Task 生命周期。

## 内容

### 库代码修正

- RWLock：读线程等待结束后递减 `r_wait`，防止等待计数永久累积并影响后续唤醒决策。
- POSIX Semaphore：名称增加必需的 `/` 前缀；将构造参数传给 sem_open；打开成功即 unlink，保证进程退出后不遗留命名对象且现有句柄继续有效。
- Android 条件宏修正 `LLB_` 拼写，确保 TimedWait 编译到预期实现。
- Task::Activate：锁已由作用域 guard 释放，删除末尾第二次 Unlock，避免解锁未持有 mutex。

## 质量保证

- 独立分支：127 tests passed，含多线程阻塞/唤醒。
- 最终组合与 UBSan 全量通过。