### PR TITLE
test: 补充 Time 与 TimeSpan 单元测试并修正日历边界

### DIFF
--- a/llbc/include/llbc/core/time/TimeInl.h
+++ b/llbc/include/llbc/core/time/TimeInl.h
@@ -88,7 +88,7 @@ LLBC_Time LLBC_Time::FromTimeStr(const char (&timeStr)[_StrArrLen],
 inline LLBC_Time LLBC_Time::FromTimeStr(const char *timeStr,
                                         const LLBC_TimeSep &timeSep)
 {
-    return FromTimeStr(timeStr, strlen(timeStr), timeSep);
+    return FromTimeStr(timeStr, timeStr ? strlen(timeStr) : 0, timeSep);
 }
 
 template <typename _StrType>
@@ -312,4 +312,3 @@ inline std::ostream &operator<<(std::ostream &stream, const LLBC_NS LLBC_Time &t
 {
     return stream << t.ToString();
 }
-

--- a/llbc/include/llbc/core/time/TimeSpanInl.h
+++ b/llbc/include/llbc/core/time/TimeSpanInl.h
@@ -80,7 +80,7 @@ LLBC_TimeSpan LLBC_TimeSpan::FromSpanStr(const char (&spanStr)[_StrArrLen],
 inline LLBC_TimeSpan LLBC_TimeSpan::FromSpanStr(const char *spanStr,
                                                 const LLBC_TimeSep &timeSep)
 {
-    return LLBC_TimeSpan(spanStr, strlen(spanStr), timeSep);
+    return LLBC_TimeSpan(spanStr, spanStr ? strlen(spanStr) : 0, timeSep);
 }
 
 template <typename _StrType>
@@ -111,7 +111,7 @@ LLBC_TimeSpan::LLBC_TimeSpan(const char (&spanStr)[_StrArrLen],
 
 inline LLBC_TimeSpan::LLBC_TimeSpan(const char *spanStr,
                                     const LLBC_TimeSep &timeSep)
-: LLBC_TimeSpan(spanStr, strlen(spanStr), timeSep)
+: LLBC_TimeSpan(spanStr, spanStr ? strlen(spanStr) : 0, timeSep)
 {
 }
 
@@ -354,5 +354,4 @@ inline std::ostream &operator<<(std::ostream &stream, const LLBC_NS LLBC_TimeSpa
 {
     return stream <<span.ToString();
 }
-
 

--- a/llbc/src/core/time/Time.cpp
+++ b/llbc/src/core/time/Time.cpp
@@ -72,10 +72,11 @@ LLBC_Time LLBC_Time::FromTimeParts(int year,
             minute * LLBC_TimeConst::numOfSecondsPerMinute + second;
         if (tz < 0 && totalSeconds < -tz)
         {
-            hour = -tz / LLBC_TimeConst::numOfSecondsPerHour;
-            minute = (-tz % LLBC_TimeConst::numOfSecondsPerHour) /
+            totalSeconds += -tz;
+            hour = totalSeconds / LLBC_TimeConst::numOfSecondsPerHour;
+            minute = (totalSeconds % LLBC_TimeConst::numOfSecondsPerHour) /
                 LLBC_TimeConst::numOfSecondsPerMinute;
-            second = -tz % LLBC_TimeConst::numOfSecondsPerMinute;
+            second = totalSeconds % LLBC_TimeConst::numOfSecondsPerMinute;
         }
     }
 
@@ -166,7 +167,7 @@ LLBC_Time LLBC_Time::AddYears(int years) const
     newTimeStruct.tm_year += years;
     bool isLeap = IsLeapYear(GetYear());
     if (isLeap && 
-        GetMonth() == 2 && GetDayOfMonth() == 29)
+        GetMonth() == 1 && GetDayOfMonth() == 29)
     {
         if (!IsLeapYear(GetYear() + years))
             newTimeStruct.tm_mday -= 1;
@@ -211,8 +212,8 @@ LLBC_Time LLBC_Time::AddMonths(int months) const
         }
     }
 
-    newTimeStruct.tm_mday = MIN(newTimeStruct.tm_mday, 
-        GetMonthMaxDays(yearAddedTime.GetYear(), newTimeStruct.tm_mon + 1));
+    newTimeStruct.tm_mday = MIN(newTimeStruct.tm_mday,
+        GetMonthMaxDays(newTimeStruct.tm_year + 1900, newTimeStruct.tm_mon + 1));
 
     return FromTimeStruct(newTimeStruct, GetMillisecond(), GetMicrosecond());
 }

--- a/tests/unit_test/core/time/UnitTest_Core_Time_Time.cpp
+++ b/tests/unit_test/core/time/UnitTest_Core_Time_Time.cpp
@@ -1,0 +1,271 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/time/Time.cpp
+// @coverage-target: llbc/include/llbc/core/time/TimeInl.h
+
+// Calendar constructors and accessors use local time consistently. Month is
+// deliberately zero-based, matching tm::tm_mon and the public documentation.
+TEST(TimeTest, ConstructsFormatsAndExposesCalendarParts)
+{
+    const auto time = LLBC_Time::FromTimeParts(2024, 2, 29, 23, 58, 57, 123, 456);
+
+    EXPECT_EQ(time.GetYear(), 2024);
+    EXPECT_EQ(time.GetMonth(), 1);
+    EXPECT_EQ(time.GetDayOfMonth(), 29);
+    EXPECT_EQ(time.GetDayOfWeek(), 4);       // Thursday, Sunday-based.
+    EXPECT_EQ(time.GetDayOfWeek(false), 3);  // Thursday, Monday-based.
+    EXPECT_EQ(time.GetHour(), 23);
+    EXPECT_EQ(time.GetMinute(), 58);
+    EXPECT_EQ(time.GetSecond(), 57);
+    EXPECT_EQ(time.GetMillisecond(), 123);
+    EXPECT_EQ(time.GetMicrosecond(), 456);
+    EXPECT_EQ(time.Format(), "2024-02-29 23:58:57");
+    EXPECT_EQ(time.ToString(), "2024-02-29 23:58:57.123456");
+    EXPECT_FALSE(time.FormatAsGmt().empty());
+
+    const timeval timevalValue {
+        static_cast<time_t>(time.GetTimestampInSecs()),
+        123456,
+    };
+    const auto fromTimeVal = LLBC_Time::FromTimeVal(timevalValue);
+    EXPECT_EQ(fromTimeVal.GetTimestampInSecs(), time.GetTimestampInSecs());
+    EXPECT_EQ(fromTimeVal.GetMicrosecond(), 456);
+
+    const timespec timeSpecValue {
+        static_cast<time_t>(time.GetTimestampInSecs()),
+        123456789,
+    };
+    const auto fromTimeSpec = LLBC_Time::FromTimeSpec(timeSpecValue);
+    EXPECT_EQ(fromTimeSpec.GetTimestampInSecs(), time.GetTimestampInSecs());
+    EXPECT_EQ(fromTimeSpec.GetMillisecond(), 123);
+    EXPECT_EQ(fromTimeSpec.GetMicrosecond(), 456);
+}
+
+// Parse string representations through every public overload, including custom
+// separators and a null C-string, which must safely return the UTC epoch value.
+TEST(TimeTest, ParsesTimeStringsAndCustomSeparators)
+{
+    const auto parsed = LLBC_Time::FromTimeStr("2024-02-29 23:58:57.123456");
+    EXPECT_EQ(parsed.ToString(), "2024-02-29 23:58:57.123456");
+
+    const std::string stdString = "2025-01-01 20:05:08.123456";
+    const LLBC_String llbcString(stdString);
+    EXPECT_EQ(LLBC_Time::FromTimeStr(stdString).ToString(), stdString);
+    EXPECT_EQ(LLBC_Time::FromTimeStr(llbcString).ToString(), stdString);
+
+    LLBC_TimeSep separators;
+    separators.YMDSep = '/';
+    separators.HMSSep = '.';
+    separators.microSecSep = '#';
+    EXPECT_EQ(LLBC_Time::FromTimeStr("2025/01/01 20.05.08#123456", separators).ToString(),
+              "2025-01-01 20:05:08.123456");
+
+    EXPECT_EQ(LLBC_Time::FromTimeStr(static_cast<const char *>(nullptr)), LLBC_Time::utcBegin);
+    EXPECT_EQ(LLBC_Time::FromTimeStr(" \t "), LLBC_Time::utcBegin);
+}
+
+// Calendar arithmetic preserves valid dates across leap years and month-end
+// boundaries, while duration arithmetic and comparisons operate in microseconds.
+TEST(TimeTest, AddsCalendarAndDurationIntervalsCorrectly)
+{
+    const auto leapDay = LLBC_Time::FromTimeParts(2020, 2, 29, 12, 0, 0, 1, 2);
+    EXPECT_EQ(leapDay.AddYears(1).ToString(), "2021-02-28 12:00:00.001002");
+    EXPECT_EQ(leapDay.AddYears(4).ToString(), "2024-02-29 12:00:00.001002");
+
+    const auto januaryEnd = LLBC_Time::FromTimeParts(2024, 1, 31, 1, 2, 3);
+    EXPECT_EQ(januaryEnd.AddMonths(1).ToString(), "2024-02-29 01:02:03.000000");
+    const auto marchEnd = LLBC_Time::FromTimeParts(2024, 3, 31, 1, 2, 3);
+    EXPECT_EQ(marchEnd.AddMonths(-1).ToString(), "2024-02-29 01:02:03.000000");
+
+    const auto base = LLBC_Time::FromTimeParts(2024, 1, 1, 1, 2, 3, 4, 5);
+    const auto shifted = base.AddDays(1)
+                             .AddHours(2)
+                             .AddMinutes(3)
+                             .AddSeconds(4)
+                             .AddMillis(5)
+                             .AddMicros(6);
+    EXPECT_EQ(shifted - base, LLBC_TimeSpan::FromDays(1, 2, 3, 4, 5, 6));
+    EXPECT_EQ(base + LLBC_TimeSpan::oneSec, base.AddSeconds(1));
+    EXPECT_EQ(base - LLBC_TimeSpan::oneSec, base.AddSeconds(-1));
+    EXPECT_LT(base, shifted);
+    EXPECT_GT(shifted, base);
+    EXPECT_NE(base, shifted);
+}
+
+// Begin/offset helpers and serialization drive timer scheduling. They must
+// normalize the calendar portions without losing subsecond precision.
+TEST(TimeTest, CalculatesBeginsOffsetsIntervalsAndSerialization)
+{
+    const auto time = LLBC_Time::FromTimeParts(2024, 2, 29, 23, 58, 57, 123, 456);
+
+    EXPECT_EQ(time.GetBeginTimeOfHour().ToString(), "2024-02-29 23:00:00.000000");
+    EXPECT_EQ(time.GetBeginTimeOfDay().ToString(), "2024-02-29 00:00:00.000000");
+    EXPECT_EQ(time.GetBeginTimeOfMonth().ToString(), "2024-02-01 00:00:00.000000");
+    EXPECT_EQ(time.GetOffsetTimeOfHour(), LLBC_TimeSpan::FromMinutes(58, 57, 123, 456));
+    EXPECT_EQ(time.GetOffsetTimeOfDay(), LLBC_TimeSpan::FromHours(23, 58, 57, 123, 456));
+    EXPECT_EQ(time.GetOffsetTimeOfMonth(),
+              LLBC_TimeSpan::FromDays(28, 23, 58, 57, 123, 456));
+
+    EXPECT_EQ(time.GetIntervalToTimeOfHour(LLBC_TimeSpan::FromMinutes(10)),
+              LLBC_TimeSpan::FromMinutes(11, 2, 876, 544));
+    EXPECT_EQ(time.GetIntervalToTimeOfDay(LLBC_TimeSpan::FromHours(1)),
+              LLBC_TimeSpan::FromHours(1, 1, 2, 876, 544));
+
+    LLBC_Stream stream;
+    time.Serialize(stream);
+    LLBC_Time decoded;
+    ASSERT_TRUE(decoded.Deserialize(stream));
+    EXPECT_EQ(decoded, time);
+
+    LLBC_Stream empty;
+    const auto unchanged = decoded;
+    EXPECT_FALSE(decoded.Deserialize(empty));
+    EXPECT_EQ(decoded, unchanged);
+
+    std::ostringstream output;
+    output << time;
+    EXPECT_EQ(output.str(), time.ToString());
+}
+
+// Short date/time forms are intentionally accepted for convenient scheduling
+// input. This exercises the one- and zero-separator parser branches as well as
+// whitespace normalization and the current-time helper.
+TEST(TimeTest, ParsesPartialFormsAndTracksCurrentTime)
+{
+    const auto secondOnly = LLBC_Time::FromTimeStr("35");
+    EXPECT_EQ(secondOnly.GetSecond(), 35);
+    EXPECT_EQ(secondOnly.GetMinute(), 0);
+
+    const auto minuteSecond = LLBC_Time::FromTimeStr("19:35");
+    EXPECT_EQ(minuteSecond.GetMinute(), 19);
+    EXPECT_EQ(minuteSecond.GetSecond(), 35);
+
+    const auto dayTime = LLBC_Time::FromTimeStr("13 19:35");
+    EXPECT_EQ(dayTime.GetDayOfMonth(), 13);
+    EXPECT_EQ(dayTime.GetHour(), 0);
+    EXPECT_EQ(dayTime.GetMinute(), 19);
+    EXPECT_EQ(dayTime.GetSecond(), 35);
+
+    const auto monthDayTime = LLBC_Time::FromTimeStr("12-13 19:35");
+    EXPECT_EQ(monthDayTime.GetMonth(), 11);
+    EXPECT_EQ(monthDayTime.GetDayOfMonth(), 13);
+
+    EXPECT_EQ(LLBC_Time::FromTimeStr(" \t2024-02-29 23:58:57.123456 \t ").ToString(),
+              "2024-02-29 23:58:57.123456");
+    EXPECT_EQ(LLBC_Time::FromTimeStr("123456789012 00:00:00"), LLBC_Time::utcBegin);
+
+    const sint64 before = LLBC_Time::NowTimestampInMicros();
+    const auto now = LLBC_Time::Now();
+    const sint64 after = LLBC_Time::NowTimestampInMicros();
+    EXPECT_GE(now.GetTimestampInMicros(), before);
+    EXPECT_LE(now.GetTimestampInMicros(), after);
+    EXPECT_FALSE(LLBC_Time::Format(now.GetTimestampInSecs(), nullptr).empty());
+    EXPECT_FALSE(LLBC_Time::FormatAsGmt(now.GetTimestampInSecs(), nullptr).empty());
+}
+
+// Calendar-cycle helpers support timers that fire at hour/day/week/month
+// boundaries. Test cross-year month math, weekly offsets, assignment, and
+// positive/non-positive cycle crossing behavior.
+TEST(TimeTest, HandlesCrossYearMonthAndCycleCalculations)
+{
+    const auto novemberEnd = LLBC_Time::FromTimeParts(2023, 11, 30, 1, 2, 3);
+    EXPECT_EQ(novemberEnd.AddMonths(3).ToString(), "2024-02-29 01:02:03.000000");
+    const auto januaryEnd = LLBC_Time::FromTimeParts(2024, 1, 31, 1, 2, 3);
+    EXPECT_EQ(januaryEnd.AddMonths(-2).ToString(), "2023-11-30 01:02:03.000000");
+
+    EXPECT_TRUE(LLBC_Time::IsLeapYear(2024));
+    EXPECT_FALSE(LLBC_Time::IsLeapYear(2023));
+    EXPECT_EQ(LLBC_Time::GetMonthMaxDays(2024, 2), 29);
+    EXPECT_EQ(LLBC_Time::GetMonthMaxDays(2023, 2), 28);
+    EXPECT_EQ(LLBC_Time::GetMonthSpanDays(2024, 2), 60);
+
+    const auto from = LLBC_Time::FromTimeParts(2024, 1, 1, 10, 0, 0);
+    const auto to = LLBC_Time::FromTimeParts(2024, 1, 3, 12, 0, 0);
+    EXPECT_EQ(LLBC_Time::GetCrossedHours(from, to), 50);
+    EXPECT_EQ(LLBC_Time::GetCrossedDays(from, to), 2);
+    EXPECT_EQ(LLBC_Time::GetCrossedHours(to, from), 0);
+    EXPECT_EQ(LLBC_Time::GetCrossedDays(to, from), 0);
+
+    const auto weeklyOffset = from.GetOffsetTimeOfWeek();
+    EXPECT_GE(weeklyOffset, LLBC_TimeSpan::zero);
+    EXPECT_LT(weeklyOffset, LLBC_TimeSpan::oneWeek);
+    EXPECT_EQ(from.GetBeginTimeOfWeek() + weeklyOffset, from);
+
+    LLBC_Time assigned;
+    assigned = from;
+    EXPECT_EQ(assigned, from);
+    const LLBC_Time &assignedAlias = assigned;
+    assigned = assignedAlias;
+    EXPECT_EQ(assigned, from);
+}
+
+// Weekly interval normalization accepts negative/overflowing offsets, and
+// crossed-month calculation handles both ordinary ranges and defensive inputs.
+// Extra date/time whitespace is accepted by the parser's separator handoff.
+TEST(TimeTest, NormalizesWeeklyIntervalsAndCountsMonthBoundaries)
+{
+    const auto parsed = LLBC_Time::FromTimeStr("2024-02-29   23:58:57");
+    EXPECT_EQ(parsed.ToString(), "2024-02-29 23:58:57.000000");
+
+    const auto time = LLBC_Time::FromTimeParts(2024, 1, 15, 12, 0, 0);
+    const auto negativeWeekOffset =
+        time.GetIntervalToTimeOfWeek(-LLBC_TimeSpan::oneDay, false);
+    const auto overflowingWeekOffset =
+        time.GetIntervalToTimeOfWeek(LLBC_TimeSpan::oneWeek + LLBC_TimeSpan::oneDay, true);
+    EXPECT_GE(negativeWeekOffset, LLBC_TimeSpan::zero);
+    EXPECT_LT(negativeWeekOffset, LLBC_TimeSpan::oneWeek);
+    EXPECT_GE(overflowingWeekOffset, LLBC_TimeSpan::zero);
+    EXPECT_LT(overflowingWeekOffset, LLBC_TimeSpan::oneWeek);
+
+    const auto from = LLBC_Time::FromTimeParts(2024, 1, 1, 0, 0, 0);
+    const auto to = LLBC_Time::FromTimeParts(2024, 3, 1, 0, 0, 0);
+    EXPECT_EQ(LLBC_Time::GetCrossedMonths(from, to), 2);
+    EXPECT_EQ(LLBC_Time::GetCrossedMonths(to, from), 0);
+    EXPECT_EQ(LLBC_Time::GetCrossedMonths(from, to, LLBC_TimeSpan::oneDay * 31), 0);
+
+    const auto weekStart = from.GetBeginTimeOfWeek();
+    EXPECT_EQ(LLBC_Time::GetCrossedWeeks(weekStart, weekStart.AddDays(15)), 2);
+
+    EXPECT_GT(LLBC_Time::NowTimestampInSecs(), 0);
+    EXPECT_GT(LLBC_Time::NowTimestampInMillis(), 0);
+    const auto microsRoundTrip = LLBC_Time::FromMicros(time.GetTimestampInMicros());
+    EXPECT_EQ(microsRoundTrip, time);
+    EXPECT_EQ(time.GetTimestampInMillis(),
+              time.GetTimestampInMicros() / LLBC_TimeConst::numOfMicrosPerMillisecond);
+    EXPECT_EQ(time.GetDayOfYear(), 14);
+
+    const tm gmt = time.GetGmtTime();
+    EXPECT_GE(gmt.tm_year, 0);
+    const tm local = time.GetLocalTime();
+    EXPECT_EQ(local.tm_year + 1900, time.GetYear());
+    EXPECT_TRUE(time >= time);
+    EXPECT_TRUE(time <= time);
+}

--- a/tests/unit_test/core/time/UnitTest_Core_Time_TimeSpan.cpp
+++ b/tests/unit_test/core/time/UnitTest_Core_Time_TimeSpan.cpp
@@ -1,0 +1,216 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/time/TimeSpan.cpp
+// @coverage-target: llbc/include/llbc/core/time/TimeSpanInl.h
+
+namespace
+{
+
+constexpr sint64 SpanMicros(int days,
+                            int hours = 0,
+                            int minutes = 0,
+                            int seconds = 0,
+                            int millis = 0,
+                            int micros = 0)
+{
+    return static_cast<sint64>(days) * LLBC_TimeConst::numOfMicrosPerDay +
+           static_cast<sint64>(hours) * LLBC_TimeConst::numOfMicrosPerHour +
+           static_cast<sint64>(minutes) * LLBC_TimeConst::numOfMicrosPerMinute +
+           static_cast<sint64>(seconds) * LLBC_TimeConst::numOfMicrosPerSecond +
+           static_cast<sint64>(millis) * LLBC_TimeConst::numOfMicrosPerMillisecond +
+           micros;
+}
+
+} // namespace
+
+// Time spans represent a signed duration in microseconds. The convenience builders
+// must preserve every component and expose both component and total accessors.
+TEST(TimeSpanTest, FactoriesComponentsAndConstants)
+{
+    constexpr auto span = LLBC_TimeSpan::FromDays(1, 2, 3, 4, 5, 6);
+    static_assert(span == LLBC_TimeSpan::FromMicros(SpanMicros(1, 2, 3, 4, 5, 6)));
+
+    EXPECT_EQ(span.GetDays(), 1);
+    EXPECT_EQ(span.GetHours(), 2);
+    EXPECT_EQ(span.GetMinutes(), 3);
+    EXPECT_EQ(span.GetSeconds(), 4);
+    EXPECT_EQ(span.GetMillis(), 5);
+    EXPECT_EQ(span.GetMicros(), 6);
+    EXPECT_EQ(span.GetTotalDays(), 1);
+    EXPECT_EQ(span.GetTotalHours(), 26);
+    EXPECT_EQ(span.GetTotalMinutes(), 1563);
+    EXPECT_EQ(span.GetTotalSeconds(), 93784);
+    EXPECT_EQ(span.GetTotalMillis(), 93784005);
+    EXPECT_EQ(span.GetTotalMicros(), SpanMicros(1, 2, 3, 4, 5, 6));
+    EXPECT_EQ(span.ToString(), "01 02:03:04.005006");
+
+    EXPECT_EQ(LLBC_TimeSpan::FromMicros(123).GetTotalMicros(), 123);
+    EXPECT_EQ(LLBC_TimeSpan::FromMillis(123, 456).GetTotalMicros(), 123456);
+    EXPECT_EQ(LLBC_TimeSpan::FromSeconds(1, 2, 3).GetTotalMicros(), 1002003);
+    EXPECT_EQ(LLBC_TimeSpan::FromMinutes(1, 2, 3, 4).GetTotalMicros(), 62003004);
+    EXPECT_EQ(LLBC_TimeSpan::FromHours(1, 2, 3, 4, 5).GetTotalMicros(), 3723004005);
+
+    EXPECT_EQ(LLBC_TimeSpan::zero, LLBC_TimeSpan::FromMicros(0));
+    EXPECT_EQ(LLBC_TimeSpan::oneMicrosec, LLBC_TimeSpan::FromMicros(1));
+    EXPECT_EQ(LLBC_TimeSpan::oneMillisec, LLBC_TimeSpan::FromMillis(1));
+    EXPECT_EQ(LLBC_TimeSpan::oneSec, LLBC_TimeSpan::FromSeconds(1));
+    EXPECT_EQ(LLBC_TimeSpan::oneMin, LLBC_TimeSpan::FromMinutes(1));
+    EXPECT_EQ(LLBC_TimeSpan::oneHour, LLBC_TimeSpan::FromHours(1));
+    EXPECT_EQ(LLBC_TimeSpan::oneDay, LLBC_TimeSpan::FromDays(1));
+    EXPECT_EQ(LLBC_TimeSpan::oneWeek, LLBC_TimeSpan::FromDays(7));
+    EXPECT_EQ(LLBC_TimeSpan::negOneMicrosec, LLBC_TimeSpan::FromMicros(-1));
+    EXPECT_EQ(LLBC_TimeSpan::negOneMillisec, LLBC_TimeSpan::FromMillis(-1));
+    EXPECT_EQ(LLBC_TimeSpan::negOneSec, LLBC_TimeSpan::FromSeconds(-1));
+    EXPECT_EQ(LLBC_TimeSpan::negOneMin, LLBC_TimeSpan::FromMinutes(-1));
+    EXPECT_EQ(LLBC_TimeSpan::negOneHour, LLBC_TimeSpan::FromHours(-1));
+    EXPECT_EQ(LLBC_TimeSpan::negOneDay, LLBC_TimeSpan::FromDays(-1));
+    EXPECT_EQ(LLBC_TimeSpan::negOneWeek, LLBC_TimeSpan::FromDays(-7));
+}
+
+// Duration arithmetic is deliberately value based: every operation returns or
+// mutates the underlying microsecond count with integer truncation for scaling.
+TEST(TimeSpanTest, ArithmeticAndComparisons)
+{
+    const auto base = LLBC_TimeSpan::FromSeconds(10, 500);
+    const auto incremented = LLBC_TimeSpan::zero
+                                 .AddDays(1)
+                                 .AddHours(2)
+                                 .AddMinutes(3)
+                                 .AddSeconds(4)
+                                 .AddMillis(5)
+                                 .AddMicros(6);
+    EXPECT_EQ(incremented, LLBC_TimeSpan::FromDays(1, 2, 3, 4, 5, 6));
+
+    EXPECT_EQ(-base, LLBC_TimeSpan::FromMillis(-10500));
+    EXPECT_EQ(base + LLBC_TimeSpan::FromSeconds(2), LLBC_TimeSpan::FromMillis(12500));
+    EXPECT_EQ(base - LLBC_TimeSpan::FromSeconds(2), LLBC_TimeSpan::FromMillis(8500));
+    EXPECT_EQ(base * 1.5, LLBC_TimeSpan::FromMillis(15750));
+    EXPECT_EQ(base / 2.0, LLBC_TimeSpan::FromMillis(5250));
+    EXPECT_EQ(base % 1000000, LLBC_TimeSpan::FromMillis(500));
+    EXPECT_EQ(base % LLBC_TimeSpan::FromSeconds(4), LLBC_TimeSpan::FromMillis(2500));
+
+    auto mutableSpan = base;
+    EXPECT_EQ((mutableSpan += LLBC_TimeSpan::FromSeconds(1)), LLBC_TimeSpan::FromMillis(11500));
+    EXPECT_EQ((mutableSpan -= LLBC_TimeSpan::FromMillis(500)), LLBC_TimeSpan::FromSeconds(11));
+    EXPECT_EQ((mutableSpan *= 1.5), LLBC_TimeSpan::FromMillis(16500));
+    EXPECT_EQ((mutableSpan /= 3.0), LLBC_TimeSpan::FromMillis(5500));
+    EXPECT_EQ((mutableSpan %= LLBC_TimeConst::numOfMicrosPerSecond),
+              LLBC_TimeSpan::FromMillis(500));
+    EXPECT_EQ((mutableSpan %= LLBC_TimeSpan::FromMicros(300)), LLBC_TimeSpan::FromMicros(200));
+
+    const auto same = LLBC_TimeSpan::FromSeconds(10, 500);
+    const auto smaller = LLBC_TimeSpan::FromSeconds(10, 499);
+    EXPECT_TRUE(base == same);
+    EXPECT_FALSE(base != same);
+    EXPECT_TRUE(base != smaller);
+    EXPECT_TRUE(base > smaller);
+    EXPECT_TRUE(base >= same);
+    EXPECT_TRUE(base >= smaller);
+    EXPECT_TRUE(smaller < base);
+    EXPECT_TRUE(smaller <= base);
+    EXPECT_TRUE(base <= same);
+}
+
+// A span string is a human-facing duration format, not a decimal seconds format:
+// the fraction after '.' is parsed directly as a microsecond integer.
+TEST(TimeSpanTest, ParsesSupportedFormatsAndStringOverloads)
+{
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("03"), LLBC_TimeSpan::FromSeconds(3));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("02:03"), LLBC_TimeSpan::FromMinutes(2, 3));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("01:02:03"), LLBC_TimeSpan::FromHours(1, 2, 3));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("8 01:02:03.4"),
+              LLBC_TimeSpan::FromDays(8, 1, 2, 3, 0, 4));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr(" \t 05   01:02:03.04 \t "),
+              LLBC_TimeSpan::FromDays(5, 1, 2, 3, 0, 4));
+
+    const std::string stdString = "05 01:02:03.04";
+    const LLBC_String llbcString(stdString);
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr(stdString),
+              LLBC_TimeSpan::FromDays(5, 1, 2, 3, 0, 4));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr(llbcString),
+              LLBC_TimeSpan::FromDays(5, 1, 2, 3, 0, 4));
+    EXPECT_EQ(LLBC_TimeSpan(stdString), LLBC_TimeSpan::FromDays(5, 1, 2, 3, 0, 4));
+    EXPECT_EQ(LLBC_TimeSpan(llbcString), LLBC_TimeSpan::FromDays(5, 1, 2, 3, 0, 4));
+    EXPECT_EQ(LLBC_TimeSpan(stdString.c_str()), LLBC_TimeSpan::FromDays(5, 1, 2, 3, 0, 4));
+
+    LLBC_TimeSep separators;
+    separators.datetimeSep = '#';
+    separators.HMSSep = '/';
+    separators.microSecSep = '*';
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("6#08/56/55*123456", separators),
+              LLBC_TimeSpan::FromDays(6, 8, 56, 55, 123, 456));
+}
+
+// Parsing must reject unsafe numeric fragments and be safe for empty or null
+// C-string inputs. Empty components are interpreted as zero by the parser.
+TEST(TimeSpanTest, ParsesDefensiveAndBoundaryInputs)
+{
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("1"), LLBC_TimeSpan::FromSeconds(1));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr(""), LLBC_TimeSpan::zero);
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr(" \t "), LLBC_TimeSpan::zero);
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr(static_cast<const char *>(nullptr)), LLBC_TimeSpan::zero);
+    EXPECT_EQ(LLBC_TimeSpan(static_cast<const char *>(nullptr)), LLBC_TimeSpan::zero);
+
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr(":2"), LLBC_TimeSpan::FromSeconds(2));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("1::2"), LLBC_TimeSpan::FromHours(1, 0, 2));
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("1:2:."), LLBC_TimeSpan::FromMinutes(62));
+
+    LLBC_TimeSep noTimeAfterDateSeparator;
+    noTimeAfterDateSeparator.datetimeSep = '#';
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("1#", noTimeAfterDateSeparator),
+              LLBC_TimeSpan::FromDays(1));
+
+    // The implementation uses a fixed 12-byte numeric buffer. An overlong part
+    // must stop parsing rather than overflow that buffer.
+    EXPECT_EQ(LLBC_TimeSpan::FromSpanStr("123456789012 01:02:03"), LLBC_TimeSpan::zero);
+}
+
+// Time spans are serializable duration values. Failed reads must not overwrite an
+// existing value, which lets callers safely retry with a complete stream.
+TEST(TimeSpanTest, SerializesAndFormatsForStreams)
+{
+    const auto source = LLBC_TimeSpan::FromDays(2, 3, 4, 5, 6, 7);
+    LLBC_Stream stream;
+    source.Serialize(stream);
+
+    LLBC_TimeSpan decoded = LLBC_TimeSpan::zero;
+    ASSERT_TRUE(decoded.Deserialize(stream));
+    EXPECT_EQ(decoded, source);
+
+    LLBC_Stream emptyStream;
+    LLBC_TimeSpan unchanged = LLBC_TimeSpan::FromSeconds(42);
+    EXPECT_FALSE(unchanged.Deserialize(emptyStream));
+    EXPECT_EQ(unchanged, LLBC_TimeSpan::FromSeconds(42));
+
+    std::ostringstream output;
+    output << source;
+    EXPECT_EQ(output.str(), "02 03:04:05.006007");
+}


### PR DESCRIPTION
## 概述

覆盖解析、格式化、算术、序列化、日历周期和边界输入。

## 内容

### 库代码修正

- C 字符串重载在调用 strlen 前检查 null，将其作为长度 0 交给既有解析逻辑，避免空指针崩溃。
- FromTimeParts 的缺省日期分支原先只从时区偏移推导时分秒，丢失传入的日内秒数；先合并 totalSeconds 与 -tz 再拆分，恢复完整时间。
- AddYears 使用 0-based 月份，闰日判断由 2 改为 1；只在 2 月 29 日跨到非闰年时归一化。
- AddMonths 取目标 `tm_year` 的月份天数，而不是仅加整年后的中间年份，修正跨年非整年月份偏移。

## 质量保证

- 独立分支：111 tests passed。
- 最终组合与 UBSan 全量通过。