### PR TITLE
build(test): 支持 GCC 8 filesystem 链接

### DIFF
--- a/tools/premake/premake5.lua
+++ b/tools/premake/premake5.lua
@@ -430,6 +430,11 @@ project "unit_test"
 
     links { "gtest" }
 
+    -- GCC 8 ships the C++17 filesystem implementation in a separate archive.
+    filter { "system:linux", "toolset:gcc" }
+        links { "stdc++fs" }
+    filter {}
+
     -- Enable c++17 support.
     filter { "system:not windows" }
         buildoptions {


### PR DESCRIPTION
## 概述

补充 Linux GCC gmake2 unit-test 目标对 GCC 8 C++17 filesystem 的链接支持。

## 背景

新增测试使用标准 `std::filesystem`。CentOS 8 默认 GCC 8 可以编译这些调用，但实现仍位于独立的 `libstdc++fs` 静态库中；当前 unit-test 链接命令未包含该库，最终产生 filesystem 符号未定义。GCC 9 及之后才将实现并入主 `libstdc++`。

## 修改

- 仅对 Linux + GCC 的 `unit_test` Premake 目标增加 `stdc++fs` 链接依赖。
- 自定义 Clang toolset、Windows、macOS、核心库和其他可执行目标均不受影响。

## 正确性

这不改变任何库代码或测试逻辑，只补齐 GCC 8 所要求的标准库实现。Premake 将依赖放入对象文件之后的链接库列表，从而解析新增测试引用的 `std::filesystem` 符号；工具链过滤条件避免把 GCC 专用兼容库施加给 Clang。

## 合并顺序

建议在使用 `std::filesystem` 的测试 PR 前合并本 PR：#566、#567、#570、#573、#576、#581、#582。

## 质量保证

- CentOS 8 / GCC 8：debug64、release64 的核心库与全部测试成功构建，Python/Lua debug/release wrapper 成功构建。
- Ubuntu 24.04 / Clang：330/330 tests passed；region/function/line/branch coverage 为 92.13% / 97.61% / 92.70% / 84.12%。
- macOS：debug/release 核心库和 release 测试成功构建。
- Windows VS2022：debug/release x86/x64 库及 release64 测试目标成功构建。
- 完整记录：[组合验证](https://github.com/reckfullol/llbc/actions/runs/30164371701)。
