### PR TITLE
test: 补充核心 Utils 单元测试并修正边界与 UB

### DIFF
--- a/llbc/include/llbc/core/utils/Util_AlgorithmInl.h
+++ b/llbc/include/llbc/core/utils/Util_AlgorithmInl.h
@@ -27,66 +27,52 @@ template <typename T>
 int LLBC_CheckFlowUseAdd(T value, T addent)
 {
     if (UNLIKELY(addent == 0))
-    {
         return LLBC_FlowType::NoFlow;
-    }
 
-    T result = value + addent;
-    if (T(T(0) - 1) > 0)
+    if constexpr (std::is_unsigned_v<T>)
     {
-        return ((result < value) ?
-            LLBC_FlowType::OverFlow : LLBC_FlowType::NoFlow);
+        return value > std::numeric_limits<T>::max() - addent ?
+            LLBC_FlowType::OverFlow : LLBC_FlowType::NoFlow;
     }
     else
     {
         if (addent > 0)
         {
-            return ((result < value) ?
-                LLBC_FlowType::OverFlow : LLBC_FlowType::NoFlow);
+            return value > std::numeric_limits<T>::max() - addent ?
+                LLBC_FlowType::OverFlow : LLBC_FlowType::NoFlow;
         }
         else
         {
-            //return ((value + addent > value) ?
-                //LLBC_FlowType::UnderFlow : LLBC_FlowType::NoFlow);
-            if (result > value)
-                return LLBC_FlowType::UnderFlow;
-            else
-                return LLBC_FlowType::NoFlow;
+            return value < std::numeric_limits<T>::lowest() - addent ?
+                LLBC_FlowType::UnderFlow : LLBC_FlowType::NoFlow;
         }
     }
-
-    return LLBC_FlowType::NoFlow;
 }
 
 template <typename T>
 int LLBC_CheckFlowUseSub(T value, T subtrahend)
 {
     if (UNLIKELY(subtrahend == 0))
-    {
         return LLBC_FlowType::NoFlow;
-    }
 
-    T result = value - subtrahend;
-    if (T(T(0) - 1) > 0)
+    if constexpr (std::is_unsigned_v<T>)
     {
-        return ((result > value) ?
-            LLBC_FlowType::UnderFlow : LLBC_FlowType::NoFlow);
+        return value < subtrahend ?
+            LLBC_FlowType::UnderFlow : LLBC_FlowType::NoFlow;
     }
     else
     {
         if (subtrahend > 0)
         {
-            return ((result > value) ?
-                LLBC_FlowType::UnderFlow : LLBC_FlowType::NoFlow);
+            return value < std::numeric_limits<T>::lowest() + subtrahend ?
+                LLBC_FlowType::UnderFlow : LLBC_FlowType::NoFlow;
         }
         else
         {
-            return ((result < value) ?
-                LLBC_FlowType::OverFlow : LLBC_FlowType::NoFlow);
+            return value > std::numeric_limits<T>::max() + subtrahend ?
+                LLBC_FlowType::OverFlow : LLBC_FlowType::NoFlow;
         }
     }
-
-    return LLBC_FlowType::NoFlow;
 }
 
 __LLBC_NS_END

--- a/llbc/include/llbc/core/utils/Util_TextInl.h
+++ b/llbc/include/llbc/core/utils/Util_TextInl.h
@@ -66,9 +66,12 @@ LLBC_FORCE_INLINE char *__LLBC_Integral2Str(_IntegralTy val, size_t *strLen)
     }
     else
     {
+        using _UnsignedTy = std::make_unsigned_t<_IntegralTy>;
+        _UnsignedTy magnitude = static_cast<_UnsignedTy>(val);
+        if (val < 0)
+            magnitude = _UnsignedTy(0) - magnitude;
         str = __LLBC_UIntegral2StrImpl<
-            std::make_unsigned_t<_IntegralTy>, _HexFormat>(
-                std::make_unsigned_t<_IntegralTy>(val < 0 ? -val : val), strEnd);
+            _UnsignedTy, _HexFormat>(magnitude, strEnd);
         if (val < 0)
             *--str = '-';
     }
@@ -98,7 +101,9 @@ LLBC_Num2Str2(_NumTy num, size_t *strLen)
     }
     else if constexpr (std::is_enum_v<_NumTy>)
     {
-        return LLBC_INL_NS __LLBC_Integral2Str<sint64, _HexFormat>(static_cast<sint64>(num), strLen);
+        using _UnderlyingTy = std::underlying_type_t<_NumTy>;
+        return LLBC_INL_NS __LLBC_Integral2Str<_UnderlyingTy, _HexFormat>(
+            static_cast<_UnderlyingTy>(num), strLen);
     }
     else if constexpr (std::is_integral_v<_NumTy>)
     {
@@ -163,12 +168,12 @@ LLBC_Num2Str(_NumTy num)
 }
 
 #define __LLBC_InlMacro_Num2StrProcessErr()           \
-    if (errno != 0) {                                 \
-        LLBC_SetLastError(LLBC_ERROR_CLIB);           \
+    if (strEnd == str) {                              \
+        LLBC_SetLastError(LLBC_ERROR_INVALID);        \
         return _NumTy();                              \
     }                                                 \
-    else if (strEnd == str) {                         \
-        LLBC_SetLastError(LLBC_ERROR_INVALID);        \
+    else if (errno != 0) {                            \
+        LLBC_SetLastError(LLBC_ERROR_CLIB);           \
         return _NumTy();                              \
     }                                                 \
     else if (*strEnd != '\0') {                       \

--- a/llbc/src/core/utils/Util_Algorithm.cpp
+++ b/llbc/src/core/utils/Util_Algorithm.cpp
@@ -53,8 +53,8 @@ static const char *__flow_descs[] =
 
 const char *LLBC_FlowType::Type2Str(int type)
 {
-    return ((type >= LLBC_FlowType::Unknown) ? 
-        __flow_descs[LLBC_FlowType::Unknown] : __flow_descs[type]);
+    return type >= LLBC_FlowType::NoFlow && type < LLBC_FlowType::Unknown ?
+        __flow_descs[type] : __flow_descs[LLBC_FlowType::Unknown];
 }
 
 int LLBC_FlowType::Str2Type(const char *type)
@@ -142,9 +142,8 @@ __LLBC_NS_END
   char *_itoa(int value, char *string, int radix)
   {
       LLBC_String result = LLBC_ItoA(value, radix);
-      strcmp(string, result.c_str());
-
-      return nullptr;
+      strcpy(string, result.c_str());
+      return string;
   }
  #endif
 
@@ -152,9 +151,8 @@ __LLBC_NS_END
   char *_i64toa(long long value, char *string, int radix)
   {
       LLBC_String result = LLBC_I64toA(value, radix);
-      strcmp(string, result.c_str());
-
-      return nullptr;
+      strcpy(string, result.c_str());
+      return string;
   }
  #endif
 
@@ -162,9 +160,8 @@ __LLBC_NS_END
   char *_ui64toa(unsigned long long value, char *string, int radix)
   {
       LLBC_String result = LLBC_UI64toA(value, radix);
-      strcmp(string, result.c_str());
-
-      return nullptr;
+      strcpy(string, result.c_str());
+      return string;
   }
  #endif
 

--- a/llbc/src/core/utils/Util_Base64.cpp
+++ b/llbc/src/core/utils/Util_Base64.cpp
@@ -159,10 +159,11 @@ size_t LLBC_Base64::CalcEncodeLen(size_t bytesLen)
 size_t LLBC_Base64::CalcDecodedLen(const char *input, size_t inputLen)
 {
     size_t placeHolderCount = 0;
-    for (size_t i = inputLen - 1; input[i] == '='; --i)
+    for (size_t i = inputLen; i > 0 && input[i - 1] == '='; --i)
         ++placeHolderCount;
 
-    return ((6 * inputLen) / 8) - placeHolderCount;
+    const size_t decodedLen = (inputLen / 4) * 3 + ((inputLen % 4) * 3) / 4;
+    return decodedLen > placeHolderCount ? decodedLen - placeHolderCount : 0;
 }
 
 __LLBC_NS_END

--- a/llbc/src/core/utils/Util_Debug.cpp
+++ b/llbc/src/core/utils/Util_Debug.cpp
@@ -77,8 +77,10 @@ LLBC_String LLBC_Byte2Hex(const void *bytes, size_t len, char byteSep, size_t li
     hexStr.resize(hexSize);
     while (true)
     {
-        *reinterpret_cast<uint16*>(&hexStr[hexStrIdx]) =
+        const uint16 hex =
             LLBC_INL_NS __g_hexTable[(reinterpret_cast<const uint8 *>(bytes))[byteIdx++]];
+        hexStr[hexStrIdx] = static_cast<char>(hex & 0xff);
+        hexStr[hexStrIdx + 1] = static_cast<char>(hex >> 8);
         hexStrIdx += 2;
 
         if (byteSep != '\0')
@@ -106,4 +108,3 @@ uint64 LLBC_Stopwatch::_frequency = 0;
 #endif
 
 __LLBC_NS_END
-

--- a/llbc/src/core/utils/Util_MD5.cpp
+++ b/llbc/src/core/utils/Util_MD5.cpp
@@ -313,9 +313,6 @@ LLBC_String LLBC_MD5::Digest(const void *bytes, size_t len)
 LLBC_String LLBC_MD5::HexDigest(const void *bytes, size_t len)
 {
     const auto digest = Digest(bytes, len);
-    if (digest.empty())
-        return "";
-
     char hexDigest[33];
     const auto digestPtr = reinterpret_cast<const uint8 *>(digest.data());
     snprintf(hexDigest,

--- a/llbc/src/core/utils/Util_Misc.cpp
+++ b/llbc/src/core/utils/Util_Misc.cpp
@@ -77,6 +77,8 @@ int LLBC_StartArgs::Parse(int argc, char *argv[])
         _namingArgs[splitedArg[0]] = splitedArg[1];
     }
 
+    _parsed = true;
+
     return LLBC_OK;
 }
 

--- a/llbc/src/core/utils/Util_Network.cpp
+++ b/llbc/src/core/utils/Util_Network.cpp
@@ -44,11 +44,18 @@ bool LLBC_IsIPv4Addr(const LLBC_String &addr)
         if (part.empty())
             return false;
 
+        uint32 value = 0;
         for (LLBC_String::size_type i = 0;
              i < part.length();
              i++)
+        {
             if (!('0' <= part[i] && part[i] <= '9'))
                 return false;
+
+            value = value * 10 + static_cast<uint32>(part[i] - '0');
+            if (value > 255)
+                return false;
+        }
     }
 
     return true;

--- a/llbc/src/core/utils/Util_Variant.cpp
+++ b/llbc/src/core/utils/Util_Variant.cpp
@@ -91,7 +91,7 @@ void LLBC_VariantUtil::Xml2Variant(const LLBC_TINYXML2_NS XMLElement &elem, LLBC
 
     // Children elements.
     auto &childrenVar = var[LLBC_XMLKeys::Children];
-    childrenVar.Become<LLBC_Variant::Dict>();
+    childrenVar.Become<LLBC_Variant::Seq>();
 
     auto child = elem.FirstChildElement();
     for (; child; child = child->NextSiblingElement())

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Algorithm.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Algorithm.cpp
@@ -1,0 +1,103 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/utils/Util_Algorithm.cpp
+// @coverage-target: llbc/include/llbc/core/utils/Util_AlgorithmInl.h
+
+// Flow descriptions are used by diagnostics and configuration. Invalid values,
+// including negative integers, must map to the safe "unknown" sentinel.
+TEST(AlgorithmUtilTest, FlowTypeStringConversions)
+{
+    EXPECT_STREQ(LLBC_FlowType::Type2Str(LLBC_FlowType::NoFlow), "no flow");
+    EXPECT_STREQ(LLBC_FlowType::Type2Str(LLBC_FlowType::UnderFlow), "underflow");
+    EXPECT_STREQ(LLBC_FlowType::Type2Str(LLBC_FlowType::OverFlow), "overflow");
+    EXPECT_STREQ(LLBC_FlowType::Type2Str(LLBC_FlowType::Unknown), "unknown");
+    EXPECT_STREQ(LLBC_FlowType::Type2Str(-1), "unknown");
+    EXPECT_STREQ(LLBC_FlowType::Type2Str(99), "unknown");
+
+    EXPECT_EQ(LLBC_FlowType::Str2Type("no flow"), LLBC_FlowType::NoFlow);
+    EXPECT_EQ(LLBC_FlowType::Str2Type("underflow"), LLBC_FlowType::UnderFlow);
+    EXPECT_EQ(LLBC_FlowType::Str2Type("overflow"), LLBC_FlowType::OverFlow);
+    EXPECT_EQ(LLBC_FlowType::Str2Type("unknown"), LLBC_FlowType::Unknown);
+    EXPECT_EQ(LLBC_FlowType::Str2Type(nullptr), LLBC_FlowType::Unknown);
+}
+
+// Overflow helpers must classify operations without evaluating an overflowing
+// signed expression. Cover signed positive/negative changes and unsigned wrap.
+TEST(AlgorithmUtilTest, FlowChecksCoverSignedAndUnsignedBoundaries)
+{
+    constexpr sint32 intMax = std::numeric_limits<sint32>::max();
+    constexpr sint32 intMin = std::numeric_limits<sint32>::lowest();
+    constexpr uint32 uintMax = std::numeric_limits<uint32>::max();
+
+    EXPECT_EQ(LLBC_CheckFlowUseAdd<sint32>(0, 0), LLBC_FlowType::NoFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseAdd<sint32>(intMax, 1), LLBC_FlowType::OverFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseAdd<sint32>(intMin, -1), LLBC_FlowType::UnderFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseAdd<sint32>(intMax, -1), LLBC_FlowType::NoFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseAdd<sint32>(intMin, 1), LLBC_FlowType::NoFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseAdd<uint32>(uintMax, 1u), LLBC_FlowType::OverFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseAdd<uint32>(42u, 1u), LLBC_FlowType::NoFlow);
+
+    EXPECT_EQ(LLBC_CheckFlowUseSub<sint32>(0, 0), LLBC_FlowType::NoFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseSub<sint32>(intMin, 1), LLBC_FlowType::UnderFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseSub<sint32>(intMax, -1), LLBC_FlowType::OverFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseSub<sint32>(intMin, -1), LLBC_FlowType::NoFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseSub<sint32>(intMax, 1), LLBC_FlowType::NoFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseSub<uint32>(0u, 1u), LLBC_FlowType::UnderFlow);
+    EXPECT_EQ(LLBC_CheckFlowUseSub<uint32>(1u, 1u), LLBC_FlowType::NoFlow);
+}
+
+// Escaping is used to preserve delimiter-bearing values. It escapes both the
+// requested characters and the escape marker itself, then restores the exact
+// input through the matching unescape operation.
+TEST(AlgorithmUtilTest, EscapesAndUnescapesDelimiterAndEscapeCharacters)
+{
+    LLBC_String escaped = "a,b\\c";
+    EXPECT_EQ(LLBC_StringEscape(escaped, ",", '\\'), "a\\,b\\\\c");
+    EXPECT_EQ(LLBC_StringUnEscape(escaped, '\\'), "a,b\\c");
+
+    LLBC_String markerOnly = "a#b";
+    EXPECT_EQ(LLBC_StringEscape(markerOnly, "", '#'), "a##b");
+    EXPECT_EQ(LLBC_StringUnEscape(markerOnly, '#'), "a#b");
+
+    LLBC_String unchanged = "plain";
+    EXPECT_EQ(LLBC_StringEscape(unchanged, ",", '\\'), "plain");
+    EXPECT_EQ(LLBC_StringUnEscape(unchanged, '\\'), "plain");
+
+    LLBC_String empty;
+    EXPECT_TRUE(LLBC_StringEscape(empty, ",", '\\').empty());
+
+    // Signed char values are intentionally ignored by the compact 128-bit flag
+    // table, which only represents the ASCII range.
+    LLBC_String nonAscii(1, static_cast<char>(0xff));
+    EXPECT_EQ(LLBC_StringEscape(nonAscii, nonAscii, static_cast<char>(0xfe)).size(), 1lu);
+
+    LLBC_String terminalEscape = "end,";
+    EXPECT_EQ(LLBC_StringEscape(terminalEscape, ",", '\\'), "end\\,");
+}

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Base64.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Base64.cpp
@@ -114,6 +114,16 @@ TEST(Base64Test, CalcEncodeLen)
     }
 }
 
+TEST(Base64Test, CalcDecodedLenHandlesEmptyAndDegeneratePadding)
+{
+    EXPECT_EQ(LLBC_Base64::CalcDecodedLen(nullptr, 0), 0lu);
+    EXPECT_EQ(LLBC_Base64::CalcDecodedLen("", 0), 0lu);
+    EXPECT_EQ(LLBC_Base64::CalcDecodedLen("====", 4), 0lu);
+    EXPECT_EQ(LLBC_Base64::CalcDecodedLen("Zg==", 4), 1lu);
+    EXPECT_EQ(LLBC_Base64::CalcDecodedLen("Zm8=", 4), 2lu);
+    EXPECT_EQ(LLBC_Base64::CalcDecodedLen("Zm9v", 4), 3lu);
+}
+
 // Test that the LLBC_String / raw-buffer overloads agree with the std::string overload:
 TEST(Base64Test, OverloadConsistency)
 {

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Debug.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Debug.cpp
@@ -1,0 +1,84 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/utils/Util_Debug.cpp
+// @coverage-target: llbc/include/llbc/core/utils/Util_DebugInl.h
+
+// Hex dumps are used by diagnostics and protocol troubleshooting. Exercise raw
+// output, separators, line wrapping, and the empty-input fast path.
+TEST(DebugUtilTest, ByteToHexFormatsBytesAndLineBreaks)
+{
+    const uint8 bytes[] = {0x00, 0x12, 0xab, 0xff};
+
+    EXPECT_EQ(LLBC_Byte2Hex(bytes, sizeof(bytes)), "0012abff");
+    EXPECT_EQ(LLBC_Byte2Hex(bytes, sizeof(bytes), ':'), "00:12:ab:ff:");
+    EXPECT_EQ(LLBC_Byte2Hex(bytes, sizeof(bytes), '\0', 2), "0012\nabff");
+    EXPECT_EQ(LLBC_Byte2Hex(bytes, sizeof(bytes), ':', 2), "00:12:\nab:ff:");
+    EXPECT_TRUE(LLBC_Byte2Hex(nullptr, 0).empty());
+}
+
+// Stopwatch supports both stopped elapsed-tick instances and live measurement.
+// Pausing must freeze the accumulated interval until it is explicitly resumed.
+TEST(DebugUtilTest, StopwatchMeasuresAndControlsElapsedTime)
+{
+    LLBC_Stopwatch::InitFrequency();
+    EXPECT_GT(LLBC_Stopwatch::GetFrequency(), 0u);
+
+    LLBC_Stopwatch stopped(123u, false);
+    EXPECT_FALSE(stopped.IsRunning());
+    EXPECT_EQ(stopped.ElapsedTicks(), 123u);
+    EXPECT_GE(stopped.Elapsed().GetTotalMicros(), 0);
+    stopped.Reset();
+    EXPECT_EQ(stopped.ElapsedTicks(), 0u);
+    EXPECT_EQ(stopped.ElapsedNanos(), 0u);
+
+    stopped.Resume();
+    EXPECT_TRUE(stopped.IsRunning());
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    stopped.Pause();
+    EXPECT_FALSE(stopped.IsRunning());
+    const uint64 pausedTicks = stopped.ElapsedTicks();
+    EXPECT_GT(pausedTicks, 0u);
+    const uint64 pausedNanos = stopped.ElapsedNanos();
+    EXPECT_GT(pausedNanos, 0u);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    EXPECT_EQ(stopped.ElapsedTicks(), pausedTicks);
+    EXPECT_EQ(stopped.ElapsedNanos(), pausedNanos);
+    EXPECT_NE(stopped.ToString().find(" ms"), static_cast<LLBC_String::size_type>(-1));
+
+    stopped.Restart();
+    EXPECT_TRUE(stopped.IsRunning());
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    EXPECT_GT(stopped.Elapsed().GetTotalMicros(), 0);
+    EXPECT_GT(stopped.ElapsedNanos(), 0u);
+    EXPECT_GT(stopped.ElapsedTicks(), 0u);
+    stopped.Pause();
+}

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_MD5.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_MD5.cpp
@@ -1,0 +1,195 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/utils/Util_MD5.cpp
+// @coverage-target: llbc/include/llbc/core/utils/Util_MD5Inl.h
+
+namespace
+{
+
+std::string DigestToHex(const LLBC_String &digest)
+{
+    static constexpr char HexDigits[] = "0123456789abcdef";
+
+    std::string result;
+    result.reserve(digest.size() * 2);
+    for (const unsigned char byte : digest)
+    {
+        result.push_back(HexDigits[byte >> 4]);
+        result.push_back(HexDigits[byte & 0x0f]);
+    }
+
+    return result;
+}
+
+std::vector<uint8> MakePayload(size_t len)
+{
+    std::vector<uint8> payload;
+    payload.reserve(len);
+    for (size_t i = 0; i < len; ++i)
+        payload.push_back(static_cast<uint8>((i * 37 + 11) % 256));
+
+    return payload;
+}
+
+class ScopedTempFile
+{
+public:
+    ScopedTempFile()
+    : _path(std::filesystem::temp_directory_path() /
+            ("llbc_unit_test_md5_" +
+             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) +
+             ".bin"))
+    {
+    }
+
+    ~ScopedTempFile()
+    {
+        std::error_code ignored;
+        std::filesystem::remove(_path, ignored);
+    }
+
+    const std::filesystem::path &Path() const
+    {
+        return _path;
+    }
+
+private:
+    std::filesystem::path _path;
+};
+
+} // namespace
+
+// The public API must produce the canonical RFC 1321 vectors.
+TEST(MD5Test, RFC1321HexDigestVectors)
+{
+    const std::pair<const char *, const char *> vectors[] = {
+        {"", "d41d8cd98f00b204e9800998ecf8427e"},
+        {"a", "0cc175b9c0f1b6a831c399e269772661"},
+        {"abc", "900150983cd24fb0d6963f7d28e17f72"},
+        {"message digest", "f96b697d7cb7938d525a2f31aaf161d0"},
+        {"abcdefghijklmnopqrstuvwxyz", "c3fcd3d76192e4007dfb496cca67e13b"},
+        {"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+         "d174ab98d277d9f5a5611c2c9f419d9f"},
+        {"1234567890123456789012345678901234567890"
+         "1234567890123456789012345678901234567890",
+         "57edf4a22be3c955ac49da2e2107b67a"},
+    };
+
+    for (const auto &[input, expected] : vectors)
+    {
+        const LLBC_String bytes(input);
+        EXPECT_EQ(LLBC_MD5::HexDigest(bytes), expected) << "input: " << input;
+        EXPECT_EQ(DigestToHex(LLBC_MD5::Digest(bytes)), expected) << "input: " << input;
+    }
+}
+
+// Exercise all MD5 padding boundaries, full message blocks, and binary input.
+TEST(MD5Test, RawBufferDigestHandlesBlockAndPaddingBoundaries)
+{
+    struct TestCase
+    {
+        size_t length;
+        const char *expectedHex;
+    };
+
+    const TestCase cases[] = {
+        {1, "13c8ffd977013703a701cf8e11deac65"},
+        {55, "d872aa0473a24da995ce4ac518ade767"},
+        {56, "e23567645846677c205de80f9779081b"},
+        {63, "4775b66278a8fc132ff80923378216cd"},
+        {64, "71e123b70c7aa64826fcfe472694cd1c"},
+        {65, "5949948f26e35203661075214faa3966"},
+        {127, "520bdc2dbab7c25d64263ffb242d9e98"},
+        {128, "3e93b378458b77da96b2357c3bda8cc2"},
+        {129, "d1ae06bbf9128955a34bedb6231eee62"},
+    };
+
+    for (const auto &testCase : cases)
+    {
+        const auto payload = MakePayload(testCase.length);
+        const auto digest = LLBC_MD5::Digest(payload.data(), payload.size());
+
+        ASSERT_EQ(digest.size(), 16lu) << "length: " << testCase.length;
+        EXPECT_EQ(DigestToHex(digest), testCase.expectedHex) << "length: " << testCase.length;
+        EXPECT_EQ(LLBC_MD5::HexDigest(payload.data(), payload.size()), testCase.expectedHex)
+            << "length: " << testCase.length;
+    }
+}
+
+// The LLBC_String inline overloads must preserve binary bytes and agree with raw buffers.
+TEST(MD5Test, OverloadsAndNullEmptyInputAreConsistent)
+{
+    const auto payload = MakePayload(65);
+    const LLBC_String bytes(reinterpret_cast<const char *>(payload.data()), payload.size());
+
+    const auto rawDigest = LLBC_MD5::Digest(payload.data(), payload.size());
+    EXPECT_EQ(LLBC_MD5::Digest(bytes), rawDigest);
+    EXPECT_EQ(LLBC_MD5::HexDigest(bytes), LLBC_MD5::HexDigest(payload.data(), payload.size()));
+
+    const auto emptyDigest = LLBC_MD5::Digest(nullptr, 0);
+    EXPECT_EQ(emptyDigest.size(), 16lu);
+    EXPECT_EQ(DigestToHex(emptyDigest), "d41d8cd98f00b204e9800998ecf8427e");
+    EXPECT_EQ(LLBC_MD5::HexDigest(nullptr, 0), "d41d8cd98f00b204e9800998ecf8427e");
+}
+
+// File hashing is intended for binary files; it must match the in-memory digest and
+// report an empty result when the file cannot be read.
+TEST(MD5Test, FileDigestMatchesMemoryAndReportsReadFailure)
+{
+    const auto payload = MakePayload(129);
+    const LLBC_String bytes(reinterpret_cast<const char *>(payload.data()), payload.size());
+    const auto expectedDigest = LLBC_MD5::Digest(bytes);
+    const auto expectedHexDigest = LLBC_MD5::HexDigest(bytes);
+
+    ScopedTempFile file;
+    {
+        std::ofstream output(file.Path(), std::ios::binary);
+        ASSERT_TRUE(output.is_open());
+        output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        ASSERT_TRUE(output.good());
+    }
+
+    const LLBC_String fileName(file.Path().string());
+    EXPECT_EQ(LLBC_MD5::FileDigest(fileName), expectedDigest);
+    EXPECT_EQ(LLBC_MD5::FileHexDigest(fileName), expectedHexDigest);
+
+    const LLBC_String missingFileName((file.Path().string() + ".missing").c_str());
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_TRUE(LLBC_MD5::FileDigest(missingFileName).empty());
+    EXPECT_NE(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_TRUE(LLBC_MD5::FileHexDigest(missingFileName).empty());
+    EXPECT_NE(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+}

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Math.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Math.cpp
@@ -1,0 +1,44 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/include/llbc/core/utils/Util_MathInl.h
+
+// The math utility deliberately supplies generic integral handling and dedicated
+// floating-point specializations. Verify sign, zero, and unsigned passthrough.
+TEST(MathUtilTest, AbsoluteValueSupportsIntegralAndFloatingTypes)
+{
+    EXPECT_EQ(LLBC_Abs(-42), 42);
+    EXPECT_EQ(LLBC_Abs(42), 42);
+    EXPECT_EQ(LLBC_Abs(0), 0);
+    EXPECT_EQ(LLBC_Abs<uint32>(42u), 42u);
+
+    EXPECT_FLOAT_EQ(LLBC_Abs(-1.25f), 1.25f);
+    EXPECT_FLOAT_EQ(LLBC_Abs(1.25f), 1.25f);
+    EXPECT_DOUBLE_EQ(LLBC_Abs(-2.5), 2.5);
+    EXPECT_DOUBLE_EQ(LLBC_Abs(2.5), 2.5);
+    EXPECT_DOUBLE_EQ(static_cast<double>(LLBC_Abs(-3.75L)), 3.75);
+}

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Misc.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Misc.cpp
@@ -1,0 +1,109 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/utils/Util_Misc.cpp
+
+// StartArgs models a process command line: argv[0] is the executable path, every
+// remaining token is positional, and non-empty keys in key=value tokens form a
+// lookup map.
+TEST(MiscUtilTest, StartArgsParsesPositionalAndNamedArguments)
+{
+    char module[] = "/opt/llbc/demo";
+    char positional[] = "input.txt";
+    char mode[] = "mode=debug";
+    char emptyValue[] = "empty=";
+    char compoundValue[] = "filter=a=b";
+    char noKey[] = "=ignored";
+    char *argv[] = {module, positional, mode, emptyValue, compoundValue, noKey};
+
+    LLBC_StartArgs args;
+    EXPECT_FALSE(args.IsParsed());
+    EXPECT_EQ(args.Parse(static_cast<int>(std::size(argv)), argv), LLBC_OK);
+    EXPECT_TRUE(args.IsParsed());
+
+    EXPECT_EQ(args.GetModuleFilePath(), module);
+    EXPECT_EQ(args.GetArgumentsCount(), 5lu);
+    EXPECT_EQ(args.GetAllArguments().size(), 5lu);
+    EXPECT_EQ(args[0].As<LLBC_String>(), positional);
+    EXPECT_EQ(args[1].As<LLBC_String>(), mode);
+    EXPECT_EQ(args[2].As<LLBC_String>(), emptyValue);
+    EXPECT_EQ(args[3].As<LLBC_String>(), compoundValue);
+    EXPECT_EQ(args[4].As<LLBC_String>(), noKey);
+
+    EXPECT_EQ(args.GetNamingArgumentsCount(), 3lu);
+    EXPECT_EQ(args.GetAllNamingArguments().size(), 3lu);
+    EXPECT_EQ(args["mode"].As<LLBC_String>(), "debug");
+    EXPECT_EQ(args["empty"].As<LLBC_String>(), "");
+    EXPECT_EQ(args["filter"].As<LLBC_String>(), "a=b");
+
+    EXPECT_TRUE(args[99].Is<void>());
+    EXPECT_TRUE(args["missing"].Is<void>());
+}
+
+// Parse() is reusable. A second command line must replace rather than append to
+// the previous state; this verifies the parsed flag and reset path.
+TEST(MiscUtilTest, StartArgsReparseResetsPriorState)
+{
+    char firstModule[] = "first";
+    char firstArg[] = "a=1";
+    char *firstArgv[] = {firstModule, firstArg};
+
+    LLBC_StartArgs args;
+    ASSERT_EQ(args.Parse(static_cast<int>(std::size(firstArgv)), firstArgv), LLBC_OK);
+    ASSERT_TRUE(args.IsParsed());
+
+    char secondModule[] = "second";
+    char secondPositional[] = "plain";
+    char secondArg[] = "b=2";
+    char *secondArgv[] = {secondModule, secondPositional, secondArg};
+    ASSERT_EQ(args.Parse(static_cast<int>(std::size(secondArgv)), secondArgv), LLBC_OK);
+
+    EXPECT_TRUE(args.IsParsed());
+    EXPECT_EQ(args.GetModuleFilePath(), secondModule);
+    EXPECT_EQ(args.GetArgumentsCount(), 2lu);
+    EXPECT_EQ(args[0].As<LLBC_String>(), secondPositional);
+    EXPECT_EQ(args[1].As<LLBC_String>(), secondArg);
+    EXPECT_EQ(args.GetNamingArgumentsCount(), 1lu);
+    EXPECT_TRUE(args["a"].Is<void>());
+    EXPECT_EQ(args["b"].As<LLBC_String>(), "2");
+}
+
+// Invalid command-line metadata is rejected and does not falsely mark an object
+// parsed. This protects callers that use IsParsed() as a parse-success guard.
+TEST(MiscUtilTest, StartArgsRejectsInvalidInput)
+{
+    LLBC_StartArgs args;
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(args.Parse(0, nullptr), LLBC_FAILED);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+    EXPECT_FALSE(args.IsParsed());
+    EXPECT_EQ(args.GetArgumentsCount(), 0lu);
+    EXPECT_EQ(args.GetNamingArgumentsCount(), 0lu);
+    EXPECT_TRUE(args[0].Is<void>());
+    EXPECT_TRUE(args["missing"].Is<void>());
+}

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Network.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Network.cpp
@@ -1,0 +1,54 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/utils/Util_Network.cpp
+
+// This predicate is used to decide whether a socket endpoint is a literal IPv4
+// address or must be resolved as a host name. It therefore validates both shape
+// and each octet's legal 0..255 range.
+TEST(NetworkUtilTest, RecognizesValidIPv4Literals)
+{
+    EXPECT_TRUE(LLBC_IsIPv4Addr("127.0.0.1"));
+    EXPECT_TRUE(LLBC_IsIPv4Addr("0.0.0.0"));
+    EXPECT_TRUE(LLBC_IsIPv4Addr("255.255.255.255"));
+    EXPECT_TRUE(LLBC_IsIPv4Addr("001.002.003.004"));
+}
+
+TEST(NetworkUtilTest, RejectsInvalidIPv4ShapesAndOctets)
+{
+    EXPECT_FALSE(LLBC_IsIPv4Addr(""));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("127.0.0"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("127.0.0.1.2"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("127..0.1"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr(".127.0.1"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("127.0.0."));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("127.a.0.1"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("127.-1.0.1"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("256.0.0.1"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("999.1.1.1"));
+    EXPECT_FALSE(LLBC_IsIPv4Addr("www.example.com"));
+}

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Text.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Text.cpp
@@ -1,0 +1,169 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/utils/Util_Text.cpp
+// @coverage-target: llbc/include/llbc/core/utils/Util_TextInl.h
+
+namespace
+{
+
+enum class TextTestEnum : sint64
+{
+    Value = 42,
+};
+
+enum class UnsignedTextTestEnum : uint64
+{
+    Max = std::numeric_limits<uint64>::max(),
+};
+
+} // namespace
+
+// Numeric formatting is a low-allocation TLS utility used throughout logging and
+// diagnostics. Exercise integral, enum, pointer, hexadecimal, and float paths.
+TEST(TextUtilTest, NumberToStringFormatsSupportedValues)
+{
+    size_t length = 0;
+    EXPECT_STREQ(LLBC_Num2Str2(true, &length), "1");
+    EXPECT_EQ(length, 1lu);
+    EXPECT_STREQ(LLBC_Num2Str2(false, &length), "0");
+    EXPECT_EQ(length, 1lu);
+
+    EXPECT_EQ(LLBC_Num2Str<sint32>(-123456), "-123456");
+    EXPECT_EQ(LLBC_Num2Str<uint64>(9876543210ull), "9876543210");
+    EXPECT_EQ(LLBC_Num2Str<sint64>(std::numeric_limits<sint64>::min()),
+              "-9223372036854775808");
+    EXPECT_EQ(LLBC_Num2Str(TextTestEnum::Value), "42");
+    EXPECT_EQ(LLBC_Num2Str(UnsignedTextTestEnum::Max), "18446744073709551615");
+    EXPECT_EQ((LLBC_Num2Str<uint32, true>(0xdeadbeefu)), "0xdeadbeef");
+
+    void *ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(0x1234));
+    EXPECT_EQ(LLBC_Num2Str<void *>(ptr), "4660");
+    EXPECT_EQ((LLBC_Num2Str<void *, true>(ptr)), "0x1234");
+    EXPECT_EQ(LLBC_Num2Str<float>(1.25f), "1.250000");
+    EXPECT_EQ(LLBC_Num2Str<double>(-2.5), "-2.500000");
+    EXPECT_EQ(LLBC_Num2Str<ldouble>(3.0L), "3.000000");
+}
+
+// Loose booleans are designed for configuration values: accept trimmed numeric,
+// hexadecimal, decimal, and optional yes/true spellings without raising errors.
+TEST(TextUtilTest, LooseBooleanRecognizesConfigurationValues)
+{
+    EXPECT_FALSE(LLBC_Str2LooseBool(nullptr));
+    EXPECT_FALSE(LLBC_Str2LooseBool(""));
+    EXPECT_FALSE(LLBC_Str2LooseBool(" \t "));
+
+    EXPECT_TRUE(LLBC_Str2LooseBool("YES"));
+    EXPECT_TRUE(LLBC_Str2LooseBool("  true  "));
+    EXPECT_FALSE(LLBC_Str2LooseBool("true", 10, false));
+    EXPECT_FALSE(LLBC_Str2LooseBool("no"));
+
+    EXPECT_TRUE(LLBC_Str2LooseBool("17"));
+    EXPECT_FALSE(LLBC_Str2LooseBool("0"));
+    EXPECT_TRUE(LLBC_Str2LooseBool("-0.25"));
+    EXPECT_FALSE(LLBC_Str2LooseBool("0.000000"));
+    EXPECT_TRUE(LLBC_Str2LooseBool("0x10"));
+    EXPECT_TRUE(LLBC_Str2LooseBool("0X10"));
+    EXPECT_FALSE(LLBC_Str2LooseBool("-0x0"));
+    EXPECT_FALSE(LLBC_Str2LooseBool("foo"));
+
+    // Oversized input is rejected before copying into the TLS conversion buffer.
+    EXPECT_FALSE(LLBC_Str2LooseBool(std::string(512, '1').c_str()));
+}
+
+// Integer conversion must distinguish a valid zero from malformed, partial, and
+// range-error input through the framework's last-error contract.
+TEST(TextUtilTest, IntegerConversionReportsErrorsAndRangeChecks)
+{
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_Str2Num<long>("0"), 0l);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+
+    EXPECT_EQ(LLBC_Str2Num<long>("-12345"), -12345l);
+    EXPECT_EQ(LLBC_Str2Num<ulong>("ff", 16), 255ul);
+    EXPECT_EQ(LLBC_Str2Num<sint64>("-922337203685477580"), -922337203685477580ll);
+    EXPECT_EQ(LLBC_Str2Num<uint64>("18446744073709551615"), std::numeric_limits<uint64>::max());
+    EXPECT_EQ(LLBC_Str2Num<TextTestEnum>("42"), TextTestEnum::Value);
+    EXPECT_EQ(LLBC_Str2Num<sint8>("127"), 127);
+    EXPECT_EQ(LLBC_Str2Num<uint8>("255"), 255u);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_Str2Num<long>("12tail"), 0l);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_PARTIAL_PARSED);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_Str2Num<long>("not-a-number"), 0l);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_Str2Num<long>(nullptr), 0l);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_Str2Num<sint8>("128"), 0);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_Str2Num<uint8>("-1"), 0u);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_EQ(LLBC_Str2Num<uint64>("18446744073709551616"), 0ull);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_CLIB);
+}
+
+// Pointer and floating-point overloads use specialized parsing rules. Pointer
+// parsing auto-detects 0x prefixes, while all floating types share the same
+// malformed/partial-result error semantics.
+TEST(TextUtilTest, PointerFloatAndBoolConversionPaths)
+{
+    const auto ptr = LLBC_Str2Num<void *>("0x1234", 10);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr), 0x1234u);
+    EXPECT_EQ(LLBC_Str2Num<void *>(nullptr), nullptr);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_FLOAT_EQ(LLBC_Str2Num<float>("0.0"), 0.0f);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_SUCCESS);
+    EXPECT_DOUBLE_EQ(LLBC_Str2Num<double>("1.25"), 1.25);
+    EXPECT_DOUBLE_EQ(static_cast<double>(LLBC_Str2Num<ldouble>("-2.5")), -2.5);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_DOUBLE_EQ(LLBC_Str2Num<double>("3.5tail"), 0.0);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_PARTIAL_PARSED);
+
+    LLBC_SetLastError(LLBC_ERROR_SUCCESS);
+    EXPECT_DOUBLE_EQ(LLBC_Str2Num<double>("not-a-number"), 0.0);
+    EXPECT_EQ(LLBC_GetLastError(), LLBC_ERROR_INVALID);
+
+    EXPECT_TRUE(LLBC_Str2Num<bool>("1"));
+    EXPECT_FALSE(LLBC_Str2Num<bool>("0"));
+    EXPECT_FALSE(LLBC_Str2Num<bool>("true"));
+}

--- a/tests/unit_test/core/utils/UnitTest_Core_Utils_Variant.cpp
+++ b/tests/unit_test/core/utils/UnitTest_Core_Utils_Variant.cpp
@@ -1,0 +1,110 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2013 lailongwei<lailongwei@126.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <llbc.h>
+using namespace llbc;
+
+#include <gtest/gtest.h>
+
+// Coverage targets exercised by this test (collected by tools/coverage/run_unit_test_coverage.sh):
+// @coverage-target: llbc/src/core/utils/Util_Variant.cpp
+
+// Ini2Variant builds a nested dictionary mirroring sections and keys, which is
+// used by configuration consumers that prefer a uniform Variant representation.
+TEST(VariantUtilTest, ConvertsIniSectionsAndReplacesExistingDestination)
+{
+    LLBC_Ini ini;
+    const LLBC_String content =
+        "[server]\n"
+        "host=127.0.0.1\n"
+        "port=8080\n"
+        "\n"
+        "[feature]\n"
+        "enabled=yes\n";
+    ASSERT_EQ(ini.LoadFromContent(content), LLBC_OK) << ini.GetLoadError();
+
+    LLBC_Variant destination;
+    LLBC_VariantUtil::Ini2Variant(ini, destination);
+    ASSERT_TRUE(destination.Is<LLBC_Variant::Dict>());
+    EXPECT_EQ(destination["server"]["host"].As<LLBC_String>(), "127.0.0.1");
+    EXPECT_EQ(destination["server"]["port"].As<LLBC_String>(), "8080");
+    EXPECT_EQ(destination["feature"]["enabled"].As<LLBC_String>(), "yes");
+
+    // Reuse an already-dictionary destination: conversion must clear stale keys.
+    destination["stale"] = 1;
+    LLBC_VariantUtil::Ini2Variant(ini, destination);
+    EXPECT_TRUE(static_cast<const LLBC_Variant &>(destination)["stale"].Is<void>());
+    EXPECT_EQ(destination.Size(), ini.GetAllSections().size());
+}
+
+// Xml2Variant exposes document roots as a children sequence and each element as
+// a dictionary containing name, text value, attributes, and a children sequence.
+TEST(VariantUtilTest, ConvertsXmlDocumentAndLeafElementsToStableShape)
+{
+    LLBC_TINYXML2_NS XMLDocument document;
+    ASSERT_EQ(document.Parse(
+                  "<root id='1'><child kind='first'>text</child><child/></root><solo/>"),
+              LLBC_TINYXML2_NS XML_SUCCESS);
+
+    LLBC_Variant converted;
+    LLBC_VariantUtil::Xml2Variant(document, converted);
+    ASSERT_TRUE(converted.Is<LLBC_Variant::Dict>());
+
+    const auto &documentChildren = converted[LLBC_XMLKeys::Children];
+    ASSERT_TRUE(documentChildren.Is<LLBC_Variant::Seq>());
+    ASSERT_EQ(documentChildren.Size(), 2lu);
+    EXPECT_EQ(documentChildren[0][LLBC_XMLKeys::Name].As<LLBC_String>(), "root");
+    EXPECT_EQ(documentChildren[1][LLBC_XMLKeys::Name].As<LLBC_String>(), "solo");
+
+    const auto &root = converted["root"];
+    ASSERT_TRUE(root.Is<LLBC_Variant::Dict>());
+    EXPECT_EQ(root[LLBC_XMLKeys::Name].As<LLBC_String>(), "root");
+    EXPECT_EQ(root[LLBC_XMLKeys::Value].As<LLBC_String>(), "");
+    EXPECT_EQ(root[LLBC_XMLKeys::Attrs]["id"].As<LLBC_String>(), "1");
+    ASSERT_TRUE(root[LLBC_XMLKeys::Children].Is<LLBC_Variant::Seq>());
+    ASSERT_EQ(root[LLBC_XMLKeys::Children].Size(), 2lu);
+
+    const auto &firstChild = root[LLBC_XMLKeys::Children][0];
+    EXPECT_EQ(firstChild[LLBC_XMLKeys::Name].As<LLBC_String>(), "child");
+    EXPECT_EQ(firstChild[LLBC_XMLKeys::Value].As<LLBC_String>(), "text");
+    EXPECT_EQ(firstChild[LLBC_XMLKeys::Attrs]["kind"].As<LLBC_String>(), "first");
+    EXPECT_TRUE(firstChild[LLBC_XMLKeys::Children].Is<LLBC_Variant::Seq>());
+    EXPECT_TRUE(firstChild[LLBC_XMLKeys::Children].IsEmpty());
+
+    // A leaf element must also retain the same children-sequence shape.
+    const auto *solo = document.FirstChildElement("solo");
+    ASSERT_NE(solo, nullptr);
+    LLBC_Variant leaf;
+    LLBC_VariantUtil::Xml2Variant(*solo, leaf);
+    EXPECT_EQ(leaf[LLBC_XMLKeys::Name].As<LLBC_String>(), "solo");
+    EXPECT_TRUE(leaf[LLBC_XMLKeys::Attrs].Is<LLBC_Variant::Dict>());
+    EXPECT_TRUE(leaf[LLBC_XMLKeys::Attrs].IsEmpty());
+    EXPECT_TRUE(leaf[LLBC_XMLKeys::Children].Is<LLBC_Variant::Seq>());
+    EXPECT_TRUE(leaf[LLBC_XMLKeys::Children].IsEmpty());
+
+    LLBC_VariantUtil::Xml2Variant(*solo, leaf);
+    EXPECT_EQ(leaf[LLBC_XMLKeys::Name].As<LLBC_String>(), "solo");
+
+    // Re-running on a dictionary clears prior content before rebuilding it.
+    converted["stale"] = 1;
+    LLBC_VariantUtil::Xml2Variant(document, converted);
+    EXPECT_TRUE(static_cast<const LLBC_Variant &>(converted)["stale"].Is<void>());
+}


### PR DESCRIPTION
## 概述

覆盖 Algorithm、Base64、Debug、MD5、Math、Misc、Network、Text 和 Variant/XML 工具。

## 内容

### 库代码修正

- Flow 检查在执行加减前用 limits 比较，避免“先溢出再判断”的有符号 UB；Type2Str 同时检查下界。
- Windows itoa 兼容函数由误用 strcmp 改为 strcpy 并返回目标缓冲区。
- 数字转字符串用无符号模运算取得负数幅值，支持最小有符号值；枚举保留实际 underlying signedness；无数字输入优先报告 INVALID。
- Base64 解码长度从尾后安全倒序，空输入/全 padding 不再索引或无符号下溢。
- Byte2Hex 拆分表项写两个 char，消除未对齐 uint16 store 并保持表内字节顺序。
- MD5 不再把合法的空输入 digest 当作失败。
- StartArgs 成功后设置 parsed；IPv4 每段累计并限制 <=255；XML children 使用 Seq 而非 Dict。

## 质量保证

- 独立分支：121 tests passed。
- 最终组合 329 passed，1 skipped；UBSan 327/327 passed。